### PR TITLE
[Validation] Validate the length of subject or session values.

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -363,6 +363,15 @@ def show_configs(*args: Any) -> None:
     project.show_configs()
 
 
+# Validate Project  ----------------------------------------------------------
+
+
+def validate_project(*args: Any) -> None:
+    """"""
+    project = args[0]
+    project.validate_project()
+
+
 # Show Logging Path ----------------------------------------------------------
 
 
@@ -953,6 +962,17 @@ def construct_parser():
         type=str,
         help="Required: (str) sub to find latest session for.",
     )
+
+    # Validate Project
+    # -------------------------------------------------------------------------
+
+    validate_project_parser = subparsers.add_parser(
+        "validate-project",
+        aliases=["validate_project"],
+        description=process_docstring(DataShuttle.validate_project.__doc__),
+        help="",
+    )
+    validate_project_parser.set_defaults(func=validate_project)
 
     # Check Name Processing
     # -------------------------------------------------------------------------

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -947,10 +947,14 @@ class DataShuttle:
 
     @check_configs_set
     def validate_project(self):
-        """Placeholder"""
+        """
+        Perform validation on the project. Currently checks that
+        sub and ses values have the same length for all sub and
+        ses in the project.
+        """
         utils.print_message_to_user("Validating project...")
 
-        self._warn_on_inconsistent_sub_or_ses_value_lengths()
+        formatting.warn_on_inconsistent_sub_or_ses_value_lengths(self.cfg)
 
     @check_configs_set
     def show_next_ses_number(self, sub: Optional[str]) -> None:
@@ -1266,10 +1270,3 @@ class DataShuttle:
         with open(self._persistent_settings_path, "r") as settings_file:
             settings = yaml.full_load(settings_file)
         return settings
-
-    def _warn_on_inconsistent_sub_or_ses_value_lengths(self) -> None:
-        """
-        Wrapper function to allow isolated testing of functions that make up
-        self.validate_project()
-        """
-        formatting.warn_on_inconsistent_sub_or_ses_value_lengths(self.cfg)

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -950,7 +950,7 @@ class DataShuttle:
         """Placeholder"""
         utils.print_message_to_user("Validating project...")
 
-        formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)
+        self._warn_on_inconsistent_sub_or_ses_leading_zeros()
 
     @check_configs_set
     def show_next_ses_number(self, sub: Optional[str]) -> None:
@@ -1268,3 +1268,10 @@ class DataShuttle:
         with open(self._persistent_settings_path, "r") as settings_file:
             settings = yaml.full_load(settings_file)
         return settings
+
+    def _warn_on_inconsistent_sub_or_ses_leading_zeros(self) -> None:
+        """
+        Wrapper function to allow isolated testing of functions that make up
+        self.validate_project()
+        """
+        formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -946,6 +946,13 @@ class DataShuttle:
         )
 
     @check_configs_set
+    def validate_project(self):
+        """Placeholder"""
+        utils.print_message_to_user("Validating project...")
+
+        formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)
+
+    @check_configs_set
     def show_next_ses_number(self, sub: Optional[str]) -> None:
         """
         Show a suggested value for the next session number of a

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -352,7 +352,7 @@ class DataShuttle:
         if init_log:
             self._start_log("upload", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._show_pre_transfer_messages()
 
         TransferData(
             self.cfg,
@@ -388,7 +388,7 @@ class DataShuttle:
         if init_log:
             self._start_log("download", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._show_pre_transfer_messages()
 
         TransferData(
             self.cfg,
@@ -475,7 +475,7 @@ class DataShuttle:
         """
         self._start_log("upload-specific-folder-or-file", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._show_pre_transfer_messages()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local"),
@@ -528,7 +528,7 @@ class DataShuttle:
             "download-specific-folder-or-file", local_vars=locals()
         )
 
-        self.show_top_level_folder()
+        self._show_pre_transfer_messages()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central"),
@@ -547,8 +547,10 @@ class DataShuttle:
 
         ds_logger.close_log_filehandler()
 
-    def _show_pre_transfer_messages(self):
+    def _show_pre_transfer_messages(self, include_top_level_folder=True):
         formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)
+        if include_top_level_folder:
+            self.show_top_level_folder()
 
     # -------------------------------------------------------------------------
     # SSH
@@ -1041,6 +1043,8 @@ class DataShuttle:
         direction : direction to transfer the data, either "upload" (from
                     local to central) or "download" (from central to local).
         """
+        self._show_pre_transfer_messages(include_top_level_folder=False)
+
         transfer_all_func = (
             self.upload_all if direction == "upload" else self.download_all
         )

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -99,9 +99,6 @@ class DataShuttle:
 
         if self.cfg:
             self._set_attributes_after_config_load()
-            formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(
-                self.cfg,
-            )
 
         if print_startup_message:
             if self.cfg:
@@ -352,7 +349,7 @@ class DataShuttle:
         if init_log:
             self._start_log("upload", local_vars=locals())
 
-        self._show_pre_transfer_messages()
+        self.show_top_level_folder()
 
         TransferData(
             self.cfg,
@@ -388,7 +385,7 @@ class DataShuttle:
         if init_log:
             self._start_log("download", local_vars=locals())
 
-        self._show_pre_transfer_messages()
+        self.show_top_level_folder()
 
         TransferData(
             self.cfg,
@@ -475,7 +472,7 @@ class DataShuttle:
         """
         self._start_log("upload-specific-folder-or-file", local_vars=locals())
 
-        self._show_pre_transfer_messages()
+        self.show_top_level_folder()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local"),
@@ -528,7 +525,7 @@ class DataShuttle:
             "download-specific-folder-or-file", local_vars=locals()
         )
 
-        self._show_pre_transfer_messages()
+        self.show_top_level_folder()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central"),
@@ -546,11 +543,6 @@ class DataShuttle:
         utils.log(output.stderr.decode("utf-8"))
 
         ds_logger.close_log_filehandler()
-
-    def _show_pre_transfer_messages(self, include_top_level_folder=True):
-        formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)
-        if include_top_level_folder:
-            self.show_top_level_folder()
 
     # -------------------------------------------------------------------------
     # SSH
@@ -1043,7 +1035,7 @@ class DataShuttle:
         direction : direction to transfer the data, either "upload" (from
                     local to central) or "download" (from central to local).
         """
-        self._show_pre_transfer_messages(include_top_level_folder=False)
+        self.show_top_level_folder(include_top_level_folder=False)
 
         transfer_all_func = (
             self.upload_all if direction == "upload" else self.download_all

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -99,6 +99,9 @@ class DataShuttle:
 
         if self.cfg:
             self._set_attributes_after_config_load()
+            formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(
+                self.cfg,
+            )
 
         if print_startup_message:
             if self.cfg:
@@ -543,6 +546,9 @@ class DataShuttle:
         utils.log(output.stderr.decode("utf-8"))
 
         ds_logger.close_log_filehandler()
+
+    def _show_pre_transfer_messages(self):
+        formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)
 
     # -------------------------------------------------------------------------
     # SSH

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -950,7 +950,7 @@ class DataShuttle:
         """Placeholder"""
         utils.print_message_to_user("Validating project...")
 
-        self._warn_on_inconsistent_sub_or_ses_leading_zeros()
+        self._warn_on_inconsistent_sub_or_ses_value_lengths()
 
     @check_configs_set
     def show_next_ses_number(self, sub: Optional[str]) -> None:
@@ -1267,9 +1267,9 @@ class DataShuttle:
             settings = yaml.full_load(settings_file)
         return settings
 
-    def _warn_on_inconsistent_sub_or_ses_leading_zeros(self) -> None:
+    def _warn_on_inconsistent_sub_or_ses_value_lengths(self) -> None:
         """
         Wrapper function to allow isolated testing of functions that make up
         self.validate_project()
         """
-        formatting.warn_on_inconsistent_sub_or_ses_leading_zeros(self.cfg)
+        formatting.warn_on_inconsistent_sub_or_ses_value_lengths(self.cfg)

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -1042,8 +1042,6 @@ class DataShuttle:
         direction : direction to transfer the data, either "upload" (from
                     local to central) or "download" (from central to local).
         """
-        self.show_top_level_folder(include_top_level_folder=False)
-
         transfer_all_func = (
             self.upload_all if direction == "upload" else self.download_all
         )

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from datashuttle import DataShuttle
@@ -378,7 +378,7 @@ def search_for_wildcards(
 
 def get_all_sub_and_ses_names(
     cfg: Configs,
-) -> Tuple[List[str], List[str]]:
+) -> Dict:
     """
     Get a list of every subject and session name in the
     local and central project folders. Local and central names are combined
@@ -405,7 +405,7 @@ def get_all_sub_and_ses_names(
             local_ses_foldernames + central_ses_foldernames
         )
 
-    return all_sub_foldernames, all_ses_foldernames
+    return {"sub": all_sub_foldernames, "ses": all_ses_foldernames}
 
 
 # Search Data Types

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -452,22 +452,17 @@ def search_for_folders(  # TODO: change name
     verbose: bool = True,
 ) -> Tuple[List[Any], List[Any]]:
     """
-        Wrapper to determine the method used to search for search
-        prefix folders in the search path.
+    Wrapper to determine the method used to search for search
+    prefix folders in the search path.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
 
-        local_or_central : "local" or "central"
-        search_path : full filepath to search in
-        search_prefix : file / folder name to search (e.g. "sub-*")
-    <<<<<<< HEAD
-        verbose : If `True`, when a search folder cannot be found, a message
-              will be printed with the missing path.
-    =======
-        verbose : If `True`, if a search folder cannot be found, a message
-    >>>>>>> 15e7660 (Add verbose option to searching folders functions.)
-                  will be printed with the un-found path.
+    local_or_central : "local" or "central"
+    search_path : full filepath to search in
+    search_prefix : file / folder name to search (e.g. "sub-*")
+    verbose : If `True`, when a search folder cannot be found, a message
+          will be printed with the missing path.
     """
     if local_or_central == "central" and cfg["connection_method"] == "ssh":
         all_folder_names, all_filenames = ssh.search_ssh_central_for_folders(

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -404,6 +404,7 @@ def get_all_local_and_central_sub_and_ses_names(
 
     return all_sub_foldernames, all_ses_foldernames
 
+
 # Search Data Types
 # -----------------------------------------------------------------------------
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -452,22 +452,22 @@ def search_for_folders(  # TODO: change name
     verbose: bool = True,
 ) -> Tuple[List[Any], List[Any]]:
     """
-    Wrapper to determine the method used to search for search
-    prefix folders in the search path.
+        Wrapper to determine the method used to search for search
+        prefix folders in the search path.
 
-    Parameters
-    ----------
+        Parameters
+        ----------
 
-    local_or_central : "local" or "central"
-    search_path : full filepath to search in
-    search_prefix : file / folder name to search (e.g. "sub-*")
-<<<<<<< HEAD
-    verbose : If `True`, when a search folder cannot be found, a message
-          will be printed with the missing path.
-=======
-    verbose : If `True`, if a search folder cannot be found, a message
->>>>>>> 15e7660 (Add verbose option to searching folders functions.)
-              will be printed with the un-found path.
+        local_or_central : "local" or "central"
+        search_path : full filepath to search in
+        search_prefix : file / folder name to search (e.g. "sub-*")
+    <<<<<<< HEAD
+        verbose : If `True`, when a search folder cannot be found, a message
+              will be printed with the missing path.
+    =======
+        verbose : If `True`, if a search folder cannot be found, a message
+    >>>>>>> 15e7660 (Add verbose option to searching folders functions.)
+                  will be printed with the un-found path.
     """
     if local_or_central == "central" and cfg["connection_method"] == "ssh":
         all_folder_names, all_filenames = ssh.search_ssh_central_for_folders(

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -254,7 +254,7 @@ def search_sub_or_ses_level(
         folder level.
 
     verbose : If `True`, if a search folder cannot be found, a message
-          will be printed with the un-found path.
+              will be printed with the un-found path.
     """
     if ses and not sub:
         utils.log_and_raise_error(
@@ -388,6 +388,7 @@ def get_all_local_and_central_sub_and_ses_names(
         local_sub_foldernames,
         central_sub_foldernames,
     ) = get_local_and_central_sub_or_ses_names(cfg, None, "sub-*")
+
     all_sub_foldernames = local_sub_foldernames + central_sub_foldernames
 
     all_ses_foldernames = []
@@ -396,6 +397,7 @@ def get_all_local_and_central_sub_and_ses_names(
             local_ses_foldernames,
             central_ses_foldernames,
         ) = get_local_and_central_sub_or_ses_names(cfg, sub, "ses-*")
+
         all_ses_foldernames.extend(
             local_ses_foldernames + central_ses_foldernames
         )
@@ -497,10 +499,12 @@ def search_filesystem_path_for_folders(
     all_folder_names = []
     all_filenames = []
     for file_or_folder in glob.glob(search_path_with_prefix.as_posix()):
+
         if os.path.isdir(file_or_folder):
             all_folder_names.append(os.path.basename(file_or_folder))
         else:
             all_filenames.append(os.path.basename(file_or_folder))
+
     return all_folder_names, all_filenames
 
 
@@ -512,6 +516,11 @@ def get_local_and_central_sub_or_ses_names(
     The search string "sub-*" is suggested in this case. Otherwise, the subject,
     level folder for the specified subject will be searched. The search_str
     "ses-*" is suggested in this case.
+
+    Note `verbose` argument of `search_sub_or_ses_level()` is set to `False`,
+    as session folders for local subjects that are not yet on central
+    will be searched for on central, showing a confusing 'folder not found'
+    message.
     """
 
     # Search local and central for folders that begin with "sub-*"
@@ -521,6 +530,7 @@ def get_local_and_central_sub_or_ses_names(
         "local",
         sub=sub,
         search_str=search_str,
+        verbose=False,
     )
     central_foldernames, _ = search_sub_or_ses_level(
         cfg,
@@ -528,6 +538,7 @@ def get_local_and_central_sub_or_ses_names(
         "central",
         sub,
         search_str=search_str,
+        verbose=False,
     )
     return local_foldernames, central_foldernames
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -376,13 +376,16 @@ def search_for_wildcards(
     return new_all_names
 
 
-def get_all_local_and_central_sub_and_ses_names(
+def get_all_sub_and_ses_names(
     cfg: Configs,
 ) -> Tuple[List[str], List[str]]:
     """
-    Get a list of every subject and session name in the project, both in the
+    Get a list of every subject and session name in the
     local and central project folders. Local and central names are combined
     into a single list, separately for subject and sessions.
+
+    Note this only finds local sub and ses names on this
+    machine. Other local machines are not searched.
     """
     (
         local_sub_foldernames,

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -499,7 +499,6 @@ def search_filesystem_path_for_folders(
     all_folder_names = []
     all_filenames = []
     for file_or_folder in glob.glob(search_path_with_prefix.as_posix()):
-
         if os.path.isdir(file_or_folder):
             all_folder_names.append(os.path.basename(file_or_folder))
         else:

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -253,8 +253,7 @@ def search_sub_or_ses_level(
     str : glob-format search string to search at the
         folder level.
 
-    verbose : If `True`, when a search folder cannot be found, a message
-          will be printed with the missing path.
+    verbose : If `True`, if a search folder cannot be found, a message
           will be printed with the un-found path.
     """
     if ses and not sub:
@@ -433,8 +432,12 @@ def search_for_folders(  # TODO: change name
     local_or_central : "local" or "central"
     search_path : full filepath to search in
     search_prefix : file / folder name to search (e.g. "sub-*")
+<<<<<<< HEAD
     verbose : If `True`, when a search folder cannot be found, a message
           will be printed with the missing path.
+=======
+    verbose : If `True`, if a search folder cannot be found, a message
+>>>>>>> 15e7660 (Add verbose option to searching folders functions.)
               will be printed with the un-found path.
     """
     if local_or_central == "central" and cfg["connection_method"] == "ssh":

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -387,25 +387,25 @@ def get_all_sub_and_ses_names(
     Note this only finds local sub and ses names on this
     machine. Other local machines are not searched.
     """
-    (
-        local_sub_foldernames,
-        central_sub_foldernames,
-    ) = get_local_and_central_sub_or_ses_names(cfg, None, "sub-*")
+    sub_folder_names = get_local_and_central_sub_or_ses_names(
+        cfg, None, "sub-*"
+    )
 
-    all_sub_foldernames = local_sub_foldernames + central_sub_foldernames
+    all_sub_folder_names = (
+        sub_folder_names["local"] + sub_folder_names["central"]
+    )
 
-    all_ses_foldernames = []
-    for sub in all_sub_foldernames:
-        (
-            local_ses_foldernames,
-            central_ses_foldernames,
-        ) = get_local_and_central_sub_or_ses_names(cfg, sub, "ses-*")
-
-        all_ses_foldernames.extend(
-            local_ses_foldernames + central_ses_foldernames
+    all_ses_folder_names = []
+    for sub in all_sub_folder_names:
+        ses_folder_names = get_local_and_central_sub_or_ses_names(
+            cfg, sub, "ses-*"
         )
 
-    return {"sub": all_sub_foldernames, "ses": all_ses_foldernames}
+        all_ses_folder_names.extend(
+            ses_folder_names["local"] + ses_folder_names["central"]
+        )
+
+    return {"sub": all_sub_folder_names, "ses": all_ses_folder_names}
 
 
 # Search Data Types
@@ -508,7 +508,7 @@ def search_filesystem_path_for_folders(
 
 def get_local_and_central_sub_or_ses_names(
     cfg: Configs, sub: Optional[str], search_str: str
-) -> Tuple[List[str], List[str]]:
+) -> Dict:
     """
     If sub is None, the top-level level folder will be searched (i.e. for subjects).
     The search string "sub-*" is suggested in this case. Otherwise, the subject,
@@ -538,7 +538,7 @@ def get_local_and_central_sub_or_ses_names(
         search_str=search_str,
         verbose=False,
     )
-    return local_foldernames, central_foldernames
+    return {"local": local_foldernames, "central": central_foldernames}
 
 
 def get_next_sub_or_ses_number(
@@ -573,17 +573,14 @@ def get_next_sub_or_ses_number(
     else:
         bids_key = "sub"
 
-    (
-        local_foldernames,
-        central_foldernames,
-    ) = get_local_and_central_sub_or_ses_names(
+    folder_names = get_local_and_central_sub_or_ses_names(
         cfg,
         sub,
         search_str,
     )
 
     # Convert subject values to a list of increasing-by-1 integers
-    all_folders = list(set(local_foldernames + central_foldernames))
+    all_folders = list(set(folder_names["local"] + folder_names["central"]))
 
     if len(all_folders) == 0:
         utils.raise_error("No folders found. Cannot suggest the next number.")

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -346,7 +346,7 @@ def check_dashes_and_underscore_alternate_correctly(all_names):
             )
 
 
-# Leading Zero Checks
+# Sub or ses value length checks
 # --------------------------------------------------------------------------------------
 
 
@@ -413,7 +413,7 @@ def project_has_inconsistent_sub_or_ses_value_lengths(
     (
         all_sub_foldernames,
         all_ses_foldernames,
-    ) = folders.get_all_local_and_central_sub_and_ses_names(cfg)
+    ) = folders.get_all_sub_and_ses_names(cfg)
 
     subs_are_inconsistent = inconsistent_sub_or_ses_value_lengths(
         all_sub_foldernames, "sub"

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -438,18 +438,18 @@ def inconsistent_num_leading_zeros(
     if all_num_lens != [] and not identical_elements(all_num_lens):
         most_common_len = statistics.mode(all_num_lens)
 
-        larger_than_most_common_has_leading_zeros = [
+        larger_than_most_common_with_leading_zeros = [
             num
             for num in all_numbers
-            if (int(num) > most_common_len and num_leading_zeros(num) != 0)
-        ]
-        less_than_most_common = [
-            num for num in all_numbers if int(num) < most_common_len
+            if (len(num) > most_common_len and num_leading_zeros(num) != 0)
         ]
 
-        if (
-            any(less_than_most_common)
-            or larger_than_most_common_has_leading_zeros
+        less_than_most_common = [
+            num for num in all_numbers if len(num) < most_common_len
+        ]
+
+        if any(less_than_most_common) or any(
+            larger_than_most_common_with_leading_zeros
         ):
             return True
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -410,16 +410,13 @@ def project_has_inconsistent_sub_or_ses_value_lengths(
     an equivalent value length (e.g.
     `sub-001`, `ses-01` is okay. But `sub-001`, `sub-02` is not.
     """
-    (
-        all_sub_foldernames,
-        all_ses_foldernames,
-    ) = folders.get_all_sub_and_ses_names(cfg)
+    folder_names = folders.get_all_sub_and_ses_names(cfg)
 
     subs_are_inconsistent = inconsistent_sub_or_ses_value_lengths(
-        all_sub_foldernames, "sub"
+        folder_names["sub"], "sub"
     )
     ses_are_inconsistent = inconsistent_sub_or_ses_value_lengths(
-        all_ses_foldernames, "ses"
+        folder_names["ses"], "ses"
     )
     return subs_are_inconsistent, ses_are_inconsistent
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -362,7 +362,7 @@ def warn_on_inconsistent_sub_or_ses_value_lengths(
     If the number of sub or ses value lengths are not consistent (across local
     and remote repositories), then throw a warning. It is allowed for subjects
     and session folder names to have inconsistent leading zeros. But, within
-    subject or session names, the value lengths t be consistent
+    subject or session names, the value lengths must be consistent
     across local and central projects.
     """
     try:

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -359,7 +359,7 @@ def warn_on_inconsistent_sub_or_ses_value_lengths(
     For example, there are inconsistent leading zeros in the list
     ["sub-001", "sub-02"], but not ["sub-001", "sub-002"]).
 
-    If the number of sub or ses value lengths not consistent (across local
+    If the number of sub or ses value lengths are not consistent (across local
     and remote repositories), then throw a warning. It is allowed for subjects
     and session folder names to have inconsistent leading zeros. But, within
     subject or session names, the value lengths t be consistent

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -373,7 +373,7 @@ def warn_on_inconsistent_sub_or_ses_leading_zeros(
         ) = project_has_inconsistent_num_leading_zeros(cfg)
     except:
         warnings.warn(
-            "Could not search local and remote respoistories. "
+            "Could not search local and remote repositories. "
             "Leading zero consistency checks not performed."
         )
         return

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -2,7 +2,7 @@ import datetime
 import re
 import warnings
 from itertools import compress
-from typing import Any, List, Literal, Tuple, Union
+from typing import Any, Dict, List, Literal, Union
 
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.configs.config_class import Configs
@@ -366,10 +366,9 @@ def warn_on_inconsistent_sub_or_ses_value_lengths(
     across local and central projects.
     """
     try:
-        (
-            subs_are_inconsistent,
-            ses_are_inconsistent,
-        ) = project_has_inconsistent_sub_or_ses_value_lengths(cfg)
+        is_inconsistent = project_has_inconsistent_sub_or_ses_value_lengths(
+            cfg
+        )
     except:
         warnings.warn(
             "Could not search local and remote repositories. "
@@ -378,7 +377,9 @@ def warn_on_inconsistent_sub_or_ses_value_lengths(
         return
 
     failing_cases = list(
-        compress(["sub", "ses"], [subs_are_inconsistent, ses_are_inconsistent])
+        compress(
+            ["sub", "ses"], [is_inconsistent["sub"], is_inconsistent["ses"]]
+        )
     )
 
     if any(failing_cases):
@@ -401,7 +402,7 @@ def warn_on_inconsistent_sub_or_ses_value_lengths(
 
 def project_has_inconsistent_sub_or_ses_value_lengths(
     cfg: Configs,
-) -> Tuple[bool, bool]:
+) -> Dict:
     """
     Return bool indicating where the project (i.e. across
     both `local` and `central`) has consistent value lengths
@@ -418,7 +419,7 @@ def project_has_inconsistent_sub_or_ses_value_lengths(
     ses_are_inconsistent = inconsistent_sub_or_ses_value_lengths(
         folder_names["ses"], "ses"
     )
-    return subs_are_inconsistent, ses_are_inconsistent
+    return {"sub": subs_are_inconsistent, "ses": ses_are_inconsistent}
 
 
 def inconsistent_sub_or_ses_value_lengths(

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -383,7 +383,6 @@ def warn_on_inconsistent_sub_or_ses_leading_zeros(
     )
 
     for fail_name in failing_cases:
-
         message = (
             f"Inconsistent number of leading zeros for "
             f"{fail_name} names in the project found. It is crucial "

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -366,10 +366,17 @@ def warn_on_inconsistent_sub_or_ses_leading_zeros(
     subject or session names, the number of leading zeros must be consistent
     across local and central projects.
     """
-    (
-        subs_are_inconsistent,
-        ses_are_inconsistent,
-    ) = project_has_inconsistent_num_leading_zeros(cfg)
+    try:
+        (
+            subs_are_inconsistent,
+            ses_are_inconsistent,
+        ) = project_has_inconsistent_num_leading_zeros(cfg)
+    except:
+        warnings.warn(
+            "Could not search local and remote respoistories. "
+            "Leading zero consistency checks not performed."
+        )
+        return
 
     failing_cases = list(
         compress(["sub", "ses"], [subs_are_inconsistent, ses_are_inconsistent])

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -1,6 +1,5 @@
 import datetime
 import re
-import statistics
 import warnings
 from itertools import compress
 from typing import Any, List, Literal, Tuple, Union
@@ -351,30 +350,30 @@ def check_dashes_and_underscore_alternate_correctly(all_names):
 # --------------------------------------------------------------------------------------
 
 
-def warn_on_inconsistent_sub_or_ses_leading_zeros(
+def warn_on_inconsistent_sub_or_ses_value_lengths(
     cfg: Configs,
 ):
     """
-    Determine if there are inconsistent leading zeros across the
+    Determine if there are inconsistent value lengths across the
     project (i.e. this local machine and the central machine.
     For example, there are inconsistent leading zeros in the list
-    ["sub-001", "sub-02"], but not ["sub-001", "sub-002"].
+    ["sub-001", "sub-02"], but not ["sub-001", "sub-002"]).
 
-    If the number of leading zeros are not consistent (across local and remote
-    repositories), then throw a warning. It is allowed for subjects
+    If the number of sub or ses value lengths not consistent (across local
+    and remote repositories), then throw a warning. It is allowed for subjects
     and session folder names to have inconsistent leading zeros. But, within
-    subject or session names, the number of leading zeros must be consistent
+    subject or session names, the value lengths t be consistent
     across local and central projects.
     """
     try:
         (
             subs_are_inconsistent,
             ses_are_inconsistent,
-        ) = project_has_inconsistent_num_leading_zeros(cfg)
+        ) = project_has_inconsistent_sub_or_ses_value_lengths(cfg)
     except:
         warnings.warn(
             "Could not search local and remote repositories. "
-            "Leading zero consistency checks not performed."
+            "sub or ses key value length checks not performed."
         )
         return
 
@@ -382,26 +381,33 @@ def warn_on_inconsistent_sub_or_ses_leading_zeros(
         compress(["sub", "ses"], [subs_are_inconsistent, ses_are_inconsistent])
     )
 
-    for fail_name in failing_cases:
-        message = (
-            f"Inconsistent number of leading zeros for "
-            f"{fail_name} names in the project found. It is crucial "
-            f"these are made consistent as soon as possible to "
-            f"avoid unexpected behaviour of DataShuttle during "
-            f"data transfer."
+    if any(failing_cases):
+        for fail_name in failing_cases:
+            message = (
+                f"Inconsistent value lengths for "
+                f"the {fail_name} key in the project found. It is crucial "
+                f"these are made consistent as soon as possible to "
+                f"avoid unexpected behaviour of DataShuttle during "
+                f"data transfer."
+            )
+            warnings.warn(message)
+
+    else:
+        utils.print_message_to_user(
+            "No cases of inconsistent value lengths for subject or session"
+            "found across this local machine and the central machine."
         )
-        warnings.warn(message)
 
 
-def project_has_inconsistent_num_leading_zeros(
+def project_has_inconsistent_sub_or_ses_value_lengths(
     cfg: Configs,
 ) -> Tuple[bool, bool]:
     """
     Return bool indicating where the project (i.e. across
-    both `local` and `central`) has consistent leading
-    number of zeros for subjects and separately, sessions.
+    both `local` and `central`) has consistent value lengths
+    for sub and ses keys.
     It is not required that subjects and sessions have
-    an equivalent number of leading zeros (e.g.
+    an equivalent value length (e.g.
     `sub-001`, `ses-01` is okay. But `sub-001`, `sub-02` is not.
     """
     (
@@ -409,31 +415,21 @@ def project_has_inconsistent_num_leading_zeros(
         all_ses_foldernames,
     ) = folders.get_all_local_and_central_sub_and_ses_names(cfg)
 
-    subs_are_inconsistent = inconsistent_num_leading_zeros(
+    subs_are_inconsistent = inconsistent_sub_or_ses_value_lengths(
         all_sub_foldernames, "sub"
     )
-    ses_are_inconsistent = inconsistent_num_leading_zeros(
+    ses_are_inconsistent = inconsistent_sub_or_ses_value_lengths(
         all_ses_foldernames, "ses"
     )
     return subs_are_inconsistent, ses_are_inconsistent
 
 
-def inconsistent_num_leading_zeros(
+def inconsistent_sub_or_ses_value_lengths(
     all_names: List[str], sub_or_ses: Literal["sub", "ses"]
 ) -> bool:
     """
-    Given a list of BIDS-formatted subject or session names, determine if
-    there are inconsistent leading zeros within the list of names.
-
-    For example, there are inconsistent leading zeros in the list
-    ["sub-001", "sub-02"], but not ["sub-001", "sub-002"].
-
-    First, check that all numbers are the same length (e.g. `010` and `100`
-    is okay). If not, if a number is larger than the most common length
-    (e.g. `1000`), check it has no leading zeros (e.g. if sub names are
-    `001`, `010`, `100`, then `1000` is allowed by `0101` is not allowed).
-    If a value length is smaller than the most common length, it is invalid
-    (because it should be padded with zero).
+    Given a list of NeuroBlueprint-formatted subject or session names, determine if
+    there are inconsistent value lengths for the sub or ses key.
     """
     all_numbers = utils.get_values_from_bids_formatted_name(
         all_names,
@@ -441,23 +437,9 @@ def inconsistent_num_leading_zeros(
     )
 
     all_num_lens = [len(num) for num in all_numbers]
+
     if all_num_lens != [] and not identical_elements(all_num_lens):
-        most_common_len = statistics.mode(all_num_lens)
-
-        larger_than_most_common_with_leading_zeros = [
-            num
-            for num in all_numbers
-            if (len(num) > most_common_len and num_leading_zeros(num) != 0)
-        ]
-
-        less_than_most_common = [
-            num for num in all_numbers if len(num) < most_common_len
-        ]
-
-        if any(less_than_most_common) or any(
-            larger_than_most_common_with_leading_zeros
-        ):
-            return True
+        return True
 
     return False
 

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -83,6 +83,7 @@ def connect_client(
     client: paramiko.SSHClient,
     cfg: Configs,
     password: Optional[str] = None,
+    message_on_sucessful_connection: bool = True,
 ) -> None:
     """
     Connect client to central server using paramiko.
@@ -101,9 +102,10 @@ def connect_client(
             else None,
             look_for_keys=True,
         )
-        utils.print_message_to_user(
-            f"Connection to { cfg['central_host_id']} made successfully."
-        )
+        if message_on_sucessful_connection:
+            utils.print_message_to_user(
+                f"Connection to { cfg['central_host_id']} made successfully."
+            )
 
     except Exception:
         utils.log_and_raise_error(
@@ -209,7 +211,7 @@ def search_ssh_central_for_folders(
     """
     client: paramiko.SSHClient
     with paramiko.SSHClient() as client:
-        connect_client(client, cfg)
+        connect_client(client, cfg, message_on_sucessful_connection=verbose)
 
         sftp = client.open_sftp()
 

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -214,7 +214,10 @@ def search_ssh_central_for_folders(
         sftp = client.open_sftp()
 
         all_folder_names, all_filenames = get_list_of_folder_names_over_sftp(
-            sftp, search_path, search_prefix, verbose
+            sftp,
+            search_path,
+            search_prefix,
+            verbose,
         )
 
     return all_folder_names, all_filenames

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,6 +234,7 @@ def get_all_folders_used():
 
 def get_config_path_with_cli(project_name=None):
     stdout = run_cli(" show_config_path", project_name)
+    breakpoint()
     path_ = stdout[0].split(".yaml")[0] + ".yaml"
     return path_
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,7 +234,6 @@ def get_all_folders_used():
 
 def get_config_path_with_cli(project_name=None):
     stdout = run_cli(" show_config_path", project_name)
-    breakpoint()
     path_ = stdout[0].split(".yaml")[0] + ".yaml"
     return path_
 

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -360,7 +360,6 @@ class TestCommandLineInterface(BaseTest):
         )
 
         config_path = test_utils.get_config_path_with_cli(clean_project_name)
-
         test_utils.check_config_file(config_path, changed_configs)
 
     def test_make_folders(self, project):

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -94,7 +94,6 @@ class TestFormatting(BaseTest):
     def test_warn_on_inconsistent_leading_zeros_subjects(
         self, project, bad_sub_name
     ):
-
         project.make_sub_folders(
             ["sub-001", "sub-010", "sub-100_date-20221314", "sub-1000"],
             ["ses-001_id-1231"],
@@ -134,7 +133,6 @@ class TestFormatting(BaseTest):
     def run_warn_on_consistentent_leading_zeros_sub_or_ses(
         self, project, sub_name, ses_name
     ):
-
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             project._show_pre_transfer_messages()
@@ -149,7 +147,6 @@ class TestFormatting(BaseTest):
         self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
 
     def check_inconsistent_sub_or_ses_level_warning(self, project, sub_or_ses):
-
         with pytest.warns(UserWarning) as w:
             project._show_pre_transfer_messages()
 

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -1,3 +1,7 @@
+import os.path
+import shutil
+import warnings
+
 import pytest
 from base import BaseTest
 
@@ -81,4 +85,78 @@ class TestFormatting(BaseTest):
             str(w[0].message)
             == "A subject number has been skipped, currently "
             "used subject numbers are: [5, 10]"
+        )
+
+    @pytest.mark.parametrize(
+        "bad_sub_name",
+        ["sub-03_date-123", "sub-0003_id-123", "sub-0999", "sub-0034"],
+    )
+    def test_warn_on_inconsistent_leading_zeros_subjects(
+        self, project, bad_sub_name
+    ):
+
+        project.make_sub_folders(
+            ["sub-001", "sub-010", "sub-100_date-20221314", "sub-1000"],
+            ["ses-001_id-1231"],
+        )
+
+        self.run_warn_on_consistentent_leading_zeros_sub_or_ses(
+            project,
+            bad_sub_name,
+            "ses-002",  # an innocuous ses-name, placeholder.
+        )
+
+    @pytest.mark.parametrize(
+        "bad_ses_name",
+        ["ses-03_date-123", "ses-0003_id-123", "ses-0999", "ses-0034"],
+    )
+    def test_warn_on_inconsistent_leading_zeros_sessions(
+        self, project, bad_ses_name
+    ):
+        # TODO: check with breakpints this is doing exactly what is expected!!!
+        # TODO: should probably check these are raised at the actual
+        # transfer / start up function not in this lower-level function.
+        project.make_sub_folders(
+            ["sub-001", "sub-002"],
+            [
+                "ses-001_id-1231",
+                "ses-020_date-123123" "ses-200",
+                "ses-2000_id-12312",
+            ],
+        )
+
+        self.run_warn_on_consistentent_leading_zeros_sub_or_ses(
+            project,
+            "sub-002",
+            bad_ses_name,  # an innocuous sub-name, placeholder.
+        )
+
+    def run_warn_on_consistentent_leading_zeros_sub_or_ses(
+        self, project, sub_name, ses_name
+    ):
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            project._show_pre_transfer_messages()
+
+        project.make_sub_folders(sub_name, ses_name)
+
+        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+
+        project.upload_all()
+        shutil.rmtree(project.cfg.get_base_folder("local") / sub_name)
+
+        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+
+    def check_inconsistent_sub_or_ses_level_warning(self, project, sub_or_ses):
+
+        with pytest.warns(UserWarning) as w:
+            project._show_pre_transfer_messages()
+
+        assert (
+            str(w[0].message) == f"Inconsistent number of leading zeros for "
+            f"{sub_or_ses} names in the project found. It is "
+            f"crucial these are made consistent as "
+            f"soon as possible to avoid unexpected "
+            f"behaviour of DataShuttle during data transfer."
         )

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -87,7 +87,7 @@ class TestFormatting(BaseTest):
         )
 
     # ----------------------------------------------------------------------------------
-    # Inconsistent leading zeros
+    # Inconsistent sub or ses value lengths
     # ----------------------------------------------------------------------------------
 
     @pytest.mark.parametrize(
@@ -95,13 +95,22 @@ class TestFormatting(BaseTest):
         ["sub-001", "sub-001_@DATE@", "sub-001_random-tag_another-tag"],
     )
     @pytest.mark.parametrize(
-        "bad_sub_name", ["sub-3", "sub-01", "sub-0001", "sub-07_@DATE@"]
+        "bad_sub_name",
+        [
+            "sub-3",
+            "sub-01",
+            "sub-0001",
+            "sub-07_@DATE@",
+            "sub-1321",
+            "sub-22",
+            "sub-234234453_@DATETIME@",
+        ],
     )
-    def test_warn_on_inconsistent_leading_zeros_sub(
+    def test_warn_on_inconsistent_sub_value_lengths(
         self, project, sub_name, bad_sub_name
     ):
         """
-        This test checks that inconsistent number of leading zeros are properly
+        This test checks that inconsistent sub value lengths are properly
         detected across the project. This is performed with an assortment
         of possible filenames and leading zero conflicts.
 
@@ -116,7 +125,7 @@ class TestFormatting(BaseTest):
         # First make conflicting leading zero subject names in the local repo
         os.makedirs(project.cfg["local_path"] / "rawdata" / sub_name)
         os.makedirs(project.cfg["local_path"] / "rawdata" / bad_sub_name)
-        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
 
         # Now, have conflicting subject names, but one in local and one in central
         project.update_config(
@@ -127,21 +136,29 @@ class TestFormatting(BaseTest):
         )
         os.makedirs(project.cfg["central_path"] / "rawdata" / bad_sub_name)
         shutil.rmtree(project.cfg["local_path"] / "rawdata" / bad_sub_name)
-        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
 
         # Have conflicting subject names both in central.
         shutil.rmtree(project.cfg["local_path"] / "rawdata" / sub_name)
         os.makedirs(project.cfg["central_path"] / "rawdata" / sub_name)
-        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
 
     @pytest.mark.parametrize(
         "ses_name",
-        ["ses-001", "ses-001_@DATE@", "ses-001_random-tag_another-tag"],
+        ["ses-01", "ses-01_@DATE@", "ses-01_random-tag_another-tag"],
     )
     @pytest.mark.parametrize(
-        "bad_ses_name", ["ses-3", "ses-01", "ses-0001", "ses-07_@DATE@"]
+        "bad_ses_name",
+        [
+            "ses-3",
+            "ses-001",
+            "ses-0001",
+            "ses-007_@DATE@",
+            "ses-1453_@DATETIME@",
+            "ses-234234234",
+        ],
     )
-    def test_warn_on_inconsistent_leading_zeros_ses(
+    def test_warn_on_inconsistent_ses_value_lengths(
         self, project, ses_name, bad_ses_name
     ):
         """
@@ -158,7 +175,7 @@ class TestFormatting(BaseTest):
         os.makedirs(
             project.cfg["local_path"] / "rawdata" / "sub-002" / bad_ses_name
         )
-        self.check_inconsistent_sub_or_ses_level_warning(project, "ses")
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "ses")
 
         # Now, have conflicting session names (in different subject directories)
         # where one subject directory is local and the other is central.
@@ -172,16 +189,16 @@ class TestFormatting(BaseTest):
             project.cfg["central_path"] / "rawdata" / "sub-001" / bad_ses_name
         )
         shutil.rmtree(project.cfg["local_path"] / "rawdata" / "sub-002")
-        self.check_inconsistent_sub_or_ses_level_warning(project, "ses")
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "ses")
 
         # Test the case where conflicting session names are both on central.
         shutil.rmtree(project.cfg["local_path"] / "rawdata" / "sub-001")
         os.makedirs(
             project.cfg["central_path"] / "rawdata" / "sub-001" / ses_name
         )
-        self.check_inconsistent_sub_or_ses_level_warning(project, "ses")
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "ses")
 
-    def test_warn_on_inconsistent_leading_zeros_sub_and_ses(self, project):
+    def test_warn_on_inconsistent_sub_and_ses_value_lengths(self, project):
         """
         Test that warning is shown for both subject and session when
         inconsistent zeros are found in both.
@@ -192,22 +209,23 @@ class TestFormatting(BaseTest):
         os.makedirs(
             project.cfg["local_path"] / "rawdata" / "sub-03" / "ses-002"
         )
-        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
-        self.check_inconsistent_sub_or_ses_level_warning(
+        self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
+        self.check_inconsistent_sub_or_ses_value_length_warning(
             project, "ses", warn_idx=1
         )
 
-    def check_inconsistent_sub_or_ses_level_warning(
+    def check_inconsistent_sub_or_ses_value_length_warning(
         self, project, sub_or_ses, warn_idx=0
     ):
         """"""
         with pytest.warns(UserWarning) as w:
-            project._warn_on_inconsistent_sub_or_ses_leading_zeros()
+            formatting.warn_on_inconsistent_sub_or_ses_value_lengths(
+                project.cfg
+            )
 
         assert (
-            str(w[warn_idx].message)
-            == f"Inconsistent number of leading zeros for "
-            f"{sub_or_ses} names in the project found. It is "
+            str(w[warn_idx].message) == f"Inconsistent value lengths for the "
+            f"{sub_or_ses} key in the project found. It is "
             f"crucial these are made consistent as "
             f"soon as possible to avoid unexpected "
             f"behaviour of DataShuttle during data transfer."

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -162,7 +162,7 @@ class TestFormatting(BaseTest):
         self, project, ses_name, bad_ses_name
     ):
         """
-        This function is exactly the same as `test_warn_on_inconsistent_leading_zeros_sub()`
+        This function is exactly the same as `test_warn_on_inconsistent_sub_value_lengths()`
         but operates at the session level. This is extreme code duplication, but
         factoring the main logic out got very messy and hard to follow.
         So, in this case code duplicate is the price to pay.

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -1,6 +1,5 @@
 import os.path
 import shutil
-import warnings
 
 import pytest
 from base import BaseTest
@@ -87,71 +86,127 @@ class TestFormatting(BaseTest):
             "used subject numbers are: [5, 10]"
         )
 
-    @pytest.mark.parametrize(
-        "bad_sub_name",
-        ["sub-03_date-123", "sub-0003_id-123", "sub-0999", "sub-0034"],
-    )
-    def test_warn_on_inconsistent_leading_zeros_subjects(
-        self, project, bad_sub_name
-    ):
-        project.make_sub_folders(
-            ["sub-001", "sub-010", "sub-100_date-20221314", "sub-1000"],
-            ["ses-001_id-1231"],
-        )
-
-        self.run_warn_on_consistentent_leading_zeros_sub_or_ses(
-            project,
-            bad_sub_name,
-            "ses-002",  # an innocuous ses-name, placeholder.
-        )
+    # ----------------------------------------------------------------------------------
+    # Inconsistent leading zeros
+    # ----------------------------------------------------------------------------------
 
     @pytest.mark.parametrize(
-        "bad_ses_name",
-        ["ses-03_date-123", "ses-0003_id-123", "ses-0999", "ses-0034"],
+        "sub_name",
+        ["sub-001", "sub-001_@DATE@", "sub-001_random-tag_another-tag"],
     )
-    def test_warn_on_inconsistent_leading_zeros_sessions(
-        self, project, bad_ses_name
+    @pytest.mark.parametrize(
+        "bad_sub_name", ["sub-3", "sub-01", "sub-0001", "sub-07_@DATE@"]
+    )
+    def test_warn_on_inconsistent_leading_zeros_sub(
+        self, project, sub_name, bad_sub_name
     ):
-        # TODO: check with breakpints this is doing exactly what is expected!!!
-        # TODO: should probably check these are raised at the actual
-        # transfer / start up function not in this lower-level function.
-        project.make_sub_folders(
-            ["sub-001", "sub-002"],
-            [
-                "ses-001_id-1231",
-                "ses-020_date-123123" "ses-200",
-                "ses-2000_id-12312",
-            ],
-        )
+        """
+        This test checks that inconsistent number of leading zeros are properly
+        detected across the project. This is performed with an assortment
+        of possible filenames and leading zero conflicts.
 
-        self.run_warn_on_consistentent_leading_zeros_sub_or_ses(
-            project,
-            "sub-002",
-            bad_ses_name,  # an innocuous sub-name, placeholder.
-        )
+        These conflicts are detected across the project (i.e. if you have sub-03
+        in remote and sub-004 in local, a warning should be shown). Therefore
+        this function tests every combination of conflict across local and central).
 
-    def run_warn_on_consistentent_leading_zeros_sub_or_ses(
-        self, project, sub_name, ses_name
-    ):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            project._show_pre_transfer_messages()
-
-        project.make_sub_folders(sub_name, ses_name)
-
+        Note SSH version is not tested, but the core functionality detecting
+        inconsistent leading zeros is agnostic to SSH, and SSH file searching
+        is tested elsewhere.
+        """
+        # First make conflicting leading zero subject names in the local repo
+        os.makedirs(project.cfg["local_path"] / "rawdata" / sub_name)
+        os.makedirs(project.cfg["local_path"] / "rawdata" / bad_sub_name)
         self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
 
-        project.upload_all()
-        shutil.rmtree(project.cfg.get_base_folder("local") / sub_name)
-
+        # Now, have conflicting subject names, but one in local and one in central
+        project.update_config(
+            "central_path",
+            project.cfg["local_path"].parent
+            / "central"
+            / project.project_name,
+        )
+        os.makedirs(project.cfg["central_path"] / "rawdata" / bad_sub_name)
+        shutil.rmtree(project.cfg["local_path"] / "rawdata" / bad_sub_name)
         self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
 
-    def check_inconsistent_sub_or_ses_level_warning(self, project, sub_or_ses):
+        # Have conflicting subject names both in central.
+        shutil.rmtree(project.cfg["local_path"] / "rawdata" / sub_name)
+        os.makedirs(project.cfg["central_path"] / "rawdata" / sub_name)
+        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+
+    @pytest.mark.parametrize(
+        "ses_name",
+        ["ses-001", "ses-001_@DATE@", "ses-001_random-tag_another-tag"],
+    )
+    @pytest.mark.parametrize(
+        "bad_ses_name", ["ses-3", "ses-01", "ses-0001", "ses-07_@DATE@"]
+    )
+    def test_warn_on_inconsistent_leading_zeros_ses(
+        self, project, ses_name, bad_ses_name
+    ):
+        """
+        This function is exactly the same as `test_warn_on_inconsistent_leading_zeros_sub()`
+        but operates at the session level. This is extreme code duplication, but
+        factoring the main logic out got very messy and hard to follow.
+        So, in this case code duplicate is the price to pay.
+        """
+        # Have conflicting session names (in different subject directories)
+        # on the local filesystem
+        os.makedirs(
+            project.cfg["local_path"] / "rawdata" / "sub-001" / ses_name
+        )
+        os.makedirs(
+            project.cfg["local_path"] / "rawdata" / "sub-002" / bad_ses_name
+        )
+        self.check_inconsistent_sub_or_ses_level_warning(project, "ses")
+
+        # Now, have conflicting session names (in different subject directories)
+        # where one subject directory is local and the other is central.
+        project.update_config(
+            "central_path",
+            project.cfg["local_path"].parent
+            / "central"
+            / project.project_name,
+        )
+        os.makedirs(
+            project.cfg["central_path"] / "rawdata" / "sub-001" / bad_ses_name
+        )
+        shutil.rmtree(project.cfg["local_path"] / "rawdata" / "sub-002")
+        self.check_inconsistent_sub_or_ses_level_warning(project, "ses")
+
+        # Test the case where conflicting session names are both on central.
+        shutil.rmtree(project.cfg["local_path"] / "rawdata" / "sub-001")
+        os.makedirs(
+            project.cfg["central_path"] / "rawdata" / "sub-001" / ses_name
+        )
+        self.check_inconsistent_sub_or_ses_level_warning(project, "ses")
+
+    def test_warn_on_inconsistent_leading_zeros_sub_and_ses(self, project):
+        """
+        Test that warning is shown for both subject and session when
+        inconsistent zeros are found in both.
+        """
+        os.makedirs(
+            project.cfg["local_path"] / "rawdata" / "sub-001" / "ses-01"
+        )
+        os.makedirs(
+            project.cfg["local_path"] / "rawdata" / "sub-03" / "ses-002"
+        )
+        self.check_inconsistent_sub_or_ses_level_warning(project, "sub")
+        self.check_inconsistent_sub_or_ses_level_warning(
+            project, "ses", warn_idx=1
+        )
+
+    def check_inconsistent_sub_or_ses_level_warning(
+        self, project, sub_or_ses, warn_idx=0
+    ):
+        """"""
         with pytest.warns(UserWarning) as w:
-            project._show_pre_transfer_messages()
+            project._warn_on_inconsistent_sub_or_ses_leading_zeros()
 
         assert (
-            str(w[0].message) == f"Inconsistent number of leading zeros for "
+            str(w[warn_idx].message)
+            == f"Inconsistent number of leading zeros for "
             f"{sub_or_ses} names in the project found. It is "
             f"crucial these are made consistent as "
             f"soon as possible to avoid unexpected "

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -192,9 +192,9 @@ class TestUnit:
     def test_num_leading_zeros(self):
         """
         Check num_leading_zeros handles prefixed and non-prefixed
-        case from -1 to -(100x 0)1.
+        case from -1 to -(101x 0)1.
         """
-        for i in range(100):
+        for i in range(101):
             assert formatting.num_leading_zeros("1".zfill(i + 1)) == i
             assert formatting.num_leading_zeros("sub-" + "1".zfill(i + 1)) == i
             assert formatting.num_leading_zeros("ses-" + "1".zfill(i + 1)) == i

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -189,6 +189,16 @@ class TestUnit:
         id = utils.get_value_from_key_regexp(bids_name, "id")[0]
         assert id == "3asd@523"
 
+    def test_num_leading_zeros(self):
+        """
+        Check num_leading_zeros handles prefixed and non-prefixed
+        case from -1 to -(100x 0)1.
+        """
+        for i in range(100):
+            assert formatting.num_leading_zeros("1".zfill(i + 1)) == i
+            assert formatting.num_leading_zeros("sub-" + "1".zfill(i + 1)) == i
+            assert formatting.num_leading_zeros("ses-" + "1".zfill(i + 1)) == i
+
     # ----------------------------------------------------------------------
     # Utlis
     # ----------------------------------------------------------------------


### PR DESCRIPTION
This PR checks that the length of `sub` and `ses` values are consistent in the project. Initially, this was focused on checking the number of leading zeros, but this was not correct. The most recent version checks simply the length of the `sub-` or `ses-` key value, which is all we really care about. 

Currently this is tested within a new `validate_project` function. Ideally, this would be tested whenever a new folder is created, so these things are caught initially. However, this will require some integration with other PRs and so is left for completion with #249.

The PR also centralises the logic to grab all subject and session names from across the project (i.e. from this local machine and the central server).

In total it:
- introduces the `validate_project()` function for API and CLI. Currently this function just validates the number of leading zeros, but will do more in future (#249)
- Introduces `get_all_sub_and_ses_names()` and `get_local_and_central_sub_or_ses_names()` functions to get the subject and session names from local machine + the central machine. These functions will form the basis for most future validation routines.
- Adds three functions in `formatting.py` to check the sub and session value lengths across the project. 
- Adds tests for this functionality.
