### PR TITLE
Stop transferring empty folders.

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -449,8 +449,7 @@ class DataShuttle:
         required (see 'filepath' input). If a folder,
         wildcards "*" or "**" must be used to transfer
         all files in the folder ("*") or all files
-        and sub-folders ("**"), otherwise the empty folder
-        only will be transferred.
+        and sub-folders ("**").
 
         e.g. "sub-001/ses-002/my_folder/**"
 
@@ -501,8 +500,7 @@ class DataShuttle:
         required (see 'filepath' input). If a folder,
         wildcards "*" or "**" must be used to transfer
         all files in the folder ("*") or all files
-        and sub-folders ("**"), otherwise the empty folder
-        only will be transferred.
+        and sub-folders ("**").
 
         e.g. "sub-001/ses-002/my_folder/**"
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -321,7 +321,6 @@ def search_data_folders_sub_or_ses_level(
         search_results,
         cfg.data_type_folders,
     )
-
     return data_folders
 
 

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -147,7 +147,7 @@ def handle_rclone_arguments(rclone_options, include_list):
     Construct the extra arguments to pass to RClone based on the
     current configs.
     """
-    extra_arguments_list = [rclone_args("create_empty_src_dirs")]
+    extra_arguments_list = []
 
     extra_arguments_list += ["-" + rclone_options["transfer_verbosity"]]
 
@@ -173,9 +173,6 @@ def rclone_args(name: str) -> str:
     """
     if name == "dry_run":
         arg = "--dry-run"
-
-    if name == "create_empty_src_dirs":
-        arg = ""  # --create-empty-src-dirs"
 
     if name == "copy":
         arg = "copy"

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -175,7 +175,7 @@ def rclone_args(name: str) -> str:
         arg = "--dry-run"
 
     if name == "create_empty_src_dirs":
-        arg = "--create-empty-src-dirs"
+        arg = ""  # --create-empty-src-dirs"
 
     if name == "copy":
         arg = "copy"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -427,12 +427,7 @@ def make_and_check_local_project_folders(
     to write a placeholder file in all bottom-level
     directories so ensure they are transferred.
     """
-    project.make_sub_folders(subs, sessions, data_type)
-
-    for root, dirs, files in os.walk(project.cfg["local_path"]):
-        if not dirs:
-            path_ = Path(root) / "placeholder_file.txt"
-            write_file(path_, contents="placeholder")
+    make_local_folders_with_files_in(project, subs, sessions, data_type)
 
     check_folder_tree_is_correct(
         project,
@@ -441,6 +436,16 @@ def make_and_check_local_project_folders(
         sessions,
         get_default_folder_used(),
     )
+
+
+def make_local_folders_with_files_in(
+    project, subs, sessions=None, data_type="all"
+):
+    project.make_sub_folders(subs, sessions, data_type)
+    for root, dirs, files in os.walk(project.cfg["local_path"]):
+        if not dirs:
+            path_ = Path(root) / "placeholder_file.txt"
+            write_file(path_, contents="placeholder")
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -422,8 +422,17 @@ def make_and_check_local_project_folders(
     """
     Make a local project folder tree with the specified data_type,
     subs, sessions and check it is made successfully.
+
+    Since empty folders are not transferred, it is necessary
+    to write a placeholder file in all bottom-level
+    directories so ensure they are transferred.
     """
     project.make_sub_folders(subs, sessions, data_type)
+
+    for root, dirs, files in os.walk(project.cfg["local_path"]):
+        if not dirs:
+            path_ = Path(root) / "placeholder_file.txt"
+            write_file(path_, contents="placeholder")
 
     check_folder_tree_is_correct(
         project,

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -494,7 +494,7 @@ class TestCommandLineInterface:
         )
 
         test_utils.run_cli(
-            f"{upload_or_download}_project_folder_or_file {subs[1]}/{sessions[0]}/ephys/*",
+            f"{upload_or_download}_project_folder_or_file {subs[1]}/{sessions[0]}/ephys/**",
             setup_project.project_name,
         )
 

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -298,7 +298,9 @@ class TestFileTransfer:
         subs = ["001", f"02{tags('to')}03"]
         sessions = [f"ses-01{tags('to')}003_{tags('datetime')}"]
 
-        project.make_sub_folders(subs, sessions, "all")
+        test_utils.make_local_folders_with_files_in(
+            project, subs, sessions, "all"
+        )
 
         (
             transfer_function,
@@ -343,7 +345,9 @@ class TestFileTransfer:
             "003_date-20220601",
         ]
 
-        project.make_sub_folders(subs, sessions, "all")
+        test_utils.make_local_folders_with_files_in(
+            project, subs, sessions, "all"
+        )
 
         (
             transfer_function,
@@ -388,7 +392,9 @@ class TestFileTransfer:
         rclone is called with the arguments set in configs
         as expected. verbosity itself is tested in another method.
         """
-        project.make_sub_folders(["sub-001"], ["ses-002"], ["behav"])
+        test_utils.make_local_folders_with_files_in(
+            project, ["sub-001"], ["ses-002"], ["behav"]
+        )
 
         project.update_config("overwrite_old_files", overwrite_old_files)
         project.update_config("transfer_verbosity", "vv")
@@ -398,8 +404,6 @@ class TestFileTransfer:
         project.upload_all(dry_run=dry_run)
 
         log = capsys.readouterr().out
-
-        assert "--create-empty-src-dirs" in log
 
         if overwrite_old_files:
             assert "--ignore-existing" not in log

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -73,6 +73,11 @@ class TestFileTransfer:
             test_utils.get_default_folder_used(),
         )
 
+    def test_empty_folder_is_not_transferred(self, project):
+        project.make_sub_folders("sub-001")
+        project.upload_all()
+        assert not (project.cfg["central_path"] / "sub-001").is_dir()
+
     @pytest.mark.parametrize(
         "folder_name", canonical_folders.get_top_level_folders()
     )

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -269,7 +269,6 @@ class TestCommandLineInterface:
         assert """ "--include" "sub-11/histology/**" """ in log
         assert """/test_logging/central/rawdata""" in log
         assert "Waiting for checks to finish" in log
-        assert "Transferred:   	          0 B / 0 B, -, 0 B/s, ETA -" in log
 
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
     def test_logs_upload_and_download_folder_or_file(
@@ -307,13 +306,12 @@ class TestCommandLineInterface:
             in log
         )
         assert (
-            "\n\nVariablesState:\nlocals: {'filepath': 'sub-001/ses-001', 'dry_run': False}\ncfg: {'local_path':"
-            in log
+            "\n\nVariablesState:\nlocals: {'filepath': 'sub-001/ses-001', "
+            "'dry_run': False}\ncfg: {'local_path':" in log
         )
         assert """sub-001/ses-001"]""" in log
         assert "Using config file from" in log
         assert "Waiting for checks to finish" in log
-        assert "DEBUG : sub-001: Making directory\n" in log
 
     # ----------------------------------------------------------------------------------------------------------
     # Check errors propagate

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -367,7 +367,10 @@ class TestMakeFolders:
         empty, or when they have different subjects in.
         """
         # Create local folders, central is empty
-        project.make_sub_folders(["001", "002", "003"])
+        test_utils.make_local_folders_with_files_in(
+            project, ["001", "002", "003"]
+        )
+
         new_num, old_num = project.get_next_sub_number()
 
         assert new_num == 4
@@ -403,7 +406,9 @@ class TestMakeFolders:
         above but reduces readability, so leave with some duplication.
         """
         sub = "sub-3"
-        project.make_sub_folders(sub, ["001", "002", "003"])
+        test_utils.make_local_folders_with_files_in(
+            project, sub, ["001", "002", "003"]
+        )
         new_num, old_num = project.get_next_sub_number()
 
         assert new_num == 4


### PR DESCRIPTION
Previoulsy the `RClone` option `create_empty_src_dirs` was used to empty folders were transferred to make things easier during testing. However, this lead to confusing behaviour when only a subset of folders are transferred. As such, use of this option was removed and the tests updated accordingly.