### PR TITLE
Update docs deployment workflow

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -24,6 +24,8 @@ jobs:
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs
     needs: build_sphinx_docs
+    permissions:
+      contents: write
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Changed the Sphinx docs workflow so that deployment only happens when a version is tagged (same trigger as for PyPI release).
