### PR TITLE
Rename transfer data functions.

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -203,7 +203,7 @@ def make_sub_folders(project: DataShuttle, args: Any) -> None:
 # Upload Data -----------------------------------------------------------------
 
 
-def upload_data(project: DataShuttle, args: Any) -> None:
+def upload(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
@@ -211,7 +211,7 @@ def upload_data(project: DataShuttle, args: Any) -> None:
 
     run_command(
         project,
-        project.upload_data,
+        project.upload,
         **filtered_kwargs,
     )
 
@@ -219,10 +219,10 @@ def upload_data(project: DataShuttle, args: Any) -> None:
 # Upload All ------------------------------------------------------------------
 
 
-def upload_all(*args: Any) -> None:
+def upload_working_folder(*args: Any) -> None:
     """"""
     project = args[0]
-    project.upload_all()
+    project.upload_working_folder()
 
 
 # Upload Entire Project -------------------------------------------------------
@@ -237,7 +237,7 @@ def upload_entire_project(*args: Any) -> None:
 # Download Data ---------------------------------------------------------------
 
 
-def download_data(project: DataShuttle, args: Any) -> None:
+def download(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
@@ -245,7 +245,7 @@ def download_data(project: DataShuttle, args: Any) -> None:
 
     run_command(
         project,
-        project.download_data,
+        project.download,
         **filtered_kwargs,
     )
 
@@ -253,10 +253,10 @@ def download_data(project: DataShuttle, args: Any) -> None:
 # Download All ----------------------------------------------------------------
 
 
-def download_all(*args: Any) -> None:
+def download_working_folder(*args: Any) -> None:
     """"""
     project = args[0]
-    project.download_all()
+    project.download_working_folder()
 
 
 # Download Entire Project -----------------------------------------------------
@@ -631,19 +631,19 @@ def construct_parser():
     # Upload Data
     # ----------------------------------------------------------------------
 
-    upload_data_parser = subparsers.add_parser(
-        "upload-data",
-        aliases=["upload_data"],
-        description=process_docstring(DataShuttle.upload_data.__doc__),
+    upload_parser = subparsers.add_parser(
+        "upload",
+        aliases=["upload"],
+        description=process_docstring(DataShuttle.upload.__doc__),
         formatter_class=argparse.RawTextHelpFormatter,
         help="",
     )
-    upload_data_parser = upload_data_parser.add_argument_group(
+    upload_parser = upload_parser.add_argument_group(
         "named arguments:"
     )  # type: ignore
-    upload_data_parser.set_defaults(func=upload_data)
+    upload_parser.set_defaults(func=upload)
 
-    upload_data_parser.add_argument(
+    upload_parser.add_argument(
         "--sub-names",
         "--sub_names",
         "-sub",
@@ -652,7 +652,7 @@ def construct_parser():
         required=True,
         help=help("required_str_single_or_multiple_or_all"),
     )
-    upload_data_parser.add_argument(
+    upload_parser.add_argument(
         "--ses-names",
         "--ses_names",
         "-ses",
@@ -661,7 +661,7 @@ def construct_parser():
         required=True,
         help=help("required_str_single_or_multiple_or_all"),
     )
-    upload_data_parser.add_argument(
+    upload_parser.add_argument(
         "--data-type",
         "--data_type",
         "-dt",
@@ -670,7 +670,7 @@ def construct_parser():
         required=False,
         help="Optional: (str, single or multiple) (selection of data types, or 'all') (default 'all')",
     )
-    upload_data_parser.add_argument(
+    upload_parser.add_argument(
         "--dry-run",
         "--dry_run",
         required=False,
@@ -681,13 +681,15 @@ def construct_parser():
     # Upload All
     # -------------------------------------------------------------------------
 
-    upload_all_parser = subparsers.add_parser(
-        "upload-all",
-        aliases=["upload_all"],
-        description=process_docstring(DataShuttle.upload_all.__doc__),
+    upload_working_folder_parser = subparsers.add_parser(
+        "upload-working-folder",
+        aliases=["upload_working_folder"],
+        description=process_docstring(
+            DataShuttle.upload_working_folder.__doc__
+        ),
         help="",
     )
-    upload_all_parser.set_defaults(func=upload_all)
+    upload_working_folder_parser.set_defaults(func=upload_working_folder)
 
     # Upload All
     # -------------------------------------------------------------------------
@@ -705,19 +707,19 @@ def construct_parser():
     # Download Data
     # -------------------------------------------------------------------------
 
-    download_data_parser = subparsers.add_parser(
-        "download-data",
-        aliases=["download_data"],
-        description=process_docstring(DataShuttle.download_data.__doc__),
+    download_parser = subparsers.add_parser(
+        "download",
+        aliases=["download"],
+        description=process_docstring(DataShuttle.download.__doc__),
         formatter_class=argparse.RawTextHelpFormatter,
         help="",
     )
-    download_data_parser = download_data_parser.add_argument_group(
+    download_parser = download_parser.add_argument_group(
         "named arguments:"  # type: ignore
     )
-    download_data_parser.set_defaults(func=download_data)
+    download_parser.set_defaults(func=download)
 
-    download_data_parser.add_argument(
+    download_parser.add_argument(
         "--sub-names",
         "--sub_names",
         "-sub",
@@ -726,7 +728,7 @@ def construct_parser():
         required=True,
         help=help("required_str_single_or_multiple_or_all"),
     )
-    download_data_parser.add_argument(
+    download_parser.add_argument(
         "--ses-names",
         "--ses_names",
         "-ses",
@@ -735,7 +737,7 @@ def construct_parser():
         required=True,
         help=help("required_str_single_or_multiple_or_all"),
     )
-    download_data_parser.add_argument(
+    download_parser.add_argument(
         "--data-type",
         "--data_type",
         "-dt",
@@ -745,7 +747,7 @@ def construct_parser():
         help="Optional: (str or list) (selection of data "
         "types, or 'all') (default 'all')",
     )
-    download_data_parser.add_argument(
+    download_parser.add_argument(
         "--dry-run",
         "--dry_run",
         required=False,
@@ -756,13 +758,15 @@ def construct_parser():
     # Download All
     # -------------------------------------------------------------------------
 
-    download_all_parser = subparsers.add_parser(
-        "download-all",
-        aliases=["download_all"],
-        description=process_docstring(DataShuttle.download_all.__doc__),
+    download_working_folder_parser = subparsers.add_parser(
+        "download-working-folder",
+        aliases=["download_working_folder"],
+        description=process_docstring(
+            DataShuttle.download_working_folder.__doc__
+        ),
         help="",
     )
-    download_all_parser.set_defaults(func=download_all)
+    download_working_folder_parser.set_defaults(func=download_working_folder)
 
     # Download Entire Project
     # -------------------------------------------------------------------------

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -271,13 +271,13 @@ def download_entire_project(*args: Any) -> None:
 # Upload Project Folder or File -----------------------------------------------
 
 
-def upload_project_folder_or_file(project: DataShuttle, args: Any) -> None:
+def upload_specific_folder_or_file(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
     run_command(
         project,
-        project.upload_project_folder_or_file,
+        project.upload_specific_folder_or_file,
         kwargs.pop("filepath"),
         **kwargs,
     )
@@ -286,13 +286,13 @@ def upload_project_folder_or_file(project: DataShuttle, args: Any) -> None:
 # Download Project Folder or File ---------------------------------------------
 
 
-def download_project_folder_or_file(project: DataShuttle, args: Any) -> None:
+def download_specific_folder_or_file(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
     run_command(
         project,
-        project.download_project_folder_or_file,
+        project.download_specific_folder_or_file,
         kwargs.pop("filepath"),
         **kwargs,
     )
@@ -784,23 +784,23 @@ def construct_parser():
     # Upload project folder or file
     # -------------------------------------------------------------------------
 
-    upload_project_folder_or_file_parser = subparsers.add_parser(
-        "upload-project-folder-or-file",
-        aliases=["upload_project_folder_or_file"],
+    upload_specific_folder_or_file_parser = subparsers.add_parser(
+        "upload-specific-folder-or-file",
+        aliases=["upload_specific_folder_or_file"],
         description=process_docstring(
-            DataShuttle.upload_project_folder_or_file.__doc__
+            DataShuttle.upload_specific_folder_or_file.__doc__
         ),
         formatter_class=argparse.RawTextHelpFormatter,
         help="",
     )
-    upload_project_folder_or_file_parser.set_defaults(
-        func=upload_project_folder_or_file
+    upload_specific_folder_or_file_parser.set_defaults(
+        func=upload_specific_folder_or_file
     )
 
-    upload_project_folder_or_file_parser.add_argument(
+    upload_specific_folder_or_file_parser.add_argument(
         "filepath", type=str, help=help("required_str")
     )
-    upload_project_folder_or_file_parser.add_argument(
+    upload_specific_folder_or_file_parser.add_argument(
         "--dry-run",
         "--dry_run",
         action="store_true",
@@ -810,23 +810,23 @@ def construct_parser():
     # Download project folder or file
     # -------------------------------------------------------------------------
 
-    download_project_folder_or_file_parser = subparsers.add_parser(
-        "download-project-folder-or-file",
-        aliases=["download_project_folder_or_file"],
+    download_specific_folder_or_file_parser = subparsers.add_parser(
+        "download-specific-folder-or-file",
+        aliases=["download_specific_folder_or_file"],
         description=process_docstring(
-            DataShuttle.download_project_folder_or_file.__doc__
+            DataShuttle.download_specific_folder_or_file.__doc__
         ),
         formatter_class=argparse.RawTextHelpFormatter,
         help="",
     )
-    download_project_folder_or_file_parser.set_defaults(
-        func=download_project_folder_or_file
+    download_specific_folder_or_file_parser.set_defaults(
+        func=download_specific_folder_or_file
     )
 
-    download_project_folder_or_file_parser.add_argument(
+    download_specific_folder_or_file_parser.add_argument(
         "filepath", type=str, help=help("required_str")
     )
-    download_project_folder_or_file_parser.add_argument(
+    download_specific_folder_or_file_parser.add_argument(
         "--dry-run",
         "--dry_run",
         action="store_true",

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -99,4 +99,4 @@ def get_non_ses_names():
 
 
 def get_top_level_folders():
-    return ["rawdata", "derivatives", "analysis", "code"]
+    return ["rawdata", "derivatives"]

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -123,9 +123,9 @@ class DataShuttle:
         """
         Set the working top level folder (e.g. 'rawdata', 'derivatives').
 
-        The top level folder defines in which top level folder folders
-        are made (e.g. make_sub_folders) or at which level folders
-        are transferred with the commands upload_data / download_data
+        The top_level_folder defines in which top level folder new
+        sub-folders will be made (e.g. make_sub_folders) or at which level
+        folders  are transferred with the commands upload_data / download_data
         and upload_all / download all.
 
         To upload the entire project (i.e. every top level
@@ -298,7 +298,7 @@ class DataShuttle:
             a subject name / list of subject names. These must
             be prefixed with "sub-", or the prefix will be
             automatically added. "@*@" can be used as a wildcard.
-            "all" will search for all subfolders in the
+            "all" will search for all sub-folders in the
             data type folder to upload.
         ses_names :
             a session name / list of session names, similar to
@@ -906,10 +906,11 @@ class DataShuttle:
         Print the current working top level folder (e.g.
         'rawdata', 'derivatives')
 
-        The top level folder defines in which top level folder folders
-        are made (e.g. make_sub_folders) or at which level folders
-        are transferred with the commands upload_data / download_data
-        and upload_all / download all.
+        The top_level_folder defines in which top level folder new
+        sub-folders will be made (e.g. make_sub_folders) or
+        at which level folders are transferred with the commands
+        upload_data / download_data and upload_all / download all.
+        upload_project_folder_or_file / download_project_folder_or_file.
 
         To upload the entire project (i.e. every top level
         folder), use the 'command upload_entire_project' or

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -424,7 +424,7 @@ class DataShuttle:
         self._transfer_entire_project("download")
 
     @check_configs_set
-    def upload_project_folder_or_file(
+    def upload_specific_folder_or_file(
         self, filepath: str, dry_run: bool = False
     ) -> None:
         """
@@ -454,7 +454,7 @@ class DataShuttle:
             transfer was taking place, but no files will be moved. Useful
             to check which files will be moved on data transfer.
         """
-        self._start_log("upload_project_folder_or_file", local_vars=locals())
+        self._start_log("upload_specific_folder_or_file", local_vars=locals())
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local"),
@@ -474,7 +474,7 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    def download_project_folder_or_file(
+    def download_specific_folder_or_file(
         self, filepath: str, dry_run: bool = False
     ) -> None:
         """
@@ -504,7 +504,9 @@ class DataShuttle:
             transfer was taking place, but no files will be moved. Useful
             to check which files will be moved on data transfer.
         """
-        self._start_log("download_project_folder_or_file", local_vars=locals())
+        self._start_log(
+            "download_specific_folder_or_file", local_vars=locals()
+        )
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central"),
@@ -908,7 +910,7 @@ class DataShuttle:
         sub-folders will be made (e.g. make_sub_folders) or
         at which level folders are transferred with the commands
         upload / download and upload_working_folder / download all.
-        upload_project_folder_or_file / download_project_folder_or_file.
+        upload_specific_folder_or_file / download_specific_folder_or_file.
 
         To upload the entire project (i.e. every top level
         folder), use the 'command upload_entire_project' or

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -125,8 +125,8 @@ class DataShuttle:
 
         The top_level_folder defines in which top level folder new
         sub-folders will be made (e.g. make_sub_folders) or at which level
-        folders  are transferred with the commands upload_data / download_data
-        and upload_all / download all.
+        folders  are transferred with the commands upload / download
+        and upload_working_folder / download all.
 
         To upload the entire project (i.e. every top level
         folder), use the 'command upload_entire_project' or
@@ -276,7 +276,7 @@ class DataShuttle:
     # -------------------------------------------------------------------------
 
     @check_configs_set
-    def upload_data(
+    def upload(
         self,
         sub_names: Union[str, list],
         ses_names: Union[str, list],
@@ -334,7 +334,7 @@ class DataShuttle:
               (on the 1st january, 2022).
         """
         if init_log:
-            self._start_log("upload_data", local_vars=locals())
+            self._start_log("upload", local_vars=locals())
 
         TransferData(
             self.cfg,
@@ -348,7 +348,7 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    def download_data(
+    def download(
         self,
         sub_names: Union[str, list],
         ses_names: Union[str, list],
@@ -363,12 +363,12 @@ class DataShuttle:
         not be overwritten even if the central file is an
         older version.
 
-        This function is identical to upload_data() but with the direction
-        of data transfer reversed. Please see upload_data() for arguments.
+        This function is identical to upload() but with the direction
+        of data transfer reversed. Please see upload() for arguments.
         "all" arguments will search the central project for sub / ses to download.
         """
         if init_log:
-            self._start_log("download_data", local_vars=locals())
+            self._start_log("download", local_vars=locals())
 
         TransferData(
             self.cfg,
@@ -382,29 +382,27 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    def upload_all(self, dry_run: bool = False):
+    def upload_working_folder(self, dry_run: bool = False):
         """
         Convenience function to upload all data.
 
         Alias for:
-            project.upload_data("all", "all", "all")
+            project.upload("all", "all", "all")
         """
-        self._start_log("upload_all", local_vars=locals())
+        self._start_log("upload_working_folder", local_vars=locals())
 
-        self.upload_data("all", "all", "all", dry_run=dry_run, init_log=False)
+        self.upload("all", "all", "all", dry_run=dry_run, init_log=False)
 
     @check_configs_set
-    def download_all(self, dry_run: bool = False):
+    def download_working_folder(self, dry_run: bool = False):
         """
         Convenience function to download all data.
 
-        Alias for : project.download_data("all", "all", "all")
+        Alias for : project.download("all", "all", "all")
         """
-        self._start_log("download_all", local_vars=locals())
+        self._start_log("download_working_folder", local_vars=locals())
 
-        self.download_data(
-            "all", "all", "all", dry_run=dry_run, init_log=False
-        )
+        self.download("all", "all", "all", dry_run=dry_run, init_log=False)
         ds_logger.close_log_filehandler()
 
     @check_configs_set
@@ -909,7 +907,7 @@ class DataShuttle:
         The top_level_folder defines in which top level folder new
         sub-folders will be made (e.g. make_sub_folders) or
         at which level folders are transferred with the commands
-        upload_data / download_data and upload_all / download all.
+        upload / download and upload_working_folder / download all.
         upload_project_folder_or_file / download_project_folder_or_file.
 
         To upload the entire project (i.e. every top level
@@ -980,8 +978,8 @@ class DataShuttle:
     def check_name_formatting(names: Union[str, list], prefix: str) -> None:
         """
         Pass list of names to check how these will be auto-formatted,
-        for example as when passed to make_sub_folders() or upload_data()
-        or download_data()
+        for example as when passed to make_sub_folders() or upload()
+        or download()
 
         Useful for checking tags e.g. @TO@, @DATE@, @DATETIME@, @DATE@.
         This method will print the formatted list of names,
@@ -1012,7 +1010,7 @@ class DataShuttle:
         Transfer (i.e. upload or download) the entire project (i.e.
         every 'top level folder' (e.g. 'rawdata', 'derivatives').
 
-        This function leverages the upload_all or download_all
+        This function leverages the upload_working_folder or download_working_folder
         methods while switching the top level folder as defined in
         self.cfg that these methods use to determine the top-level
         folder to transfer.
@@ -1024,7 +1022,9 @@ class DataShuttle:
                     local to central) or "download" (from central to local).
         """
         transfer_all_func = (
-            self.upload_all if direction == "upload" else self.download_all
+            self.upload_working_folder
+            if direction == "upload"
+            else self.download_working_folder
         )
 
         tmp_current_top_level_folder = copy.copy(self.cfg.top_level_folder)

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -333,7 +333,7 @@ def search_for_wildcards(
     sub: Optional[str] = None,
 ) -> List[str]:
     """
-    Handle wildcard flag in upload_data or download_data.
+    Handle wildcard flag in upload or download.
 
     All names in name are searched for @*@ string, and replaced
     with single * for glob syntax. If sub is passed, it is

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -209,7 +209,7 @@ only one @DATE@, @TIME@ or @DATETIME@ flag can be used per subject / session nam
 ## Data Transfer
 
 Data transfer can be either from the local project to the central project ("upload") or from the central to local project("download"). Data
-transfers are primarily managed using the upload_data() and download_data() functions.
+transfers are primarily managed using the upload() and download() functions.
 
 By default, uploading or downloading data will never overwrite files when transferring data. If an
 existing file with the same name is found in the target folder, even if it is older, it will not be overwritten.
@@ -219,13 +219,13 @@ determine if any files were not transferred for this reason.
 To transfer all data, the keyword "all" can be used for sub_names, ses_names and data_type arguments. Note that
 any existing data_type will be transferred, even if the flag use_<data_type> (e.g. use_behav) is False.
 
-For example, `project.upload_data(sub_names="all", ses_names="all", data_type="all")`
+For example, `project.upload(sub_names="all", ses_names="all", data_type="all")`
 
 or equivalently
-`datashuttle my_project upload_data --sub_names all --ses_names all --data_type all`
+`datashuttle my_project upload --sub_names all --ses_names all --data_type all`
 
-will transfer everything in the local project folder to the central. The convenience functions upload_all()
-and download_all() can be used as shortcuts for this. See below for a full list of all sub_names, ses_names and data_type
+will transfer everything in the local project folder to the central. The convenience functions upload_working_folder()
+and download_working_folder() can be used as shortcuts for this. See below for a full list of all sub_names, ses_names and data_type
 keyword options.
 
 A number of configuration settings define the behaviour of datashuttle during file transfer (see make_config_file). Datashuttle
@@ -254,7 +254,7 @@ When true, real-time transfer statistics will be reported and logged.
 ### All sub_names, ses_names and data_type keywords
 
 For each argument, the subject, session or datatype to transfer can be specified directly, e.g.
-`project.upload_data(sub_names="sub-001", ses_names=["ses-001", "ses-002]", data_type="behav" )`
+`project.upload(sub_names="sub-001", ses_names=["ses-001", "ses-002]", data_type="behav" )`
 
 However, a number of keyword arguments can be used to specify more general rules for transfer:
 
@@ -299,7 +299,7 @@ is not found, it will be added.
 For example,
 
 ```
-project.download_data(
+project.download(
 sub_names=["all"],
 ses_names=["ses-001", "ses-005"],
 data_type="behav"
@@ -311,7 +311,7 @@ or equivalently
 ```
 datashuttle \
 my_project \
-download_data \
+download \
 --sub-names all
 --ses-names ses-001 ses-005
 --data-type behav
@@ -328,8 +328,8 @@ The wildcard flag can be used to avoid specifying particular parts of subject / 
 to tbe transferred. This is particularly useful for skipping the `date_xxxxxx` flag that might differ across sessions or subjects.
 
 For example,
-`project.upload_data(sub_names="sub-@*@", ses_names="ses-001_date-@*@", data_type="all")` or
-equivalently `datashuttle my_project upload_data --sub_names sub-@*@ --ses_names ses-001_date-@*@ --data_type all`
+`project.upload(sub_names="sub-@*@", ses_names="ses-001_date-@*@", data_type="all")` or
+equivalently `datashuttle my_project upload --sub_names sub-@*@ --ses_names ses-001_date-@*@ --data_type all`
 
 would transfer all any first session, irregardless of date, or all subjects and all data types.
 

--- a/docs/source/pages/get_started.md
+++ b/docs/source/pages/get_started.md
@@ -145,7 +145,7 @@ will create the folder structure:
 ## Data Transfer
 
 Data transfer can be either from the local project to the central project ("upload") or from the central to local project("download"). Data
-transfers are primarily managed using the upload_data() and download_data() functions.
+transfers are primarily managed using the upload() and download() functions.
 
 By default, uploading or downloading data will never overwrite files when transferring data. If an
 existing file with the same name is found in the target folder, even if it is older, it will not be overwritten.
@@ -155,7 +155,7 @@ determine if any files were not transferred for this reason.
 For example,
 
 ```
-project.download_data(
+project.download(
 sub_names=["all"],
 ses_names=["ses-001", "ses-005"],
 data_type="behav"
@@ -167,7 +167,7 @@ or equivalently
 ```
 datashuttle \
 my_project \
-download_data \
+download \
 --sub-names all
 --ses-names ses-001 ses-005
 --data-type behav

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -528,18 +528,18 @@ def handle_upload_or_download(
         if transfer_entire_project:
             transfer_function = project.download_entire_project
         elif use_all_alias:
-            transfer_function = project.download_all
+            transfer_function = project.download_working_folder
         else:
-            transfer_function = project.download_data
+            transfer_function = project.download
     else:
         central_path = project.cfg["central_path"]
 
         if transfer_entire_project:
             transfer_function = project.upload_entire_project
         elif use_all_alias:
-            transfer_function = project.upload_all
+            transfer_function = project.upload_working_folder
         else:
-            transfer_function = project.upload_data
+            transfer_function = project.upload
 
     return transfer_function, central_path
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -670,10 +670,10 @@ def check_working_top_level_folder_only_exists(
 ):
     """
     Check that the folder tree made in the 'folder_name'
-    (e.g. 'rawdata') top level folder is correctly. Additionally,
+    (e.g. 'rawdata') top level folder is correct. Additionally,
     check that no other top-level folders exist. This is to ensure
     that folders made / transferred from one top-level folder
-    do not inadvertently transfer other top-level folders
+    do not inadvertently transfer other top-level folders.
     """
     check_folder_tree_is_correct(
         project,

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -189,23 +189,35 @@ class TestCommandLineInterface:
 
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
     @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_upload_download_variables(self, upload_or_download, sep):
+    @pytest.mark.parametrize("shortcut_flags", [True, False])
+    def test_upload_download_variables(
+        self, upload_or_download, sep, shortcut_flags
+    ):
         """
         As upload and download take identical args,
         test both together.
         """
+        if shortcut_flags:
+            sub_flag = f"--sub{sep}names"
+            ses_flag = f"--ses{sep}names"
+            data_type_flag = f"--data{sep}type"
+        else:
+            sub_flag = "-sub"
+            ses_flag = "-ses"
+            data_type_flag = "-dt"
+
         stdout, _ = test_utils.run_cli(
-            f" {upload_or_download}{sep}data "
-            f"--data{sep}type all "
-            f"--sub{sep}names one "
-            f"--ses{sep}names two"
+            f" {upload_or_download} "
+            f"{sub_flag} one "
+            f"{ses_flag} two "
+            f"{data_type_flag} all"
         )
 
         args_, kwargs_ = self.decode(stdout)
         self.check_upload_download_args(args_, kwargs_, dry_run_is=False)
 
         stdout, _ = test_utils.run_cli(
-            f" {upload_or_download}_data "
+            f" {upload_or_download} "
             f"--data{sep}type all "
             f"--sub{sep}names one "
             f"--ses{sep}names two "
@@ -228,7 +240,8 @@ class TestCommandLineInterface:
         but without wasting time with seps.
         """
         stdout, stderr = test_utils.run_cli(
-            f"{upload_or_download}{sep}all", setup_project.project_name
+            f"{upload_or_download}{sep}working{sep}folder",
+            setup_project.project_name,
         )
 
         assert stderr == ""
@@ -255,7 +268,7 @@ class TestCommandLineInterface:
         As upload_folder_or_file and download_folder_or_file
         take identical args, test both together"""
         stdout, stderr = test_utils.run_cli(
-            f" {upload_or_download}{sep}project{sep}folder{sep}or{sep}file /fake/filepath"
+            f" {upload_or_download}{sep}specific{sep}folder{sep}or{sep}file /fake/filepath"
         )
         args_, kwargs_ = self.decode(stdout)
 
@@ -263,7 +276,7 @@ class TestCommandLineInterface:
         assert kwargs_["dry_run"] is False
 
         stdout, stderr = test_utils.run_cli(
-            f" {upload_or_download}{sep}project{sep}folder{sep}or{sep}file "
+            f" {upload_or_download}{sep}specific{sep}folder{sep}or{sep}file "
             f"/fake/filepath --dry{sep}run"
         )
 
@@ -444,12 +457,12 @@ class TestCommandLineInterface:
 
         if transfer_method == "all_alias":
             test_utils.run_cli(
-                f"{upload_or_download}-all",
+                f"{upload_or_download}-working-folder",
                 setup_project.project_name,
             )
         elif transfer_method == "standard":
             test_utils.run_cli(
-                f"{upload_or_download}_data "
+                f"{upload_or_download} "
                 f"--data_type all "
                 f"--sub_names all "
                 f"--ses_names all",
@@ -457,7 +470,7 @@ class TestCommandLineInterface:
             )
         elif transfer_method == "entire_project":
             test_utils.run_cli(
-                f"{upload_or_download}_entire_project",
+                f"{upload_or_download}-entire-project",
                 setup_project.project_name,
             )
 
@@ -494,7 +507,7 @@ class TestCommandLineInterface:
         )
 
         test_utils.run_cli(
-            f"{upload_or_download}_project_folder_or_file {subs[1]}/{sessions[0]}/ephys/*",
+            f"{upload_or_download}_specific_folder_or_file {subs[1]}/{sessions[0]}/ephys/*",
             setup_project.project_name,
         )
 

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -550,7 +550,7 @@ class TestCommandLineInterface:
     def test_set_top_level_folder(self, setup_project, sep):
         """
         Test that the top level folder is "rawdata" by default,
-        setting the top level folder to a new folder ("code")
+        setting the top level folder to a new folder ("derivatives")
         updates the top level folder correctly. Finally, test
         passing a not-allowed top-level-folder to
         set-top-level-folder raises an error.
@@ -562,17 +562,17 @@ class TestCommandLineInterface:
         assert "rawdata" in stdout
 
         stdout, _ = test_utils.run_cli(
-            f"set{sep}top{sep}level{sep}folder code",
+            f"set{sep}top{sep}level{sep}folder derivatives",
             setup_project.project_name,
         )
 
-        assert "code" in stdout
+        assert "derivatives" in stdout
 
         stdout, _ = test_utils.run_cli(
             f"show{sep}top{sep}level{sep}folder", setup_project.project_name
         )
 
-        assert "code" in stdout
+        assert "derivatives" in stdout
 
         _, stderr = test_utils.run_cli(
             f"set{sep}top{sep}level{sep}folder NOT_RECOGNISED",

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -189,9 +189,9 @@ class TestCommandLineInterface:
 
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
     @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_upload_download_data_variables(self, upload_or_download, sep):
+    def test_upload_download_variables(self, upload_or_download, sep):
         """
-        As upload_data and download_data take identical args,
+        As upload and download take identical args,
         test both together.
         """
         stdout, _ = test_utils.run_cli(
@@ -218,13 +218,13 @@ class TestCommandLineInterface:
 
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
     @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_upload_download_all_variables(
+    def test_upload_download_working_folder_variables(
         self, setup_project, upload_or_download, sep
     ):
         """
         To quickly check whether this runs with both seps by only
         checking if no error is raised. This is also tested
-        more thoroughly in test_upload_and_download_data()
+        more thoroughly in test_upload_and_download()
         but without wasting time with seps.
         """
         stdout, stderr = test_utils.run_cli(
@@ -239,7 +239,7 @@ class TestCommandLineInterface:
         self, setup_project, upload_or_download, sep
     ):
         """
-        see test_upload_download_all_variables()
+        see test_upload_download_working_folder_variables()
         """
         stdout, stderr = test_utils.run_cli(
             f"{upload_or_download}{sep}entire{sep}project",
@@ -252,7 +252,7 @@ class TestCommandLineInterface:
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_upload_download_folder_or_file(self, upload_or_download, sep):
         """
-        As upload_data_folder_or_file and download_data_folder_or_file
+        As upload_folder_or_file and download_folder_or_file
         take identical args, test both together"""
         stdout, stderr = test_utils.run_cli(
             f" {upload_or_download}{sep}project{sep}folder{sep}or{sep}file /fake/filepath"
@@ -273,7 +273,7 @@ class TestCommandLineInterface:
         assert kwargs_["dry_run"] is True
 
     @pytest.mark.parametrize(
-        "command", ["make_sub_folders", "upload_data", "download_data"]
+        "command", ["make_sub_folders", "upload", "download"]
     )
     def test_multiple_inputs(self, command):
         """
@@ -418,7 +418,7 @@ class TestCommandLineInterface:
     @pytest.mark.parametrize(
         "transfer_method", ["standard", "all_alias", "entire_project"]
     )
-    def test_upload_and_download_data(
+    def test_upload_and_download(
         self, setup_project, upload_or_download, transfer_method
     ):
         """
@@ -427,7 +427,7 @@ class TestCommandLineInterface:
         "_" vs. "-" command separators are not tested here to avoid
         adding another enumeration, as these tests are slow.
         Testing that the command runs with both separators is done above,
-        in test_upload_download_all_variables() and test_upload_download_data_variables()
+        in test_upload_download_working_folder_variables() and test_upload_download_variables()
         """
         subs, sessions = test_utils.get_default_sub_sessions_to_test()
 

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -487,7 +487,7 @@ class TestFileTransfer:
         self, project, transfer_file, full_path, upload_or_download
     ):
         """
-        Test upload_project_folder_or_file() and download_project_folder_or_file().
+        Test upload_specific_folder_or_file() and download_specific_folder_or_file().
 
         This test has a few different parameterisations. It tests
         1) transfer_file : this transfers a file or folder. if transferring
@@ -510,11 +510,11 @@ class TestFileTransfer:
         ) = self.setup_specific_file_or_folder_files(project)
 
         if upload_or_download == "upload":
-            transfer_function = project.upload_project_folder_or_file
+            transfer_function = project.upload_specific_folder_or_file
             transfer_from = "local_path"
             transfer_to = "central_path"
         else:
-            transfer_function = project.download_project_folder_or_file
+            transfer_function = project.download_specific_folder_or_file
             transfer_from = "central_path"
             transfer_to = "local_path"
             test_utils.swap_local_and_central_paths(project)

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -84,8 +84,8 @@ class TestFileTransfer:
         """
         For each possible top level folder (e.g. rawdata, derivatives)
         (parametrized) create a folder tree in every top-level folder,
-        then transfer using upload_data / download_data and
-        upload_all / download_all that only the working top-level folder
+        then transfer using upload / download and
+        upload_working_folder / download_working_folder that only the working top-level folder
         is transferred.
         """
         project.set_top_level_folder(folder_name)
@@ -390,7 +390,7 @@ class TestFileTransfer:
         project.update_config("show_transfer_progress", show_transfer_progress)
 
         test_utils.clear_capsys(capsys)
-        project.upload_all(dry_run=dry_run)
+        project.upload_working_folder(dry_run=dry_run)
 
         log = capsys.readouterr().out
 
@@ -422,7 +422,7 @@ class TestFileTransfer:
         project.update_config("transfer_verbosity", transfer_verbosity)
 
         test_utils.clear_capsys(capsys)
-        project.upload_all()
+        project.upload_working_folder()
 
         log = capsys.readouterr().out
 
@@ -462,7 +462,7 @@ class TestFileTransfer:
         if overwrite_old_files:
             project.update_config("overwrite_old_files", True)
 
-        project.upload_all()
+        project.upload_working_folder()
 
         # Update the file and transfer and transfer again
         test_utils.write_file(
@@ -471,7 +471,7 @@ class TestFileTransfer:
 
         assert time_written < os.path.getatime(local_test_file_path)
 
-        project.upload_all()
+        project.upload_working_folder()
 
         central_contents = test_utils.read_file(central_test_file_path)
 

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -296,9 +296,9 @@ class TestCommandLineInterface:
         self.delete_log_files(setup_project.cfg.logging_path)
 
         if upload_or_download == "upload":
-            setup_project.upload_project_folder_or_file("sub-001/ses-001")
+            setup_project.upload_specific_folder_or_file("sub-001/ses-001")
         else:
-            setup_project.download_project_folder_or_file("sub-001/ses-001")
+            setup_project.download_specific_folder_or_file("sub-001/ses-001")
 
         log = self.read_log_file(setup_project.cfg.logging_path)
 

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -244,12 +244,15 @@ class TestCommandLineInterface:
 
         log = self.read_log_file(setup_project.cfg.logging_path)
 
-        suffix = "_all" if use_all_alias else "_data"
+        suffix = "_working_folder" if use_all_alias else ""
 
-        assert (
-            f"Starting logging for command {upload_or_download}{suffix}" in log
-        )
-
+        try:
+            assert (
+                f"Starting logging for command {upload_or_download}{suffix}"
+                in log
+            )
+        except:
+            breakpoint()
         if use_all_alias:
             assert (
                 "VariablesState:\nlocals: {'dry_run': False}\ncfg: {'local_path':"
@@ -303,7 +306,7 @@ class TestCommandLineInterface:
         log = self.read_log_file(setup_project.cfg.logging_path)
 
         assert (
-            f"Starting logging for command {upload_or_download}_project_folder_or_file"
+            f"Starting logging for command {upload_or_download}_specific_folder_or_file"
             in log
         )
         assert (

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -208,7 +208,7 @@ class TestCommandLineInterface:
 
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
     @pytest.mark.parametrize("use_all_alias", [True, False])
-    def test_logs_upload_and_download_data(
+    def test_logs_upload_and_download(
         self, setup_project, upload_or_download, use_all_alias
     ):
         """

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -433,7 +433,7 @@ class TestMakeFolders:
         assert old_num == 3
 
         # Upload to central, now local and central folders match
-        project.upload_all()
+        project.upload_working_folder()
         new_num, old_num = project.get_next_sub_number()
         assert new_num == 4
         assert old_num == 3
@@ -468,7 +468,7 @@ class TestMakeFolders:
         assert new_num == 4
         assert old_num == 3
 
-        project.upload_all()
+        project.upload_working_folder()
         new_num, old_num = project.get_next_ses_number(sub)
         assert new_num == 4
         assert old_num == 3


### PR DESCRIPTION
Further to #115, it will be nice to have the purpose of each transfer function (e.g. `upload_all`) very clear, which is not trivial. Currently (using examples involving `upload` only), `upload_data`, `upload_all` `upload_project_file_or_folder` are relative to the top-level working directory. `upload_entire_project` just uploads everything in `rawdata` and `derivatives`.

This PR is an attempt to make the naming scheme a little clearer. `upload_data` was shorted to `upload`. (This is nicer for API, but will make future searches a pain).

 `upload_all` was changed to `upload_working_folder`, as `all` is ambigious now that it is also possible to upload all top level folders. 

`upload_project_file_or_folder` was renamed to `upload_specific_file_or_folder`.

I'm not 100% sure on this and am happy to scrap this PR in case the namings are still not clear. What do you think @neuroinformatics-unit/neuroinformatics-team?

