### PR TITLE
Show existing projects

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -390,6 +390,12 @@ def show_top_level_folder(*args: Any) -> None:
     project.show_top_level_folder()
 
 
+def show_existing_projects(*args: Any) -> None:
+    """"""
+    project = args[0]
+    project.show_existing_projects()
+
+
 # Show Next Sub Number -------------------------------------------------------
 
 
@@ -930,6 +936,19 @@ def construct_parser():
         help="",
     )
     show_top_level_folder_parser.set_defaults(func=show_top_level_folder)
+
+    # Show Existing Projects
+    # -------------------------------------------------------------------------
+
+    show_existing_projects_parser = subparsers.add_parser(
+        "show-existing-projects",
+        aliases=["show_existing_projects"],
+        description=process_docstring(
+            DataShuttle.show_existing_projects.__doc__
+        ),
+        help="",
+    )
+    show_existing_projects_parser.set_defaults(func=show_existing_projects)
 
     # Show Next Sub Number
     # -------------------------------------------------------------------------

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from .config_class import Configs
+
+from pathlib import Path
+
+from datashutt.utils import folders
 
 from datashuttle.utils.folder_class import Folder
 
@@ -100,3 +104,30 @@ def get_non_ses_names():
 
 def get_top_level_folders():
     return ["rawdata", "derivatives"]
+
+
+def get_datashuttle_path():
+    """
+    Get the datashuttle path where all project
+    configs are stored.
+    """
+    return Path.home() / ".datashuttle"
+
+
+def get_project_datashuttle_path(project_name: str) -> Tuple[Path, Path]:
+    """
+    Get the datashuttle path for the project,
+    where configuration files are stored.
+    Also, return a temporary path in this for logging in
+    some cases where local_path location is not clear.
+
+    The datashuttle configuration path is stored in the user home
+    folder.
+    """
+    base_path = get_datashuttle_path() / project_name
+    temp_logs_path = base_path / "temp_logs"
+
+    folders.make_folders(base_path)
+    folders.make_folders(temp_logs_path)
+
+    return base_path, temp_logs_path

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -7,8 +7,7 @@ if TYPE_CHECKING:
 
 from pathlib import Path
 
-from datashutt.utils import folders
-
+from datashuttle.utils import folders
 from datashuttle.utils.folder_class import Folder
 
 

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -256,7 +256,9 @@ class Configs(UserDict):
         elif base == "central":
             base_folder = self["central_path"] / self.top_level_folder
         elif base == "datashuttle":
-            base_folder, _ = utils.get_datashuttle_path(self.project_name)
+            base_folder, _ = utils.get_project_datashuttle_path(
+                self.project_name
+            )
         return base_folder
 
     def get_rclone_config_name(

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -256,7 +256,7 @@ class Configs(UserDict):
         elif base == "central":
             base_folder = self["central_path"] / self.top_level_folder
         elif base == "datashuttle":
-            base_folder, _ = utils.get_project_datashuttle_path(
+            base_folder, _ = canonical_folders.get_project_datashuttle_path(
                 self.project_name
             )
         return base_folder

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -84,7 +84,7 @@ class DataShuttle:
         (
             self._datashuttle_path,
             self._temp_log_path,
-        ) = utils.get_project_datashuttle_path(self.project_name)
+        ) = canonical_folders.get_project_datashuttle_path(self.project_name)
 
         self._config_path = self._datashuttle_path / "config.yaml"
 
@@ -1003,7 +1003,7 @@ class DataShuttle:
         folder in the home / .datashuttle folder that contains a
         config.yaml file.
         """
-        datashuttle_path = utils.get_datashuttle_path()
+        datashuttle_path = canonical_folders.get_datashuttle_path()
 
         all_folders, _ = folders.search_filesystem_path_for_folders(
             datashuttle_path / "*"

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -996,45 +996,13 @@ class DataShuttle:
             f"The suggested new session number is: {suggested_new_num}"
         )
 
-    def get_existing_project_paths_and_names(self):
-        """
-        Return full path and names of datashuttle projects on
-        this local machine. A project is determined by a project
-        folder in the home / .datashuttle folder that contains a
-        config.yaml file.
-        """
-        datashuttle_path = canonical_folders.get_datashuttle_path()
-
-        all_folders, _ = folders.search_filesystem_path_for_folders(
-            datashuttle_path / "*"
-        )
-
-        existing_project_paths = []
-        existing_project_names = []
-        for folder_name in all_folders:
-            config_file = list(
-                (datashuttle_path / folder_name).glob("config.yaml")
-            )
-
-            if len(config_file) > 1:
-                utils.raise_error(
-                    f"There are two config files in project"
-                    f"{folder_name} at path {datashuttle_path}. There "
-                    f"should only ever be one config per project. "
-                )
-            elif len(config_file) == 1:
-                existing_project_paths.append(datashuttle_path / folder_name)
-                existing_project_names.append(folder_name)
-
-        return existing_project_names, existing_project_paths
-
     def show_existing_projects(self):
         """
         Print a list of existing project names found on the local machine.
         This is based on project folders in the "home / .datashuttle" folder
         that valid config.yaml files.
         """
-        project_names, _ = self.get_existing_project_paths_and_names()
+        project_names, _ = folders.get_existing_project_paths_and_names()
         utils.print_message_to_user(
             f"The existing project names are {project_names}."
         )

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -84,7 +84,7 @@ class DataShuttle:
         (
             self._datashuttle_path,
             self._temp_log_path,
-        ) = utils.get_datashuttle_path(self.project_name)
+        ) = utils.get_project_datashuttle_path(self.project_name)
 
         self._config_path = self._datashuttle_path / "config.yaml"
 
@@ -994,6 +994,49 @@ class DataShuttle:
             f"Local and Central repository searched for sessions for {sub}. "
             f"The most recent session number found is: {latest_existing_num}. "
             f"The suggested new session number is: {suggested_new_num}"
+        )
+
+    def get_existing_project_paths_and_names(self):
+        """
+        Return full path and names of datashuttle projects on
+        this local machine. A project is determined by a project
+        folder in the home / .datashuttle folder that contains a
+        config.yaml file.
+        """
+        datashuttle_path = utils.get_datashuttle_path()
+
+        all_folders, _ = folders.search_filesystem_path_for_folders(
+            datashuttle_path / "*"
+        )
+
+        existing_project_paths = []
+        existing_project_names = []
+        for folder_name in all_folders:
+            config_file = list(
+                (datashuttle_path / folder_name).glob("config.yaml")
+            )
+
+            if len(config_file) > 1:
+                utils.raise_error(
+                    f"There are two config files in project"
+                    f"{folder_name} at path {datashuttle_path}. There "
+                    f"should only ever be one config per project. "
+                )
+            elif len(config_file) == 1:
+                existing_project_paths.append(datashuttle_path / folder_name)
+                existing_project_names.append(folder_name)
+
+        return existing_project_names, existing_project_paths
+
+    def show_existing_projects(self):
+        """
+        Print a list of existing project names found on the local machine.
+        This is based on project folders in the "home / .datashuttle" folder
+        that valid config.yaml files.
+        """
+        project_names, _ = self.get_existing_project_paths_and_names()
+        utils.print_message_to_user(
+            f"The existing project names are {project_names}."
         )
 
     @staticmethod

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -564,7 +564,7 @@ def get_next_sub_or_ses_number(
     return suggested_new_num, latest_existing_num
 
 
-def get_existing_project_paths_and_names():
+def get_existing_project_paths_and_names() -> Tuple[List[str], List[Path]]:
     """
     Return full path and names of datashuttle projects on
     this local machine. A project is determined by a project

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -12,9 +12,9 @@ import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
-from datashuttle.configs.canonical_tags import tags
+from datashuttle.configs import canonical_folders, canonical_tags
 
-from . import formatting, ssh, utils
+from . import folders, formatting, ssh, utils
 
 # -----------------------------------------------------------------------------
 # Make Folders
@@ -368,8 +368,8 @@ def search_for_wildcards(
     """
     new_all_names = []
     for name in all_names:
-        if tags("*") in name:
-            name = name.replace(tags("*"), "*")
+        if canonical_tags.tags("*") in name:
+            name = name.replace(canonical_tags.tags("*"), "*")
 
             if sub:
                 matching_names = search_sub_or_ses_level(
@@ -562,3 +562,36 @@ def get_next_sub_or_ses_number(
     suggested_new_num = latest_existing_num + 1
 
     return suggested_new_num, latest_existing_num
+
+
+def get_existing_project_paths_and_names():
+    """
+    Return full path and names of datashuttle projects on
+    this local machine. A project is determined by a project
+    folder in the home / .datashuttle folder that contains a
+    config.yaml file.
+    """
+    datashuttle_path = canonical_folders.get_datashuttle_path()
+
+    all_folders, _ = folders.search_filesystem_path_for_folders(
+        datashuttle_path / "*"
+    )
+
+    existing_project_paths = []
+    existing_project_names = []
+    for folder_name in all_folders:
+        config_file = list(
+            (datashuttle_path / folder_name).glob("config.yaml")
+        )
+
+        if len(config_file) > 1:
+            utils.raise_error(
+                f"There are two config files in project"
+                f"{folder_name} at path {datashuttle_path}. There "
+                f"should only ever be one config per project. "
+            )
+        elif len(config_file) == 1:
+            existing_project_paths.append(datashuttle_path / folder_name)
+            existing_project_names.append(folder_name)
+
+    return existing_project_names, existing_project_paths

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -69,16 +69,25 @@ def raise_error(message: str) -> None:
     raise BaseException(message)
 
 
-def get_datashuttle_path(project_name: str) -> Tuple[Path, Path]:
+def get_datashuttle_path():
     """
-    Get the datashuttle path where configuration files are stored.
+    Get the datashuttle path where all project
+    configs are stored.
+    """
+    return Path.home() / ".datashuttle"
+
+
+def get_project_datashuttle_path(project_name: str) -> Tuple[Path, Path]:
+    """
+    Get the datashuttle path for the project,
+    where configuration files are stored.
     Also, return a temporary path in this for logging in
     some cases where local_path location is not clear.
 
     The datashuttle configuration path is stored in the user home
     folder.
     """
-    base_path = Path.home() / ".datashuttle" / project_name
+    base_path = get_datashuttle_path() / project_name
     temp_logs_path = base_path / "temp_logs"
 
     folders.make_folders(base_path)

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -4,11 +4,9 @@ import logging
 import re
 import traceback
 from pathlib import Path
-from typing import List, Literal, Tuple, Union, overload
+from typing import List, Literal, Union, overload
 
 from rich import print as rich_print
-
-from . import folders
 
 # --------------------------------------------------------------------------------------
 # General Utils
@@ -67,33 +65,6 @@ def raise_error(message: str) -> None:
     Temporary centralized way to raise and error
     """
     raise BaseException(message)
-
-
-def get_datashuttle_path():
-    """
-    Get the datashuttle path where all project
-    configs are stored.
-    """
-    return Path.home() / ".datashuttle"
-
-
-def get_project_datashuttle_path(project_name: str) -> Tuple[Path, Path]:
-    """
-    Get the datashuttle path for the project,
-    where configuration files are stored.
-    Also, return a temporary path in this for logging in
-    some cases where local_path location is not clear.
-
-    The datashuttle configuration path is stored in the user home
-    folder.
-    """
-    base_path = get_datashuttle_path() / project_name
-    temp_logs_path = base_path / "temp_logs"
-
-    folders.make_folders(base_path)
-    folders.make_folders(temp_logs_path)
-
-    return base_path, temp_logs_path
 
 
 def get_path_after_base_folder(base_folder: Path, path_: Path) -> Path:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,7 +121,7 @@ def delete_all_folders_in_project_path(project, local_or_central):
 
 def delete_project_if_it_exists(project_name):
     """"""
-    config_path, _ = utils.get_datashuttle_path(project_name)
+    config_path, _ = utils.get_project_datashuttle_path(project_name)
 
     if config_path.is_dir():
         ds_logger.close_log_filehandler()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import yaml
 
 from datashuttle.configs import canonical_configs, canonical_folders
 from datashuttle.datashuttle import DataShuttle
-from datashuttle.utils import ds_logger, rclone, utils
+from datashuttle.utils import ds_logger, rclone
 
 # -----------------------------------------------------------------------------
 # Setup and Teardown Test Project
@@ -121,7 +121,9 @@ def delete_all_folders_in_project_path(project, local_or_central):
 
 def delete_project_if_it_exists(project_name):
     """"""
-    config_path, _ = utils.get_project_datashuttle_path(project_name)
+    config_path, _ = canonical_folders.get_project_datashuttle_path(
+        project_name
+    )
 
     if config_path.is_dir():
         ds_logger.close_log_filehandler()

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import pytest
@@ -377,6 +378,61 @@ class TestConfigs:
             f"The {path_type} does not end in the project name: {project.project_name}."
             in str(e.value)
         )
+
+    def test_exiting_projects(self, setup_project, monkeypatch, tmp_path):
+        """
+        Test existing projects are correctly found based on whether
+        they exist in the home directory and contain a config.yaml.
+
+        By default, datashuttle saves project folders to
+        Path.home() / .datashuttle. In order to not mess with
+        the home directory during this test the `get_datashuttle_path()`
+        function is monkeypatched in order to point to a tmp_path.
+
+        The tmp_path / "projects" is filled with a mix of project folders
+        with and without config, and tested against accordingly. The `local_path`
+        and `central_path` specified in the DataShuttle config are arbitrarily put in
+        `tmp_path`.
+        """
+
+        def patch_get_datashuttle_path():
+            return tmp_path / "projects"
+
+        monkeypatch.setattr(
+            "datashuttle.datashuttle.utils.get_datashuttle_path",
+            patch_get_datashuttle_path,
+        )
+
+        project_1 = DataShuttle("project_1")
+        project_1.make_config_file(
+            tmp_path / "project_1",
+            tmp_path / "project_1",
+            "local_filesystem",
+            use_behav=True,
+        )
+
+        # project 2 will not be found, because it does not
+        # have a config file.
+        os.mkdir(tmp_path / "projects" / "project_2")
+
+        project_2 = DataShuttle("project_3")
+        project_2.make_config_file(
+            tmp_path / "project_3",
+            tmp_path / "project_2",
+            "local_filesystem",
+            use_behav=True,
+        )
+
+        (
+            project_names,
+            project_paths,
+        ) = setup_project.get_existing_project_paths_and_names()
+
+        assert project_names == ["project_1", "project_3"]
+        assert project_paths == [
+            (tmp_path / "projects" / "project_1"),
+            (tmp_path / "projects" / "project_3"),
+        ]
 
     # --------------------------------------------------------------------------------------------------------------------
     # Utils

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -399,7 +399,7 @@ class TestConfigs:
             return tmp_path / "projects"
 
         monkeypatch.setattr(
-            "datashuttle.datashuttle.utils.get_datashuttle_path",
+            "datashuttle.datashuttle.configs.canonical_folders.get_datashuttle_path",
             patch_get_datashuttle_path,
         )
 

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -9,6 +9,7 @@ from datashuttle.configs.canonical_configs import (
     get_canonical_config_required_types,
 )
 from datashuttle.datashuttle import DataShuttle
+from datashuttle.utils import folders
 
 TEST_PROJECT_NAME = "test_configs"
 
@@ -357,6 +358,7 @@ class TestConfigs:
 
         test_utils.check_configs(setup_project, new_configs)
 
+
     @pytest.mark.parametrize("path_type", ["local_path", "central_path"])
     def test_config_wrong_project_name(self, project, path_type, tmp_path):
         """ """
@@ -379,7 +381,8 @@ class TestConfigs:
             in str(e.value)
         )
 
-    def test_exiting_projects(self, setup_project, monkeypatch, tmp_path):
+    def test_exiting_projects(self, monkeypatch, tmp_path):
+
         """
         Test existing projects are correctly found based on whether
         they exist in the home directory and contain a config.yaml.
@@ -399,7 +402,7 @@ class TestConfigs:
             return tmp_path / "projects"
 
         monkeypatch.setattr(
-            "datashuttle.datashuttle.configs.canonical_folders.get_datashuttle_path",
+            "datashuttle.configs.canonical_folders.get_datashuttle_path",
             patch_get_datashuttle_path,
         )
 
@@ -426,7 +429,7 @@ class TestConfigs:
         (
             project_names,
             project_paths,
-        ) = setup_project.get_existing_project_paths_and_names()
+        ) = folders.get_existing_project_paths_and_names()
 
         assert project_names == ["project_1", "project_3"]
         assert project_paths == [

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -419,7 +419,7 @@ class TestConfigs:
         project_2 = DataShuttle("project_3")
         project_2.make_config_file(
             tmp_path / "project_3",
-            tmp_path / "project_2",
+            tmp_path / "project_3",
             "local_filesystem",
             use_behav=True,
         )

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -381,8 +381,7 @@ class TestConfigs:
             in str(e.value)
         )
 
-    def test_exiting_projects(self, monkeypatch, tmp_path):
-
+    def test_existing_projects(self, monkeypatch, tmp_path):
         """
         Test existing projects are correctly found based on whether
         they exist in the home directory and contain a config.yaml.
@@ -431,8 +430,8 @@ class TestConfigs:
             project_paths,
         ) = folders.get_existing_project_paths_and_names()
 
-        assert project_names == ["project_1", "project_3"]
-        assert project_paths == [
+        assert sorted(project_names) == ["project_1", "project_3"]
+        assert sorted(project_paths) == [
             (tmp_path / "projects" / "project_1"),
             (tmp_path / "projects" / "project_3"),
         ]

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -358,7 +358,6 @@ class TestConfigs:
 
         test_utils.check_configs(setup_project, new_configs)
 
-
     @pytest.mark.parametrize("path_type", ["local_path", "central_path"])
     def test_config_wrong_project_name(self, project, path_type, tmp_path):
         """ """


### PR DESCRIPTION
closes #153. This PR implements a `show-existing-projects` function (API and CLI). This will search the `Path.home() / ".datashuttle"` directory for any folder that has a `config.yaml` inside (assuming this is a project folder). 

A test is added, it is not required to add to docs because these convenience functions are not explicitly documented but are in the auto-updated CLI / API.

This PR also does some minor refactoring to make the logic clearer. Overall this PR:

1) moves `utils/get_datashuttle_path()` to `canonical_folders.py` and splits the logic into two separate functions
2) does some minor refactoring of imports on `folders.py`
3) introduces `folders/get_existing_project_paths_and_names` function and API, CLI front-end functions
4) adds test function.