### PR TITLE
Add print start up message as well as top-level-folder state to relevant methods.

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -1025,6 +1025,50 @@ parser = construct_parser()
 # -----------------------------------------------------------------------------
 
 
+def should_show_startup_message(func_name: str) -> bool:
+    """ """
+    show_message_funcs = [
+        "make_config_file",
+        "update_config",
+        "supply_config_file",
+        "make_sub_folders",
+        "upload_data",
+        "upload_all",
+        "upload_entire_project",
+        "download_data",
+        "download_all",
+        "download_entire_project",
+        "upload_project_folder_or_file",
+        "download_project_folder_or_file",
+    ]
+
+    dont_show_message_funcs = [
+        "setup_ssh_connection_to_central_server",
+        "set_top_level_folder",
+        "show_local_path",
+        "show_datashuttle_path",
+        "show_config_path",
+        "show_central_path",
+        "show_configs",
+        "show_logging_path",
+        "show_local_tree",
+        "show_top_level_folder",
+        "show_next_sub_number",
+        "show_next_ses_number",
+        "check_name_formatting",
+    ]
+
+    assert func_name in show_message_funcs + dont_show_message_funcs, (
+        "func name not found. Make sure to add it to the list above"
+        "if implementing a new CLI command."
+    )
+
+    if func_name in show_message_funcs:
+        return True
+    else:
+        return False
+
+
 def main() -> None:
     """
     All arguments from the CLI are collected and
@@ -1049,13 +1093,16 @@ def main() -> None:
     """
     args = parser.parse_args()
 
-    if "func" in args and str(args.func.__name__) == "make_config_file":
+    func_name = args.func.__name__
+    if "func" in args and str(func_name) == "make_config_file":
         warn = "ignore"
     else:
         warn = "default"
 
+    show_startup_message = should_show_startup_message(func_name)
+
     warnings.filterwarnings(warn)  # type: ignore
-    project = DataShuttle(args.project_name)
+    project = DataShuttle(args.project_name, show_startup_message)
     warnings.filterwarnings("default")
 
     if len(vars(args)) > 1:

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -1025,50 +1025,6 @@ parser = construct_parser()
 # -----------------------------------------------------------------------------
 
 
-def should_show_startup_message(func_name: str) -> bool:
-    """ """
-    show_message_funcs = [
-        "make_config_file",
-        "update_config",
-        "supply_config_file",
-        "make_sub_folders",
-        "upload_data",
-        "upload_all",
-        "upload_entire_project",
-        "download_data",
-        "download_all",
-        "download_entire_project",
-        "upload_project_folder_or_file",
-        "download_project_folder_or_file",
-    ]
-
-    dont_show_message_funcs = [
-        "setup_ssh_connection_to_central_server",
-        "set_top_level_folder",
-        "show_local_path",
-        "show_datashuttle_path",
-        "show_config_path",
-        "show_central_path",
-        "show_configs",
-        "show_logging_path",
-        "show_local_tree",
-        "show_top_level_folder",
-        "show_next_sub_number",
-        "show_next_ses_number",
-        "check_name_formatting",
-    ]
-
-    assert func_name in show_message_funcs + dont_show_message_funcs, (
-        "func name not found. Make sure to add it to the list above"
-        "if implementing a new CLI command."
-    )
-
-    if func_name in show_message_funcs:
-        return True
-    else:
-        return False
-
-
 def main() -> None:
     """
     All arguments from the CLI are collected and
@@ -1094,20 +1050,13 @@ def main() -> None:
     """
     args = parser.parse_args()
 
-    if "func" in args:
-        func_name = args.func.__name__
-        if str(func_name) == "make_config_file":
-            warn = "ignore"
-        else:
-            warn = "default"
-
-        show_startup_message = should_show_startup_message(func_name)
+    if "func" in args and str(args.func.__name__) == "make_config_file":
+        warn = "ignore"
     else:
         warn = "default"
-        show_startup_message = False
 
     warnings.filterwarnings(warn)  # type: ignore
-    project = DataShuttle(args.project_name, show_startup_message)
+    project = DataShuttle(args.project_name, print_startup_message=False)
     warnings.filterwarnings("default")
 
     if len(vars(args)) > 1:

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -1090,16 +1090,21 @@ def main() -> None:
     These command functions (all defined above) will process
     the CLI arguments and then call the appropriate API function
     through run_command().
+
     """
     args = parser.parse_args()
 
-    func_name = args.func.__name__
-    if "func" in args and str(func_name) == "make_config_file":
-        warn = "ignore"
+    if "func" in args:
+        func_name = args.func.__name__
+        if str(func_name) == "make_config_file":
+            warn = "ignore"
+        else:
+            warn = "default"
+
+        show_startup_message = should_show_startup_message(func_name)
     else:
         warn = "default"
-
-    show_startup_message = should_show_startup_message(func_name)
+        show_startup_message = False
 
     warnings.filterwarnings(warn)  # type: ignore
     project = DataShuttle(args.project_name, show_startup_message)

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -209,6 +209,8 @@ class DataShuttle:
         """
         self._start_log("make_sub_folders", local_vars=locals())
 
+        self.show_top_level_folder()
+
         utils.log("\nFormatting Names...")
         ds_logger.log_names(["sub_names", "ses_names"], [sub_names, ses_names])
 
@@ -340,6 +342,8 @@ class DataShuttle:
         if init_log:
             self._start_log("upload_data", local_vars=locals())
 
+        self.show_top_level_folder()
+
         TransferData(
             self.cfg,
             "upload",
@@ -373,6 +377,8 @@ class DataShuttle:
         """
         if init_log:
             self._start_log("download_data", local_vars=locals())
+
+        self.show_top_level_folder()
 
         TransferData(
             self.cfg,
@@ -462,6 +468,8 @@ class DataShuttle:
         """
         self._start_log("upload_project_folder_or_file", local_vars=locals())
 
+        self.show_top_level_folder()
+
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local"),
             Path(filepath),
@@ -511,6 +519,8 @@ class DataShuttle:
             to check which files will be moved on data transfer.
         """
         self._start_log("download_project_folder_or_file", local_vars=locals())
+
+        self.show_top_level_folder()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central"),

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -70,7 +70,7 @@ class DataShuttle:
                    see the path to this folder.
     """
 
-    def __init__(self, project_name: str):
+    def __init__(self, project_name: str, print_startup_message: bool = True):
 
         if " " in project_name:
             utils.log_and_raise_error(
@@ -96,6 +96,10 @@ class DataShuttle:
 
         if self.cfg:
             self._set_attributes_after_config_load()
+
+        if print_startup_message:
+            if self.cfg:
+                self.show_top_level_folder()
 
         rclone.prompt_rclone_download_if_does_not_exist()
 
@@ -917,7 +921,7 @@ class DataShuttle:
         """
         utils.print_message_to_user(
             f"\nThe working top level folder is: "
-            f"{self.cfg.top_level_folder}"
+            f"{self.cfg.top_level_folder}\n"
         )
 
     @check_configs_set

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -18,7 +18,7 @@ class TestFileTransfer:
     @pytest.fixture(
         scope="class",
         params=[  # Set running SSH or local filesystem
-            #     False,
+            False,
             pytest.param(
                 True,
                 marks=pytest.mark.skipif(


### PR DESCRIPTION
This PR sets a 'welcome' message on project initialisation. This at the moment only shows the current top-level working directory. However, we don't want to show this every time a CLI command is run (the CLI works by initialising the API and running the required function). So, this is turned off for CLI calls. 

Also, the `show_top_level_folder` method is called when all relevant functions are run (`make_sub_folders` and upload / download transfer methods that rely on the working top level folder).