### PR TITLE
Hide datashuttle logs during testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,9 @@ connect through SSH
 """
 import platform
 from types import SimpleNamespace
-
+import logging
 import pytest
+import test_utils
 
 test_ssh = False
 username = "jziminski"
@@ -42,9 +43,8 @@ def pytest_configure(config):
         FILESYSTEM_PATH=filesystem_path,  # FILESYSTEM_PATH and SERVER_PATH these must point to the same folder on the HPC, filesystem
         SERVER_PATH=server_path,  # as a mounted drive and server as the linux path to connect through SSH
     )
-    for name in []:
-        logger = logging.getLogger(name)
-        logger.propagate = False
+    test_utils.set_datashuttle_loggers(disable=True)
+
 
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,9 @@ def pytest_configure(config):
         FILESYSTEM_PATH=filesystem_path,  # FILESYSTEM_PATH and SERVER_PATH these must point to the same folder on the HPC, filesystem
         SERVER_PATH=server_path,  # as a mounted drive and server as the linux path to connect through SSH
     )
+    for name in []:
+        logger = logging.getLogger(name)
+        logger.propagate = False
+
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ connect through SSH
 """
 import platform
 from types import SimpleNamespace
-import logging
+
 import pytest
 import test_utils
 
@@ -44,7 +44,3 @@ def pytest_configure(config):
         SERVER_PATH=server_path,  # as a mounted drive and server as the linux path to connect through SSH
     )
     test_utils.set_datashuttle_loggers(disable=True)
-
-
-
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import subprocess
 import warnings
 from os.path import join
 from pathlib import Path
+import logging
 
 import yaml
 
@@ -630,3 +631,18 @@ def read_file(path_):
     with open(path_, "r") as file:
         contents = file.readlines()
     return contents
+
+def set_datashuttle_loggers(disable):
+    """
+    Turn off or on datashuttle logs, if these are
+    on when testing with pytest they will be propagated
+    to pytest's output, making it difficult to read.
+
+    As such, these are turned off for all tests
+    (in conftest.py)  and dynamically turned on in setup
+    of test_logging.py and turned back off during
+    tear-down.
+    """
+    for name in ["datashuttle", "rich"]:
+        logger = logging.getLogger(name)
+        logger.disabled = disable

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import copy
 import glob
+import logging
 import os
 import pathlib
 import shutil
@@ -7,7 +8,6 @@ import subprocess
 import warnings
 from os.path import join
 from pathlib import Path
-import logging
 
 import yaml
 
@@ -631,6 +631,7 @@ def read_file(path_):
     with open(path_, "r") as file:
         contents = file.readlines()
     return contents
+
 
 def set_datashuttle_loggers(disable):
     """

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -22,11 +22,17 @@ class TestCommandLineInterface:
         Create an empty project, but ensure no
         configs already exists, and delete created configs
         after test.
+
+        Switch on datashuttle logging as required for
+        these tests, then turn back off during tear-down.
         """
         project_name = "test_logging"
         test_utils.delete_project_if_it_exists(project_name)
+        test_utils.set_datashuttle_loggers(disable=False)
+
         yield project_name
         test_utils.delete_project_if_it_exists(project_name)
+        test_utils.set_datashuttle_loggers(disable=True)
 
     @pytest.fixture(scope="function")
     def setup_project(self, tmp_path):
@@ -34,8 +40,8 @@ class TestCommandLineInterface:
         Setup a project with default configs to use
         for testing.
 
-        # Note this fixture is a duplicate of project()
-        in test_filesystem_transfer.py fixture
+        Switch on datashuttle logging as required for
+        these tests, then turn back off during tear-down.
         """
         test_project_name = "test_logging"
         setup_project, cwd = test_utils.setup_project_fixture(
@@ -44,8 +50,12 @@ class TestCommandLineInterface:
 
         self.delete_log_files(setup_project.cfg.logging_path)
 
+        test_utils.set_datashuttle_loggers(disable=False)
+
         yield setup_project
+
         test_utils.teardown_project(cwd, setup_project)
+        test_utils.set_datashuttle_loggers(disable=True)
 
     # ----------------------------------------------------------------------------------------------------------
     # Test Public API Logging


### PR DESCRIPTION
Since logging was introduced, the logs from datashuttle contaminate the output of pytest. The solution here is to turn off datashuttle loggers for all tests in the `pytest_configure` hook. These are selectively turned back on in `test_logging.py` setup and turned off again in tear-down.
