### PR TITLE
Fix wrong docsting and possibility to init empty path in `_start_log()`.

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -1110,10 +1110,9 @@ class DataShuttle:
                  see ds_logger.wrap_variables_for_fancylog for more info
 
         store_in_temp_folder :
-            if False, existing logging path will be used
-            (local project .datashuttle). If "default"", the temp
-            log backup will be used. Otherwise, expect a path / string
-            to the new path to make the logs at.
+            if `False`, existing logging path will be used
+            (local project .datashuttle). if `True`, path is
+            read from `temp_folder_path`.
 
         temp_folder_path :
             if "default", use the default temp folder path stored at
@@ -1127,6 +1126,9 @@ class DataShuttle:
             )
 
         if store_in_temp_folder:
+            assert (
+                temp_folder_path != ""
+            ), "`temp_folder_path` must be 'default' or a filepath."
             path_to_save = (
                 self._temp_log_path
                 if temp_folder_path == "default"


### PR DESCRIPTION
In the function `start_log`, there is some logic to handle the case that the logging path has moved. This is because the logs are saved to `local_path` for convenience, but the `local_path` may be changed (e.g. `update_config()`.

In this case, it is necssary to log to a temp path before moving the logs to the set `local_path`. The docstring regarding this logic was not clear and it was also possible, if forgetting to change the default argument, to write logs to `Path(.)`. This PR introduces an assert to stop this form happening.