### PR TITLE
Rename get convenience functions to show

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -289,10 +289,10 @@ def download_project_folder_or_file(project: DataShuttle, args: Any) -> None:
 # Get Local Path --------------------------------------------------------------
 
 
-def get_local_path(*args: Any) -> None:
+def show_local_path(*args: Any) -> None:
     """"""
     project = args[0]
-    project.get_local_path()
+    project.show_local_path()
 
 
 # Get Appdir Path -------------------------------------------------------------
@@ -331,7 +331,16 @@ def show_configs(*args: Any) -> None:
     project.show_configs()
 
 
-# Show Local Three ------------------------------------------------------------
+# Show Logging Path ----------------------------------------------------------
+
+
+def show_logging_path(*args: Any) -> None:
+    """"""
+    project = args[0]
+    project.show_logging_path()
+
+
+# Show Local Tree ------------------------------------------------------------
 
 
 def show_local_tree(*args: Any) -> None:
@@ -726,12 +735,12 @@ def construct_parser():
     # Get Local Path
     # -------------------------------------------------------------------------
 
-    get_local_path_parser = subparsers.add_parser(
-        "get-local-path",
-        aliases=["get_local_path"],
-        description=process_docstring(DataShuttle.get_local_path.__doc__),
+    show_local_path_parser = subparsers.add_parser(
+        "show-local-path",
+        aliases=["show_local_path"],
+        description=process_docstring(DataShuttle.show_local_path.__doc__),
     )
-    get_local_path_parser.set_defaults(func=get_local_path)
+    show_local_path_parser.set_defaults(func=show_local_path)
 
     get_datashuttle_path_parser = subparsers.add_parser(
         "get-datashuttle-path",
@@ -771,6 +780,16 @@ def construct_parser():
         description=process_docstring(DataShuttle.show_configs.__doc__),
     )
     show_configs_parser.set_defaults(func=show_configs)
+
+    # Show Logging Path
+    # -------------------------------------------------------------------------
+
+    show_logging_path_parser = subparsers.add_parser(
+        "show-logging-path",
+        aliases=["show_logging_path"],
+        description=process_docstring(DataShuttle.show_logging_path.__doc__),
+    )
+    show_logging_path_parser.set_defaults(func=show_logging_path)
 
     # Show Local tree
     # -------------------------------------------------------------------------

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -316,10 +316,10 @@ def show_config_path(*args: Any) -> None:
 # Get Remote Path -------------------------------------------------------------
 
 
-def get_remote_path(*args: Any) -> None:
+def show_remote_path(*args: Any) -> None:
     """"""
     project = args[0]
-    project.get_remote_path()
+    project.show_remote_path()
 
 
 # Show Configs ----------------------------------------------------------------
@@ -755,12 +755,12 @@ def construct_parser():
     # Get Remote Path
     # -------------------------------------------------------------------------
 
-    get_remote_path_parser = subparsers.add_parser(
-        "get-remote-path",
-        aliases=["get_remote_path"],
-        description=process_docstring(DataShuttle.get_remote_path.__doc__),
+    show_remote_path_parser = subparsers.add_parser(
+        "show-remote-path",
+        aliases=["show_remote_path"],
+        description=process_docstring(DataShuttle.show_remote_path.__doc__),
     )
-    get_remote_path_parser.set_defaults(func=get_remote_path)
+    show_remote_path_parser.set_defaults(func=show_remote_path)
 
     # Show Configs
     # -------------------------------------------------------------------------

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -331,15 +331,6 @@ def show_configs(*args: Any) -> None:
     project.show_configs()
 
 
-# Show Logging Path ----------------------------------------------------------
-
-
-def show_logging_path(*args: Any) -> None:
-    """"""
-    project = args[0]
-    project.show_logging_path()
-
-
 # Show Local Tree ------------------------------------------------------------
 
 
@@ -732,7 +723,7 @@ def construct_parser():
         help=help("flag_default_false"),
     )
 
-    # Get Local Path
+    # Show Local Path
     # -------------------------------------------------------------------------
 
     show_local_path_parser = subparsers.add_parser(
@@ -780,16 +771,6 @@ def construct_parser():
         description=process_docstring(DataShuttle.show_configs.__doc__),
     )
     show_configs_parser.set_defaults(func=show_configs)
-
-    # Show Logging Path
-    # -------------------------------------------------------------------------
-
-    show_logging_path_parser = subparsers.add_parser(
-        "show-logging-path",
-        aliases=["show_logging_path"],
-        description=process_docstring(DataShuttle.show_logging_path.__doc__),
-    )
-    show_logging_path_parser.set_defaults(func=show_logging_path)
 
     # Show Local tree
     # -------------------------------------------------------------------------

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -298,19 +298,19 @@ def show_local_path(*args: Any) -> None:
 # Get Appdir Path -------------------------------------------------------------
 
 
-def get_datashuttle_path(*args: Any) -> None:
+def show_datashuttle_path(*args: Any) -> None:
     """"""
     project = args[0]
-    project.get_datashuttle_path()
+    project.show_datashuttle_path()
 
 
 # Get Config Path -------------------------------------------------------------
 
 
-def get_config_path(*args: Any) -> None:
+def show_config_path(*args: Any) -> None:
     """"""
     project = args[0]
-    project.get_config_path()
+    project.show_config_path()
 
 
 # Get Remote Path -------------------------------------------------------------
@@ -733,24 +733,24 @@ def construct_parser():
     )
     show_local_path_parser.set_defaults(func=show_local_path)
 
-    get_datashuttle_path_parser = subparsers.add_parser(
-        "get-datashuttle-path",
-        aliases=["get_datashuttle_path"],
+    show_datashuttle_path_parser = subparsers.add_parser(
+        "show-datashuttle-path",
+        aliases=["show_datashuttle_path"],
         description=process_docstring(
-            DataShuttle.get_datashuttle_path.__doc__
+            DataShuttle.show_datashuttle_path.__doc__
         ),
     )
-    get_datashuttle_path_parser.set_defaults(func=get_datashuttle_path)
+    show_datashuttle_path_parser.set_defaults(func=show_datashuttle_path)
 
     # Get Config Path
     # -------------------------------------------------------------------------
 
-    get_config_path_parser = subparsers.add_parser(
-        "get-config-path",
-        aliases=["get_config_path"],
-        description=process_docstring(DataShuttle.get_config_path.__doc__),
+    show_config_path_parser = subparsers.add_parser(
+        "show-config-path",
+        aliases=["show_config_path"],
+        description=process_docstring(DataShuttle.show_config_path.__doc__),
     )
-    get_config_path_parser.set_defaults(func=get_config_path)
+    show_config_path_parser.set_defaults(func=show_config_path)
 
     # Get Remote Path
     # -------------------------------------------------------------------------

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -768,7 +768,7 @@ class DataShuttle:
     # Public Getters
     # -------------------------------------------------------------------------
 
-    def get_local_path(self) -> None:
+    def show_local_path(self) -> None:
         """
         Print the projects local path.
         """

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -65,7 +65,7 @@ class DataShuttle:
                    and folders are specified in make_config_file().
                    Datashuttle-related files are stored in
                    a .datashuttle folder in the user home
-                   folder. Use get_datashuttle_path() to
+                   folder. Use show_datashuttle_path() to
                    see the path to this folder.
     """
 
@@ -531,7 +531,7 @@ class DataShuttle:
 
         These settings are stored in a config file on the
         datashuttle path (not in the project folder)
-        on the local machine. Use get_config_path() to
+        on the local machine. Use show_config_path() to
         get the full path to the saved config file.
 
         Use update_config() to update a single config, and
@@ -774,7 +774,7 @@ class DataShuttle:
         """
         utils.print_message_to_user(self.cfg["local_path"].as_posix())
 
-    def get_datashuttle_path(self) -> None:
+    def show_datashuttle_path(self) -> None:
         """
         Print the path to the local datashuttle
         folder where configs another other
@@ -782,7 +782,7 @@ class DataShuttle:
         """
         utils.print_message_to_user(self._datashuttle_path.as_posix())
 
-    def get_config_path(self) -> None:
+    def show_config_path(self) -> None:
         """
         Print the full path to the DataShuttle config file.
         This is always formatted to UNIX style.

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -789,7 +789,7 @@ class DataShuttle:
         """
         utils.print_message_to_user(self._config_path.as_posix())
 
-    def get_remote_path(self) -> None:
+    def show_remote_path(self) -> None:
         """
         Print the project remote path.
         This is always formatted to UNIX style.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import copy
 import glob
+import logging
 import os
 import pathlib
 import shutil
@@ -247,7 +248,7 @@ def get_default_folder_used():
 
 
 def get_config_path_with_cli(project_name=None):
-    stdout = run_cli(" get_config_path", project_name)
+    stdout = run_cli(" show_config_path", project_name)
     path_ = stdout[0].split(".yaml")[0] + ".yaml"
     return path_
 
@@ -630,3 +631,19 @@ def read_file(path_):
     with open(path_, "r") as file:
         contents = file.readlines()
     return contents
+
+
+def set_datashuttle_loggers(disable):
+    """
+    Turn off or on datashuttle logs, if these are
+    on when testing with pytest they will be propagated
+    to pytest's output, making it difficult to read.
+
+    As such, these are turned off for all tests
+    (in conftest.py)  and dynamically turned on in setup
+    of test_logging.py and turned back off during
+    tear-down.
+    """
+    for name in ["datashuttle", "rich"]:
+        logger = logging.getLogger(name)
+        logger.disabled = disable


### PR DESCRIPTION
previously certain public functions were called `get_xxxx_path` e.g. `get_local_path` and returned the path. However, these were changed to simply show the path (currently print, but later this might be a popup window in a GUI) but were not all renamed. This PR renames all instances where such function does not return anything from "get" to "show"