### PR TITLE
Introduce setters, handle make_sub_folder and data transfer for additional top level folders (e.g. derivatives, code, analysis)

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -934,6 +934,7 @@ def construct_parser():
         description=process_docstring(
             DataShuttle.show_top_level_folder.__doc__
         ),
+        help="",
     )
     show_top_level_folder_parser.set_defaults(func=show_top_level_folder)
 

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -225,6 +225,15 @@ def upload_all(*args: Any) -> None:
     project.upload_all()
 
 
+# Upload Entire Project -------------------------------------------------------
+
+
+def upload_entire_project(*args: Any) -> None:
+    """"""
+    project = args[0]
+    project.upload_entire_project()
+
+
 # Download Data ---------------------------------------------------------------
 
 
@@ -250,6 +259,15 @@ def download_all(*args: Any) -> None:
     project.download_all()
 
 
+# Download Entire Project -----------------------------------------------------
+
+
+def download_entire_project(*args: Any) -> None:
+    """"""
+    project = args[0]
+    project.download_entire_project()
+
+
 # Upload Project Folder or File -----------------------------------------------
 
 
@@ -265,7 +283,7 @@ def upload_project_folder_or_file(project: DataShuttle, args: Any) -> None:
     )
 
 
-# Download Project Folder or File ------------------------------------------------
+# Download Project Folder or File ---------------------------------------------
 
 
 def download_project_folder_or_file(project: DataShuttle, args: Any) -> None:
@@ -277,6 +295,20 @@ def download_project_folder_or_file(project: DataShuttle, args: Any) -> None:
         project.download_project_folder_or_file,
         kwargs.pop("filepath"),
         **kwargs,
+    )
+
+
+# Set Top Level Folder or File ------------------------------------------------
+
+
+def set_top_level_folder(project: DataShuttle, args: Any) -> None:
+    """"""
+    kwargs = make_kwargs(args)
+
+    run_command(
+        project,
+        project.set_top_level_folder,
+        kwargs["folder_name"],
     )
 
 
@@ -340,13 +372,22 @@ def show_logging_path(*args: Any) -> None:
     project.show_logging_path()
 
 
-# Show Local Tree ------------------------------------------------------------
+# Show Local Tree -------------------------------------------------------------
 
 
 def show_local_tree(*args: Any) -> None:
     """"""
     project = args[0]
     project.show_local_tree()
+
+
+# Show Top Level Folder -------------------------------------------------------
+
+
+def show_top_level_folder(*args: Any) -> None:
+    """"""
+    project = args[0]
+    project.show_top_level_folder()
 
 
 # Show Next Sub Number -------------------------------------------------------
@@ -384,7 +425,7 @@ def check_name_formatting(project: DataShuttle, args: Any) -> None:
 
 # Supply Own Config -----------------------------------------------------------
 
-#
+
 def supply_config_file(project: DataShuttle, args: Any) -> None:
 
     kwargs = make_kwargs(args)
@@ -648,6 +689,19 @@ def construct_parser():
     )
     upload_all_parser.set_defaults(func=upload_all)
 
+    # Upload All
+    # -------------------------------------------------------------------------
+
+    upload_entire_project_parser = subparsers.add_parser(
+        "upload-entire-project",
+        aliases=["upload_entire_project"],
+        description=process_docstring(
+            DataShuttle.upload_entire_project.__doc__
+        ),
+        help="",
+    )
+    upload_entire_project_parser.set_defaults(func=upload_entire_project)
+
     # Download Data
     # -------------------------------------------------------------------------
 
@@ -688,7 +742,8 @@ def construct_parser():
         type=str,
         nargs="+",
         required=False,
-        help="Optional: (str or list) (selection of data types, or 'all') (default 'all')",
+        help="Optional: (str or list) (selection of data "
+        "types, or 'all') (default 'all')",
     )
     download_data_parser.add_argument(
         "--dry-run",
@@ -708,6 +763,19 @@ def construct_parser():
         help="",
     )
     download_all_parser.set_defaults(func=download_all)
+
+    # Download Entire Project
+    # -------------------------------------------------------------------------
+
+    download_entire_project_parser = subparsers.add_parser(
+        "download-entire-project",
+        aliases=["download_entire_project"],
+        description=process_docstring(
+            DataShuttle.download_entire_project.__doc__
+        ),
+        help="",
+    )
+    download_entire_project_parser.set_defaults(func=download_entire_project)
 
     # Upload project folder or file
     # -------------------------------------------------------------------------
@@ -759,6 +827,26 @@ def construct_parser():
         "--dry_run",
         action="store_true",
         help=help("flag_default_false"),
+    )
+
+    # Set Top Level Folder
+    # -------------------------------------------------------------------------
+
+    set_top_level_folder_parser = subparsers.add_parser(
+        "set-top-level-folder",
+        aliases=["set_top_level_folder"],
+        description=process_docstring(
+            DataShuttle.set_top_level_folder.__doc__
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+        help="",
+    )
+    set_top_level_folder_parser.set_defaults(func=set_top_level_folder)
+
+    set_top_level_folder_parser.add_argument(
+        "folder_name",
+        type=str,
+        help=help("required_str"),
     )
 
     # Show Local Path
@@ -837,7 +925,19 @@ def construct_parser():
     )
     show_local_tree_parser.set_defaults(func=show_local_tree)
 
-    # Show Local tree
+    # Show Top Level Folder
+    # -------------------------------------------------------------------------
+
+    show_top_level_folder_parser = subparsers.add_parser(
+        "show-top-level-folder",
+        aliases=["show_top_level_folder"],
+        description=process_docstring(
+            DataShuttle.show_top_level_folder.__doc__
+        ),
+    )
+    show_top_level_folder_parser.set_defaults(func=show_top_level_folder)
+
+    # Show Next Sub Number
     # -------------------------------------------------------------------------
 
     show_next_sub_number_parser = subparsers.add_parser(
@@ -850,7 +950,7 @@ def construct_parser():
     )
     show_next_sub_number_parser.set_defaults(func=show_next_sub_number)
 
-    # Show Local tree
+    # Show Next Ses Number
     # -------------------------------------------------------------------------
 
     show_next_ses_number_parser = subparsers.add_parser(

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -96,3 +96,7 @@ def get_non_ses_names():
         "all_data_type",
         "all_ses_level_non_data_type",
     ]
+
+
+def get_top_level_folder_names():
+    return ["rawdata", "derivatives", "analysis", "code"]

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -83,9 +83,7 @@ class DataShuttle:
             self._temp_log_path,
         ) = utils.get_datashuttle_path(self.project_name)
 
-        self._config_path = (
-            utils.get_datashuttle_path(project_name)[0] / "config.yaml"
-        )
+        self._config_path = self._datashuttle_path / "config.yaml"
 
         self._persistent_settings_path = (
             self._datashuttle_path / "persistent_settings.yaml"
@@ -109,6 +107,11 @@ class DataShuttle:
         self.cfg.top_level_folder_name = self._load_persistent_settings()[
             "top_level_folder"
         ]
+
+        utils.print_message_to_user(
+            f"\nThe working top level folder is: "
+            f"{self.cfg.top_level_folder_name}\n"
+        )
 
         self.cfg.init_paths()
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -6,12 +6,12 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 import paramiko
 import yaml
 
-from datashuttle.configs import load_configs
+from datashuttle.configs import canonical_folders, load_configs
 from datashuttle.configs.config_class import Configs
 from datashuttle.utils import (
     ds_logger,
@@ -108,11 +108,6 @@ class DataShuttle:
             "top_level_folder"
         ]
 
-        utils.print_message_to_user(
-            f"\nThe working top level folder is: "
-            f"{self.cfg.top_level_folder_name}\n"
-        )
-
         self.cfg.init_paths()
 
         self._make_project_metadata_if_does_not_exist()
@@ -122,6 +117,36 @@ class DataShuttle:
     # -------------------------------------------------------------------------
     # Public Folder Makers
     # -------------------------------------------------------------------------
+
+    def set_top_level_folder(self, folder_name):
+        """
+        Set the working top level folder (e.g. 'rawdata', 'derivatives').
+
+        The top level folder defines in which top level folder folders
+        are made (e.g. make_sub_folders) or at which level folders
+        are transferred with the commands upload_data / download_data
+        and upload_all / download all.
+
+        To upload the entire project (i.e. every top level
+        folder), use the 'command upload_entire_project' or
+        'download_entire_project'.
+        """
+        canonical_top_level_folder_names = (
+            canonical_folders.get_top_level_folder_names()
+        )
+
+        if folder_name not in canonical_top_level_folder_names:
+            utils.raise_error(
+                f"Folder name: {folder_name} "
+                f"is not in permitted top-level folder"
+                f" names: {canonical_top_level_folder_names}"
+            )
+
+        self.cfg.top_level_folder_name = folder_name
+
+        self._update_persistent_setting("top_level_folder", folder_name)
+
+        self.show_top_level_folder()
 
     @check_configs_set
     def make_sub_folders(
@@ -376,6 +401,22 @@ class DataShuttle:
             "all", "all", "all", dry_run=dry_run, init_log=False
         )
         ds_logger.close_log_filehandler()
+
+    def upload_entire_project(self):
+        """
+        Upload the entire project (from 'local' to 'remote'),
+        i.e. including every top level folder (e.g. 'rawdata',
+        'derivatives', 'code', 'analysis').
+        """
+        self._transfer_entire_project("upload")
+
+    def download_entire_project(self):
+        """
+        Download the entire project (from 'remote' to 'local'),
+        i.e. including every top level folder (e.g. 'rawdata',
+        'derivatives', 'code', 'analysis').
+        """
+        self._transfer_entire_project("download")
 
     def upload_project_folder_or_file(
         self, filepath: str, dry_run: bool = False
@@ -842,6 +883,25 @@ class DataShuttle:
         """
         ds_logger.print_tree(self.cfg["local_path"])
 
+    def show_top_level_folder(self):
+        """
+        Print the current working top level folder (e.g.
+        'rawdata', 'derivatives')
+
+        The top level folder defines in which top level folder folders
+        are made (e.g. make_sub_folders) or at which level folders
+        are transferred with the commands upload_data / download_data
+        and upload_all / download all.
+
+        To upload the entire project (i.e. every top level
+        folder), use the 'command upload_entire_project' or
+        'download_entire_project'.
+        """
+        utils.print_message_to_user(
+            f"\nThe working top level folder is: "
+            f"{self.cfg.top_level_folder_name}"
+        )
+
     def show_next_sub_number(self) -> None:
         """
         Show a suggested value for the next available subject number.
@@ -899,8 +959,8 @@ class DataShuttle:
     def check_name_formatting(names: Union[str, list], prefix: str) -> None:
         """
         Pass list of names to check how these will be auto-formatted,
-        for example as when passed to make_sub_folders() or upload_data() or
-        download_data()
+        for example as when passed to make_sub_folders() or upload_data()
+        or download_data()
 
         Useful for checking tags e.g. @TO@, @DATE@, @DATETIME@, @DATE@.
         This method will print the formatted list of names,
@@ -923,6 +983,38 @@ class DataShuttle:
     # =========================================================================
     # Private Functions
     # =========================================================================
+
+    def _transfer_entire_project(
+        self, direction: Literal["upload", "download"]
+    ) -> None:
+        """
+        Transfer (i.e. upload or download) the entire project (i.e.
+        every 'top level folder' (e.g. 'rawdata', 'derivatives').
+
+        This function leverages the upload_all or download_all
+        methods while switching the top level folder as defined in
+        self.cfg that these methods use to determine the top-level
+        folder to transfer.
+
+        Parameters
+        ----------
+
+        direction : direction to transfer the data, either "upload" (from
+                    local to remote) or "download" (from remote to local).
+        """
+        transfer_all_func = (
+            self.upload_all if direction == "upload" else self.download_all
+        )
+
+        tmp_current_top_level_folder_name = copy.copy(
+            self.cfg.top_level_folder_name
+        )
+
+        for folder_name in canonical_folders.get_top_level_folder_names():
+            self.cfg.top_level_folder_name = folder_name
+            transfer_all_func()
+
+        self.cfg.top_level_folder_name = tmp_current_top_level_folder_name
 
     # -------------------------------------------------------------------------
     # SSH
@@ -1037,7 +1129,8 @@ class DataShuttle:
         if message:
             utils.print_message_to_user("Update successful.")
         utils.log(
-            f"Update successful. New config file: \n {self._get_json_dumps_config()}"
+            f"Update successful. New config file: "
+            f"\n {self._get_json_dumps_config()}"
         )
 
     def _get_json_dumps_config(self):

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -7,6 +7,7 @@ from os.path import join
 import pytest
 import test_utils
 
+from datashuttle.configs import canonical_folders
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.utils import formatting
 
@@ -381,6 +382,39 @@ class TestMakeFolders:
         assert all([re.search(datetime_regexp, name) for name in ses_names])
         assert all([tags("time") not in name for name in ses_names])
 
+    # ----------------------------------------------------------------------------------------------------------
+    # Test Make Folders in Different Top Level Folders
+    # ----------------------------------------------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "folder_name", canonical_folders.get_top_level_folder_names()
+    )
+    def test_all_top_level_folders(self, project, folder_name):
+        """
+        Check that when switching the top level folder (e.g. rawdata, derivatives)
+        new folders are made in the correct folder. The code that underpins this
+        is very simple (all the path for folder creation / transfer is determined
+        only by project.cfg.top_level_folder_name. Therefore if these tests pass,
+        any test that passes for rawdata (all other tests are for rawdata) should
+        pass for all top-level folders.
+        """
+        project.cfg.top_level_folder_name = folder_name
+
+        subs = ["sub-001", "sub-2"]
+        sessions = ["ses-001", "ses-03"]
+
+        project.make_sub_folders(subs, sessions)
+
+        # Check folder tree is made in the desired top level folder
+        test_utils.check_working_top_level_folder_only_exists(
+            folder_name,
+            project,
+            project.cfg["local_path"] / folder_name,
+            subs,
+            sessions,
+        )
+
+    # ----------------------------------------------------------------------------------------------------------
     # Test get next subject / session numbers
     # ----------------------------------------------------------------------------------
 

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -67,3 +67,24 @@ class TestPersistentSettings:
         fresh_project = DataShuttle(TEST_PROJECT_NAME)
 
         assert fresh_project.cfg.top_level_folder_name == "rawdata"
+
+    def test_set_top_level_folder_is_persistent(self, project):
+        """
+        Test that set_top_level_folder_name sets the top
+        level folder name persistently across sessions.
+        """
+        assert project.cfg.top_level_folder_name == "rawdata"
+
+        project.set_top_level_folder("derivatives")
+
+        assert project.cfg.top_level_folder_name == "derivatives"
+
+        project_reload = DataShuttle(TEST_PROJECT_NAME)
+
+        assert project_reload.cfg.top_level_folder_name == "derivatives"
+
+        stdout = test_utils.run_cli(
+            " show-top-level-folder", TEST_PROJECT_NAME
+        )
+
+        assert "The working top level folder is: derivatives" in stdout[0]


### PR DESCRIPTION
This PR introduces handling of top-level folders in addition to `rawdata`, i.e. `derivatives`, `code` and `analysis`. In retrospect  it has gone slightly out of scope and introduces two related but distinct functionalities:

1) Set and show the current working top-level folder (e.g. `rawdata`, `derivatives`)
2) Implement functionality to transfer the entire project (i.e. the contents of all top-level-folders).

With #135, the current working top level folder is shown on project initialisation (API), when setting the top-level folder, and a subset of CLI commands.

Details
-------

The working `top_level_folder` can now be set using `set_top_level_folder` and shown with `show_top_level_folder`. The working top level folder is saved to the `persistent_settings`, so when the next session is started, the working top level folder is maintained.

All previous methods `make_sub_folders`, `upload_data` / `download_data`, `upload_all` / `download_all` still work only on the working top level folder. For example if you are in `derivatives` and choose `upload_all`, only the contents of derivatives will be uploaded.

As such, this PR introduces two new methods, `upload_entire_project()` and `download_entire_project()` and associated CLI. This will upload or download everything in every top level folder.

I am not sure if this naming scheme is confusing. Maybe `upload_all` should become `upload_working_top_level_folder` or something, but it is hard to think of a name that is concise but informative.

@neuroinformatics-unit/neuroinformatics-team it would be good to get some general feedback on this PR as it covers a topic we have all discussed together, and is quite critical for how datashuttle will be used.