### PR TITLE
Remove customisable DataShuttle sub or ses names attribute.

### DIFF
--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -46,8 +46,6 @@ class Configs(UserDict):
             "local_path",
             "central_path",
         ]
-        self.sub_prefix = "sub"
-        self.ses_prefix = "ses"
 
         self.top_level_folder: str
 
@@ -366,14 +364,3 @@ class Configs(UserDict):
             )
 
         return data_type_items
-
-    def get_sub_or_ses_prefix(self, sub_or_ses: str) -> str:
-        """
-        Get the sub / ses prefix (default is "sub-" and "ses-") set in cfgs.
-        These should always be "sub-" or "ses-" by SWC-BIDS.
-        """
-        if sub_or_ses == "sub":
-            prefix = self.sub_prefix
-        elif sub_or_ses == "ses":
-            prefix = self.ses_prefix
-        return prefix

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -214,14 +214,10 @@ class DataShuttle:
         utils.log("\nFormatting Names...")
         ds_logger.log_names(["sub_names", "ses_names"], [sub_names, ses_names])
 
-        sub_names = formatting.check_and_format_names(
-            self.cfg, sub_names, "sub"
-        )
+        sub_names = formatting.check_and_format_names(sub_names, "sub")
 
         if ses_names is not None:
-            ses_names = formatting.check_and_format_names(
-                self.cfg, ses_names, "ses"
-            )
+            ses_names = formatting.check_and_format_names(ses_names, "ses")
 
         ds_logger.log_names(
             ["formatted_sub_names", "formatted_ses_names"],
@@ -991,7 +987,9 @@ class DataShuttle:
         )
 
     @staticmethod
-    def check_name_formatting(names: Union[str, list], prefix: str) -> None:
+    def check_name_formatting(
+        names: Union[str, list], prefix: Literal["sub", "ses"]
+    ) -> None:
         """
         Pass list of names to check how these will be auto-formatted,
         for example as when passed to make_sub_folders() or upload_data()

--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from datashuttle.configs.config_class import Configs
 
@@ -313,12 +313,11 @@ class TransferData:
         see transfer_sub_ses_data()
 
         """
+        sub_or_ses: Literal["sub", "ses"]
         if sub is None:
             sub_or_ses = "sub"
-            search_prefix = self.cfg.sub_prefix + "-"
         else:
             sub_or_ses = "ses"
-            search_prefix = self.cfg.ses_prefix + "-"
 
         if names_checked in [["all"], [f"all_{sub_or_ses}"]]:
             processed_names = folders.search_sub_or_ses_level(
@@ -326,7 +325,7 @@ class TransferData:
                 self.base_folder,
                 self.local_or_central,
                 sub,
-                search_str=f"{search_prefix}*",
+                search_str=f"{sub_or_ses}-*",
             )[0]
 
             if names_checked == ["all"]:
@@ -334,7 +333,7 @@ class TransferData:
 
         else:
             processed_names = formatting.check_and_format_names(
-                self.cfg, names_checked, sub_or_ses
+                names_checked, sub_or_ses
             )
             processed_names = folders.search_for_wildcards(
                 self.cfg,

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import List, Union
+from typing import List, Literal, Union
 
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.configs.config_class import Configs
@@ -20,9 +20,8 @@ RESERVED_KEYWORDS = [
 
 
 def check_and_format_names(
-    cfg: Configs,
     names: Union[list, str],
-    sub_or_ses: str,
+    sub_or_ses: Literal["sub", "ses"],
 ) -> List[str]:
     """
     Format a list of subject or session names, e.g.
@@ -38,15 +37,13 @@ def check_and_format_names(
 
     sub_or_ses: "sub" or "ses" - this defines the prefix checks.
     """
-    prefix = cfg.get_sub_or_ses_prefix(sub_or_ses)
-    formatted_names = format_names(names, prefix)
+    formatted_names = format_names(names, sub_or_ses)
 
     return formatted_names
 
 
 def format_names(
-    names: Union[List[str], str],
-    prefix: str,
+    names: Union[List[str], str], prefix: Literal["sub", "ses"]
 ) -> List[str]:
     """
     Check a single or list of input session or subject names.
@@ -62,6 +59,8 @@ def format_names(
 
     prefix: "sub" or "ses" - this defines the prefix checks.
     """
+    assert prefix in ["sub", "ses"], "`sub_or_ses` but be 'sub' or 'ses'."
+
     if type(names) not in [str, list] or any(
         [not isinstance(ele, str) for ele in names]
     ):


### PR DESCRIPTION
Remove the ability to set customisable `sub` or `ses` names. Since SWC-Blueprint, these are fixed and will not change. Even if we want to make them customisable later, these fields were not updated regularly and were applied inconsistently through the codebase.