### PR TITLE
Perform check that we are running in TTY terminal before `getpass` is…

### DIFF
--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 import fnmatch
 import getpass
 import stat
+import sys
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
@@ -45,6 +46,17 @@ def setup_ssh_key(
 
     log : log if True, logger must already be initialised.
     """
+    if not sys.stdin.isatty():
+        utils.raise_error(
+            f"Attempting to run outside of a TTY terminal. "
+            f"This may happen if attempting to run in an IDE console. "
+            f"`getpass` (used for ssh password input) cannot run. "
+            f"Try running using the command-line-interface with "
+            f"'datashuttle {cfg.project_name} "
+            f"setup-ssh-connection-to-central-server' "
+            f"or in a terminal rather than IDE console."
+        )
+
     generate_and_write_ssh_key(cfg.ssh_key_path)
 
     password = getpass.getpass(


### PR DESCRIPTION
closes #179

`getpass` fails in certain terminal environments that are not TTY terminals. See [here](https://unix.stackexchange.com/questions/4126/what-is-the-exact-difference-between-a-terminal-a-shell-a-tty-and-a-con) difference between all of these terminal types. I'm not 100% sure of the actual distrinction, but some consoles (e..g in the PyCharm IDE) are not true TTY terminals which results in problems reading the `stdin` and `stdout`, and `getpass` hangs.

The solution is to check we are running in a TTY terminal, if not throw an error rather than hang. I've tested this manually (not sure how to write an actual test for it, nor if it is needed). It errors running in PyCharm IDE (i.e. using Python API) but works fine using command-line-interface through terminal. I saw some edge cases online where this will fail in debug mode, wheras it should actually work in debug mode, but I don't think this case really concerns us, and it is best to be conservative.

