### PR TITLE
Reformat log filename to start with ISO8601 datetime

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -1089,7 +1089,7 @@ class DataShuttle:
 
     def _start_log(
         self,
-        name: str,
+        command_name: str,
         local_vars: Optional[dict] = None,
         store_in_temp_folder: bool = False,
         temp_folder_path: Union[str, Path] = "",
@@ -1103,8 +1103,7 @@ class DataShuttle:
         Parameters
         ----------
 
-        name : name of the log output files. Typically, the
-            name of the function logged e.g. "update_config"
+        command_name : name of the command, for the log output files.
 
         local_vars : local_vars are passed to fancylog variables argument.
                  see ds_logger.wrap_variables_for_fancylog for more info
@@ -1135,7 +1134,7 @@ class DataShuttle:
         else:
             path_to_save = self.cfg.logging_path
 
-        ds_logger.start(path_to_save, name, variables, verbose)
+        ds_logger.start(path_to_save, command_name, variables, verbose)
 
     def _move_logs_from_temp_folder(self):
         """

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -210,7 +210,7 @@ class DataShuttle:
                              ["ses-001", "ses-002"],
                              ["ephys", "behav"])
         """
-        self._start_log("make_sub_folders", local_vars=locals())
+        self._start_log("make-sub-folders", local_vars=locals())
 
         self.show_top_level_folder()
 
@@ -407,7 +407,7 @@ class DataShuttle:
         Alias for:
             project.upload("all", "all", "all")
         """
-        self._start_log("upload_all", local_vars=locals())
+        self._start_log("upload-all", local_vars=locals())
 
         self.upload("all", "all", "all", dry_run=dry_run, init_log=False)
 
@@ -418,7 +418,7 @@ class DataShuttle:
 
         Alias for : project.download("all", "all", "all")
         """
-        self._start_log("download_all", local_vars=locals())
+        self._start_log("download-all", local_vars=locals())
 
         self.download("all", "all", "all", dry_run=dry_run, init_log=False)
         ds_logger.close_log_filehandler()
@@ -471,7 +471,7 @@ class DataShuttle:
             transfer was taking place, but no files will be moved. Useful
             to check which files will be moved on data transfer.
         """
-        self._start_log("upload_specific_folder_or_file", local_vars=locals())
+        self._start_log("upload-specific-folder-or-file", local_vars=locals())
 
         self.show_top_level_folder()
 
@@ -523,7 +523,7 @@ class DataShuttle:
             to check which files will be moved on data transfer.
         """
         self._start_log(
-            "download_specific_folder_or_file", local_vars=locals()
+            "download-specific-folder-or-file", local_vars=locals()
         )
 
         self.show_top_level_folder()
@@ -565,7 +565,7 @@ class DataShuttle:
         will be setup.
         """
         self._start_log(
-            "setup_ssh_connection_to_central_server", local_vars=locals()
+            "setup-ssh-connection-to-central-server", local_vars=locals()
         )
 
         verified = ssh.verify_ssh_central_host(
@@ -694,7 +694,7 @@ class DataShuttle:
             if True, will allow behav folder creation
         """
         self._start_log(
-            "make_config_file",
+            "make-config-file",
             local_vars=locals(),
             store_in_temp_folder=True,
             temp_folder_path="default",
@@ -772,14 +772,14 @@ class DataShuttle:
 
         if store_logs_in_temp_folder:
             self._start_log(
-                "update_config",
+                "update-config",
                 local_vars=locals(),
                 store_in_temp_folder=True,
                 temp_folder_path="default",
             )
         else:
             self._start_log(
-                "update_config",
+                "update-config",
                 local_vars=locals(),
                 store_in_temp_folder=False,
             )
@@ -834,14 +834,14 @@ class DataShuttle:
         store_logs_in_temp_folder = not self._local_path_exists()
         if store_logs_in_temp_folder:
             self._start_log(
-                "supply_config_file",
+                "supply-config-file",
                 local_vars=locals(),
                 store_in_temp_folder=True,
                 temp_folder_path="default",
             )
         else:
             self._start_log(
-                "supply_config_file",
+                "supply-config-file",
                 local_vars=locals(),
                 store_in_temp_folder=False,
             )

--- a/datashuttle/utils/ds_logger.py
+++ b/datashuttle/utils/ds_logger.py
@@ -25,14 +25,14 @@ from . import utils
 
 def start(
     path_to_log: Path,
-    name: str,
+    command_name: str,
     variables: Optional[List[Any]],
     verbose: bool = True,
 ) -> None:
     """
     Call fancylog to initialise logging.
     """
-    filename = get_logging_filename(name)
+    filename = get_logging_filename(command_name)
 
     fancylog.start_logging(
         path_to_log,
@@ -45,16 +45,16 @@ def start(
         write_git=True,
         log_to_console=False,
     )
-    logging.info(f"Starting logging for command {name}")
+    logging.info(f"Starting logging for command {command_name}")
 
 
-def get_logging_filename(name: str) -> str:
+def get_logging_filename(command_name: str) -> str:
     """
     Get the filename to which the log will be saved. This
     starts with ISO8601-formatted datetime, so logs are stored
     in datetime order.
     """
-    filename = datetime.now().strftime(f"%Y%m%dT%H%M%S_{name}")
+    filename = datetime.now().strftime(f"%Y%m%dT%H%M%S_{command_name}")
     return filename
 
 

--- a/datashuttle/utils/ds_logger.py
+++ b/datashuttle/utils/ds_logger.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 import copy
 import logging
+from datetime import datetime
 from pathlib import Path
 
 from fancylog import fancylog
@@ -31,18 +32,30 @@ def start(
     """
     Call fancylog to initialise logging.
     """
+    filename = get_logging_filename(name)
+
     fancylog.start_logging(
         path_to_log,
         package_to_log,
-        filename=name,
+        filename=filename,
         variables=variables,
         verbose=verbose,
-        timestamp=True,
+        timestamp=False,
         file_log_level="DEBUG",
         write_git=True,
         log_to_console=False,
     )
     logging.info(f"Starting logging for command {name}")
+
+
+def get_logging_filename(name: str) -> str:
+    """
+    Get the filename to which the log will be saved. This
+    starts with ISO8601-formatted datetime, so logs are stored
+    in datetime order.
+    """
+    filename = datetime.now().strftime(f"%Y%m%dT%H%M%S_{name}")
+    return filename
 
 
 def print_tree(project_path: Path) -> None:

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -625,7 +625,7 @@ to the `.datashuttle` folder that is created in the *local* project folder.
 For each command run, a log of that command is placed in the logs folder, with the time and date of the command. The log itself contains relevant information pertaining to that command. For example, if the commands `make_sub_folders`, `upload`, `download` were run sequentially, the logs output folder would look like:
 
 ```
-make_sub_folders_2023-06-08_09-55-14.log
-upload_data_2023-06-08_09-55-45.log
-download_data_2023-06-08_09-56-19.log
+20230608T095514_make-sub-folders.log
+20230608T095545_upload-data.log
+20230608T095621_download-data.log
 ```

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import platform
+import re
 from pathlib import Path
 
 import pytest
@@ -80,6 +81,22 @@ class TestCommandLineInterface:
         logs = glob.glob((str(logging_path / "*.log")))
         for log in logs:
             os.remove(log)
+
+    def test_log_filename(self, setup_project):
+        """
+        Check the log filename is formatted correctly, for
+        `update_config`, an arbitrary command
+        """
+        setup_project.update_config("central_host_id", "test_id")
+
+        log_search = list(setup_project.cfg.logging_path.glob("*.log"))
+        assert (
+            len(log_search) == 1
+        ), "should only be 1 log in this test environment."
+        log_filename = log_search[0].name
+
+        regex = re.compile(r"\d{8}T\d{6}_update-config.log")
+        assert re.search(regex, log_filename) is not None
 
     def test_logs_make_config_file(self, clean_project_name, tmp_path):
         """"""

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -91,7 +91,7 @@ class TestCommandLineInterface:
 
         log = self.read_log_file(project.cfg.logging_path)
 
-        assert "Starting logging for command make_config_file" in log
+        assert "Starting logging for command make-config-file" in log
         assert "\nVariablesState:\nlocals: {'local_path':" in log
         assert "Successfully created rclone config." in log
         assert (
@@ -105,7 +105,7 @@ class TestCommandLineInterface:
 
         log = self.read_log_file(setup_project.cfg.logging_path)
 
-        assert "Starting logging for command update_config" in log
+        assert "Starting logging for command update-config" in log
         assert (
             "\n\nVariablesState:\nlocals: {'option_key': 'central_host_id'"
             in log
@@ -126,7 +126,7 @@ class TestCommandLineInterface:
 
         log = self.read_log_file(orig_project_path)
 
-        assert "supply_config_file" in log
+        assert "supply-config-file" in log
         assert "\n\nVariablesState:\nlocals: {'input_path_to_config':" in log
         assert "Update successful. New config file: " in log
         assert (
@@ -241,7 +241,7 @@ class TestCommandLineInterface:
 
         log = self.read_log_file(setup_project.cfg.logging_path)
 
-        suffix = "_all" if use_all_alias else ""
+        suffix = "-all" if use_all_alias else ""
 
         assert (
             f"Starting logging for command {upload_or_download}{suffix}" in log
@@ -299,7 +299,7 @@ class TestCommandLineInterface:
         log = self.read_log_file(setup_project.cfg.logging_path)
 
         assert (
-            f"Starting logging for command {upload_or_download}_specific_folder_or_file"
+            f"Starting logging for command {upload_or_download}-specific-folder-or-file"
             in log
         )
         assert (
@@ -363,7 +363,7 @@ class TestCommandLineInterface:
         tmp_path_logs = glob.glob(str(project._temp_log_path / "*.log"))
 
         assert len(tmp_path_logs) == 1
-        assert "make_config_file" in tmp_path_logs[0]
+        assert "make-config-file" in tmp_path_logs[0]
 
     def test_temp_log_folder_moved_make_config_file(
         self, clean_project_name, tmp_path
@@ -382,7 +382,7 @@ class TestCommandLineInterface:
 
         assert len(tmp_path_logs) == 0
         assert len(project_path_logs) == 1
-        assert "make_config_file" in project_path_logs[0]
+        assert "make-config-file" in project_path_logs[0]
 
     @pytest.mark.skipif("not IS_WINDOWS")
     @pytest.mark.parametrize("supply_or_update", ["update", "supply"])


### PR DESCRIPTION
closes #154. This PR changes the format of the logging filename to be in the format
```<ISO8601datetime>_command-name.log```

This required:
1) Reformatting the filename as passed to fancylog.
2) Reformatting the command-names passed to fancylog to use hypen not underscore.
3) I also renamed a variable called `name` to `command_name` for clarity.
4) Fix tests that required the previous format.
5) Update docs to reflect the new format.
6) Add a test on the log filename format.