### PR TITLE
Split make_sub_folders and formatting tests into two modules.

### DIFF
--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -1,0 +1,118 @@
+import os.path
+
+import pytest
+import test_utils
+
+from datashuttle.utils import formatting
+
+
+class TestMakeFolders:
+    """"""
+
+    @pytest.fixture(scope="function")
+    def project(test, tmp_path):
+        """
+        Create a project with default configs loaded.
+        This makes a fresh project for each function,
+        saved in the appdir path for platform independent
+        and to avoid path setup on new machine.
+
+        Ensure change folder at end of session otherwise
+        it is not possible to delete project.
+        """
+        tmp_path = tmp_path / "test with space"
+
+        test_project_name = "test_make_folders"
+
+        project = test_utils.setup_project_default_configs(
+            test_project_name,
+            tmp_path,
+            local_path=tmp_path / test_project_name,
+        )
+
+        cwd = os.getcwd()
+        yield project
+        test_utils.teardown_project(cwd, project)
+
+    # ----------------------------------------------------------------------------------
+    # Tests
+    # ----------------------------------------------------------------------------------
+
+    @pytest.mark.parametrize("prefix", ["sub", "ses"])
+    @pytest.mark.parametrize(
+        "input", [1, {"test": "one"}, 1.0, ["1", "2", ["three"]]]
+    )
+    def test_format_names_bad_input(self, input, prefix):
+        """
+        Test that names passed in incorrect type
+        (not str, list) raise appropriate error.
+        """
+        with pytest.raises(BaseException) as e:
+            formatting.format_names(input, prefix)
+
+        assert (
+            "Ensure subject and session names are "
+            "list of strings, or string" == str(e.value)
+        )
+
+    @pytest.mark.parametrize("prefix", ["sub", "ses"])
+    def test_format_names_duplicate_ele(self, prefix):
+        """
+        Test that appropriate error is raised when duplicate name
+        is passed to format_names().
+        """
+        with pytest.raises(BaseException) as e:
+            formatting.format_names(["1", "2", "3", "3", "4"], prefix)
+
+        assert (
+            "Subject and session names but all be unique "
+            "(i.e. there are no duplicates in list input)." == str(e.value)
+        )
+
+    def test_format_names_prefix(self):
+        """
+        Check that format_names correctly prefixes input
+        with default sub or ses prefix. This is less useful
+        now that ses/sub name dash and underscore order is
+        more strictly checked.
+        """
+        prefix = "sub"
+
+        # check name is prefixed
+        formatted_names = formatting.format_names("1", prefix)
+        assert formatted_names[0] == "sub-1"
+
+        # check existing prefix is not duplicated
+        formatted_names = formatting.format_names("sub-1", prefix)
+        assert formatted_names[0] == "sub-1"
+
+        # test mixed list of prefix and unprefixed are prefixed correctly.
+        mixed_names = ["1", prefix + "-four", "5", prefix + "-6"]
+        formatted_names = formatting.format_names(mixed_names, prefix)
+        assert formatted_names == [
+            "sub-1",
+            "sub-four",
+            "sub-5",
+            "sub-6",
+        ]
+
+    def test_warning_non_consecutive_numbers(self, project):
+
+        project.make_sub_folders(
+            ["sub-01", "sub-2", "sub-04"], ["ses-05", "ses-10"]
+        )
+
+        with pytest.warns(UserWarning) as w:
+            project.get_next_sub_number()
+        assert (
+            str(w[0].message) == "A subject number has been skipped, "
+            "currently used subject numbers are: [1, 2, 4]"
+        )
+
+        with pytest.warns(UserWarning) as w:
+            project.get_next_ses_number("sub-2")
+        assert (
+            str(w[0].message)
+            == "A subject number has been skipped, currently "
+            "used subject numbers are: [5, 10]"
+        )

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -9,7 +9,6 @@ import test_utils
 
 from datashuttle.configs import canonical_folders
 from datashuttle.configs.canonical_tags import tags
-from datashuttle.utils import formatting
 
 
 class TestMakeFolders:
@@ -43,37 +42,6 @@ class TestMakeFolders:
     # ----------------------------------------------------------------------------------
     # Tests
     # ----------------------------------------------------------------------------------
-
-    @pytest.mark.parametrize("prefix", ["sub", "ses"])
-    @pytest.mark.parametrize(
-        "input", [1, {"test": "one"}, 1.0, ["1", "2", ["three"]]]
-    )
-    def test_format_names_bad_input(self, input, prefix):
-        """
-        Test that names passed in incorrect type
-        (not str, list) raise appropriate error.
-        """
-        with pytest.raises(BaseException) as e:
-            formatting.format_names(input, prefix)
-
-        assert (
-            "Ensure subject and session names are "
-            "list of strings, or string" == str(e.value)
-        )
-
-    @pytest.mark.parametrize("prefix", ["sub", "ses"])
-    def test_format_names_duplicate_ele(self, prefix):
-        """
-        Test that appropriate error is raised when duplicate name
-        is passed to format_names().
-        """
-        with pytest.raises(BaseException) as e:
-            formatting.format_names(["1", "2", "3", "3", "4"], prefix)
-
-        assert (
-            "Subject and session names but all be unique "
-            "(i.e. there are no duplicates in list input)." == str(e.value)
-        )
 
     def test_duplicate_ses_or_sub_key_value_pair(self, project):
         """
@@ -143,33 +111,6 @@ class TestMakeFolders:
             " sub-001 (possibly with leading zeros) "
             "already exists in the project"
         )
-
-    def test_format_names_prefix(self):
-        """
-        Check that format_names correctly prefixes input
-        with default sub or ses prefix. This is less useful
-        now that ses/sub name dash and underscore order is
-        more strictly checked.
-        """
-        prefix = "sub"
-
-        # check name is prefixed
-        formatted_names = formatting.format_names("1", prefix)
-        assert formatted_names[0] == "sub-1"
-
-        # check existing prefix is not duplicated
-        formatted_names = formatting.format_names("sub-1", prefix)
-        assert formatted_names[0] == "sub-1"
-
-        # test mixed list of prefix and unprefixed are prefixed correctly.
-        mixed_names = ["1", prefix + "-four", "5", prefix + "-6"]
-        formatted_names = formatting.format_names(mixed_names, prefix)
-        assert formatted_names == [
-            "sub-1",
-            "sub-four",
-            "sub-5",
-            "sub-6",
-        ]
 
     def test_generate_folders_default_ses(self, project):
         """
@@ -487,27 +428,6 @@ class TestMakeFolders:
         new_num, old_num = project.get_next_ses_number(sub)
         assert new_num == 6
         assert old_num == 5
-
-    def test_warning_non_consecutive_numbers(self, project):
-
-        project.make_sub_folders(
-            ["sub-01", "sub-2", "sub-04"], ["ses-05", "ses-10"]
-        )
-
-        with pytest.warns(UserWarning) as w:
-            project.get_next_sub_number()
-        assert (
-            str(w[0].message) == "A subject number has been skipped, "
-            "currently used subject numbers are: [1, 2, 4]"
-        )
-
-        with pytest.warns(UserWarning) as w:
-            project.get_next_ses_number("sub-2")
-        assert (
-            str(w[0].message)
-            == "A subject number has been skipped, currently "
-            "used subject numbers are: [5, 10]"
-        )
 
     # ----------------------------------------------------------------------------------
     # Test Helpers


### PR DESCRIPTION
`test_make_sub_folders.py` was bloated with tests more related to formatting (i.e. `utils/formatting.py`). Have factored these out.