### PR TITLE
Add verbose option to searching folders functions.

### DIFF
--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -447,7 +447,8 @@ def search_for_folders(  # TODO: change name
     local_or_central : "local" or "central"
     search_path : full filepath to search in
     search_prefix : file / folder name to search (e.g. "sub-*")
-    verbose : If `True`, if a search folder cannot be found, a message
+    verbose : If `True`, when a search folder cannot be found, a message
+          will be printed with the missing path.
               will be printed with the un-found path.
     """
     if local_or_central == "central" and cfg["connection_method"] == "ssh":

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -240,6 +240,7 @@ def search_sub_or_ses_level(
     sub: Optional[str] = None,
     ses: Optional[str] = None,
     search_str: str = "*",
+    verbose: bool = True,
 ) -> Tuple[List[str], List[str]]:
     """
     Search project folder at the subject or session level.
@@ -259,12 +260,15 @@ def search_sub_or_ses_level(
     sub : either a subject name (string) or None. If None, the search
         is performed at the top_level_folder level
 
-    ses: either a session name (string) or None, This must not
+    ses : either a session name (string) or None, This must not
         be a session name if sub is None. If provided (with sub)
         then the session folder is searched
 
-    str: glob-format search string to search at the
+    str : glob-format search string to search at the
         folder level.
+
+    verbose : If `True`, if a search folder cannot be found, a message
+          will be printed with the un-found path.
     """
     if ses and not sub:
         utils.log_and_raise_error(
@@ -279,7 +283,11 @@ def search_sub_or_ses_level(
         base_folder = base_folder / ses
 
     all_folder_names, all_filenames = search_for_folders(
-        cfg, base_folder, local_or_central, search_str
+        cfg,
+        base_folder,
+        local_or_central,
+        search_str,
+        verbose,
     )
 
     return all_folder_names, all_filenames
@@ -426,6 +434,7 @@ def search_for_folders(  # TODO: change name
     search_path: Path,
     local_or_central: str,
     search_prefix: str,
+    verbose: bool = True,
 ) -> Tuple[List[Any], List[Any]]:
     """
     Wrapper to determine the method used to search for search
@@ -437,16 +446,22 @@ def search_for_folders(  # TODO: change name
     local_or_central : "local" or "central"
     search_path : full filepath to search in
     search_prefix : file / folder name to search (e.g. "sub-*")
+    verbose : If `True`, if a search folder cannot be found, a message
+              will be printed with the un-found path.
     """
     if local_or_central == "central" and cfg["connection_method"] == "ssh":
         all_folder_names, all_filenames = ssh.search_ssh_central_for_folders(
             search_path,
             search_prefix,
             cfg,
+            verbose,
         )
     else:
         if not search_path.exists():
-            utils.log_and_message(f"No file found at {search_path.as_posix()}")
+            if verbose:
+                utils.log_and_message(
+                    f"No file found at {search_path.as_posix()}"
+                )
             return [], []
 
         all_folder_names, all_filenames = search_filesystem_path_for_folders(

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -267,7 +267,8 @@ def search_sub_or_ses_level(
     str : glob-format search string to search at the
         folder level.
 
-    verbose : If `True`, if a search folder cannot be found, a message
+    verbose : If `True`, when a search folder cannot be found, a message
+          will be printed with the missing path.
           will be printed with the un-found path.
     """
     if ses and not sub:

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -177,6 +177,7 @@ def search_ssh_central_for_folders(
     search_path: Path,
     search_prefix: str,
     cfg: Configs,
+    verbose: bool = True,
 ) -> Tuple[List[Any], List[Any]]:
     """
     Search for the search prefix in the search path over SSH.
@@ -190,6 +191,9 @@ def search_ssh_central_for_folders(
     search_prefix : search prefix for folder names e.g. "sub-*"
 
     cfg : see connect_client()
+
+    verbose : If `True`, if a search folder cannot be found, a message
+              will be printed with the un-found path.
     """
     client: paramiko.SSHClient
     with paramiko.SSHClient() as client:
@@ -198,14 +202,17 @@ def search_ssh_central_for_folders(
         sftp = client.open_sftp()
 
         all_folder_names, all_filenames = get_list_of_folder_names_over_sftp(
-            sftp, search_path, search_prefix
+            sftp, search_path, search_prefix, verbose
         )
 
     return all_folder_names, all_filenames
 
 
 def get_list_of_folder_names_over_sftp(
-    sftp, search_path: Path, search_prefix: str
+    sftp,
+    search_path: Path,
+    search_prefix: str,
+    verbose: bool = True,
 ) -> Tuple[List[Any], List[Any]]:
     """
     Use paramiko's sftp to search a path
@@ -221,6 +228,9 @@ def get_list_of_folder_names_over_sftp(
 
     search_prefix : prefix (can include wildcards)
         to search folder names.
+
+    verbose : If `True`, if a search folder cannot be found, a message
+          will be printed with the un-found path.
     """
     all_folder_names = []
     all_filenames = []
@@ -233,6 +243,7 @@ def get_list_of_folder_names_over_sftp(
                     all_filenames.append(file_or_folder.filename)
 
     except FileNotFoundError:
-        utils.log_and_message(f"No file found at {search_path.as_posix()}")
+        if verbose:
+            utils.log_and_message(f"No file found at {search_path.as_posix()}")
 
     return all_folder_names, all_filenames


### PR DESCRIPTION
This PR introduces a `verbose` option to the folders that search for files and folders in the local or remote paths. By default, these will log if no path is found at the passed `search_string`. However in #148 , paths are searched in a blind manner and it is not known a priori if they will exist, so this message is very annoying. 

This PR is a blocker for #148 and should be merged before it.