### PR TITLE
Add print statement showing processed sub and ses names before data transfer.

### DIFF
--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -344,6 +344,10 @@ class TransferData:
                 sub=sub,
             )
 
+        utils.log_and_message(
+            f"The {sub_or_ses} names to transfer are: {processed_names}"
+        )
+
         return processed_names
 
     def transfer_non_data_type(self, data_type_checked: List[str]) -> bool:


### PR DESCRIPTION
There can be potentially unxpected behaviour of formatting tags when transferring data with the @TO@ tag.

For example, if the subjects sub-01 and ses-002 exist in the project, seahing with datashuttle project_name -sub 01@TO@002 -ses ... will search for sub-001 and sub-002 due to the auto-formatting feature. The solution is to not support non-consistent number of leading zeros, but this is not trivial as found in https://github.com/neuroinformatics-unit/datashuttle/pull/140. As some protection, here print the results of the auto-formatting of sub and ses names so it is clearer what is being transferred. Will also follow this up in a future PR that adds a warning when inconsistent names are found in the project.