### PR TITLE
Use integers to check duplicate subjects or sessions, to handle leading zeros.

### DIFF
--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -190,16 +190,21 @@ def check_no_duplicate_sub_ses_key_values(
         )[0]
 
         existing_sub_values = utils.get_values_from_bids_formatted_name(
-            existing_sub_names, "sub"
+            existing_sub_names,
+            "sub",
+            return_as_int=True,
         )
 
         for new_sub in utils.get_values_from_bids_formatted_name(
-            new_sub_names, "sub"
+            new_sub_names,
+            "sub",
+            return_as_int=True,
         ):
             if new_sub in existing_sub_values:
                 utils.log_and_raise_error(
                     f"Cannot make folders. "
-                    f"The key sub-{new_sub} already exists in the project"
+                    f"The key sub-{new_sub} (possibly with leading zeros) "
+                    f"already exists in the project"
                 )
     else:
         # for each subject, check session level
@@ -209,16 +214,21 @@ def check_no_duplicate_sub_ses_key_values(
             )[0]
 
             existing_ses_values = utils.get_values_from_bids_formatted_name(
-                existing_ses_names, "ses"
+                existing_ses_names,
+                "ses",
+                return_as_int=True,
             )
             for new_ses in utils.get_values_from_bids_formatted_name(
-                new_ses_names, "ses"
+                new_ses_names,
+                "ses",
+                return_as_int=True,
             ):
 
                 if new_ses in existing_ses_values:
                     utils.log_and_raise_error(
                         f"Cannot make folders. "
-                        f"The key ses-{new_ses} for {sub} already exists in the project"
+                        f"The key ses-{new_ses} for {sub} (possibly with leading "
+                        f"zeros) already exists in the project"
                     )
 
 
@@ -472,11 +482,6 @@ def search_filesystem_path_for_folders(
     return all_folder_names, all_filenames
 
 
-# -----------------------------------------------------------------------------
-# Get Next Subject or Session Number
-# -----------------------------------------------------------------------------
-
-
 def get_next_sub_or_ses_number(
     cfg: Configs, sub: Optional[str], search_str: str
 ) -> Tuple[int, int]:
@@ -488,27 +493,22 @@ def get_next_sub_or_ses_number(
     pair values, and return the maximum value + 1 as the new number.
     A warning will be shown if the existing sub / session numbers are not
     consecutive.
-
     If sub is None, the top-level level folder will be searched (i.e. for subjects).
     The search string "sub-*" is suggested in this case. Otherwise, the subject,
     level folder for the specified subject will be searched. The search_str
     "ses-*" is suggested in this case.
-
     Parameters
     ----------
-
     cfg : datashuttle configs class
     sub : subject name to search within if searching for sessions, otherwise None
           to search for subjects
     search_str : the string to search for within the top-level or subject-levle
                  folder ("sub-*") or ("ses-*") are suggested, respectively.
-
     Returns
     -------
     suggested_new_num : the new suggested sub / ses number.
     latest_existing_num : the latest sub / ses number that currently
                           exists in the project.
-
     """
     if sub:
         bids_key = "ses"

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -384,7 +384,7 @@ class TestCommandLineInterface:
         see test_filesystem_transfer.py
         """
         subs = ["sub-1_1", "sub-two", "sub-3_3-3"]
-        ses = ["ses-123", "ses-hello_hello_world"]
+        ses = ["ses-123", "ses-999"]
 
         test_utils.run_cli(
             f"make_sub_folders --data_type all --sub_names {self.to_cli_input(subs)} --ses_names {self.to_cli_input(ses)} ",  # noqa

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -138,29 +138,32 @@ class TestCommandLineInterface:
 
     def test_make_sub_folders__(self, setup_project):
 
-        subs = ["sub-1_1", f"sub-002{tags('to')}004"]
-        ses = ["ses-123", "ses-hello_world"]
+        subs = ["sub-11", f"sub-002{tags('to')}004"]
+        ses = ["ses-123", "ses-101"]
 
         setup_project.make_sub_folders(subs, ses, data_type="all")
 
         log = self.read_log_file(setup_project.cfg.logging_path)
 
         assert "Formatting Names..." in log
+
         assert (
-            "\n\nVariablesState:\nlocals: {'sub_names': ['sub-1_1', 'sub-002@TO@004'], 'ses_names': ['ses-123', 'ses-hello_world'], 'data_type': 'all'}\ncfg: {'local_path':"
+            "\n\nVariablesState:\nlocals: {'sub_names': ['sub-11', "
+            "'sub-002@TO@004'], 'ses_names': ['ses-123', 'ses-101'], "
+            "'data_type': 'all'}\ncfg: {'local_path':" in log
+        )
+
+        assert f"sub_names: ['sub-11', 'sub-002{tags('to')}004']" in log
+        assert "ses_names: ['ses-123', 'ses-101']" in log
+        assert (
+            "formatted_sub_names: ['sub-11', 'sub-002', 'sub-003', 'sub-004']"
             in log
         )
-        assert f"sub_names: ['sub-1_1', 'sub-002{tags('to')}004']" in log
-        assert "ses_names: ['ses-123', 'ses-hello_world']" in log
-        assert (
-            "formatted_sub_names: ['sub-1_1', 'sub-002', 'sub-003', 'sub-004']"
-            in log
-        )
-        assert "formatted_ses_names: ['ses-123', 'ses-hello_world']" in log
+        assert "formatted_ses_names: ['ses-123', 'ses-101']" in log
         assert "Made folder at path:" in log
 
         assert (
-            str(Path("test_logging") / "local" / "rawdata" / "sub-1_1") in log
+            str(Path("test_logging") / "local" / "rawdata" / "sub-11") in log
         )
         assert (
             str(
@@ -168,7 +171,7 @@ class TestCommandLineInterface:
                     "test_logging",
                     "local",
                     "rawdata",
-                    "sub-1_1",
+                    "sub-11",
                     "ses-123",
                     "funcimg",
                     ".datashuttle_meta",
@@ -196,7 +199,7 @@ class TestCommandLineInterface:
                     "local",
                     "rawdata",
                     "sub-004",
-                    "ses-hello_world",
+                    "ses-101",
                 )
             )
             in log
@@ -212,7 +215,7 @@ class TestCommandLineInterface:
         Set transfer verbosity and progress settings so
         maximum output is produced to test against.
         """
-        subs = ["sub-1_1"]
+        subs = ["sub-11"]
         sessions = ["ses-123"]
 
         test_utils.make_and_check_local_project(
@@ -261,7 +264,7 @@ class TestCommandLineInterface:
         assert "Creating backend with remote" in log
         assert "Using config file from" in log
         assert "Local file system at" in log
-        assert """ "--include" "sub-1_1/histology/**" """ in log
+        assert """ "--include" "sub-11/histology/**" """ in log
         assert """/test_logging/remote/rawdata""" in log
         assert "Waiting for checks to finish" in log
         assert "Transferred:   	          0 B / 0 B, -, 0 B/s, ETA -" in log
@@ -343,7 +346,7 @@ class TestCommandLineInterface:
         log = self.read_log_file(setup_project.cfg.logging_path)
 
         assert (
-            "Cannot make folders. The key sub-001 already exists in the project"
+            "Cannot make folders. The key sub-1 (possibly with leading zeros) already exists in the project"
             in log
         )
 

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -115,6 +115,34 @@ class TestMakeFolders:
 
         project.make_sub_folders("sub-001", "ses-003")
 
+    def test_duplicate_sub_and_ses_num_leading_zeros(self, project):
+        """
+        Very similar to test_duplicate_ses_or_sub_key_value_pair(),
+        but explicitly check that error is raised if the same
+        number is used with different number of leading zeros.
+        """
+        project.make_sub_folders("sub-001")
+
+        with pytest.raises(BaseException) as e:
+            project.make_sub_folders("sub-1")
+
+        assert (
+            str(e.value) == "Cannot make folders. The key sub-1 "
+            "(possibly with leading zeros) already exists "
+            "in the project"
+        )
+
+        project.make_sub_folders("sub-001", "ses-3")
+
+        with pytest.raises(BaseException) as e:
+            project.make_sub_folders("sub-001", "ses-003")
+
+        assert (
+            str(e.value) == "Cannot make folders. The key ses-3 for"
+            " sub-001 (possibly with leading zeros) "
+            "already exists in the project"
+        )
+
     def test_format_names_prefix(self):
         """
         Check that format_names correctly prefixes input

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -93,7 +93,8 @@ class TestMakeFolders:
 
         assert (
             str(e.value) == "Cannot make folders. "
-            "The key sub-001 already exists in the project"
+            "The key sub-1 (possibly with leading zeros) "
+            "already exists in the project"
         )
 
         project.make_sub_folders("sub-003")
@@ -106,8 +107,10 @@ class TestMakeFolders:
             project.make_sub_folders("sub-001_id-123", "ses-002_date-1607")
 
         assert (
-            str(e.value) == "Cannot make folders. "
-            "The key ses-002 for sub-001_id-123 already exists in the project"
+            str(e.value)
+            == "Cannot make folders. The key ses-2 for sub-001_id-123 "
+            "(possibly with leading zeros) already exists "
+            "in the project"
         )
 
         project.make_sub_folders("sub-001", "ses-003")
@@ -148,14 +151,14 @@ class TestMakeFolders:
         a dict that indicates if each subfolder is used (to avoid
         circular testing from the project itself).
         """
-        subs = ["1_1", "sub-two", "3_3-3"]
+        subs = ["11", "sub-002", "30303"]
 
         project.make_sub_folders(subs)
 
         test_utils.check_folder_tree_is_correct(
             project,
             base_folder=test_utils.get_rawdata_path(project),
-            subs=["sub-1_1", "sub-two", "sub-3_3-3"],
+            subs=["sub-11", "sub-002", "sub-30303"],
             sessions=[],
             folder_used=test_utils.get_default_folder_used(),
         )
@@ -170,12 +173,12 @@ class TestMakeFolders:
         This is highlighted in an assert in check_and_cd_folder()
         """
         subs = ["sub-001", "sub-002"]
-        sessions = ["ses-001", "="]
+        sessions = ["ses-001", "50432"]
         project.make_sub_folders(subs, sessions)
         base_folder = test_utils.get_rawdata_path(project)
 
         for sub in subs:
-            for ses in ["ses-001", "ses-="]:
+            for ses in ["ses-001", "ses-50432"]:
                 test_utils.check_and_cd_folder(
                     join(base_folder, sub, ses, "ephys")
                 )


### PR DESCRIPTION
This PR makes a very small change to use integers rather than strings for checking the sub / ses number is not duplicated. The conversion to integer removes any leading zeros. Previously it was possible to have `sub-001` and `sub-1` in the same project, this is no longer possible.