### PR TITLE
[Validation] (2) Validation of passed `--sub_names` and `--ses_names`.

### DIFF
--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -83,12 +83,12 @@ def get_non_ses_names():
     ]
 
 
-def get_keys_that_we_cant_format():
+def canonical_reserved_keywords():
     """
     Key keyword arguments that are passed to `sub_names` or
     `ses_names` but that we
     """
-    return get_non_sub_names() + get_non_ses_names() + ["@*@"]
+    return get_non_sub_names() + get_non_ses_names()
 
 
 def get_top_level_folders():

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -220,6 +220,8 @@ class DataShuttle:
 
         if ses_names is not None:
             ses_names = formatting.check_and_format_names(ses_names, "ses")
+        else:
+            ses_names = []
 
         ds_logger.log_names(
             ["formatted_sub_names", "formatted_ses_names"],
@@ -231,18 +233,6 @@ class DataShuttle:
             base_folder=self.cfg.get_base_folder("local"),
             new_sub_names=sub_names,
             new_ses_names=ses_names,
-        )
-
-        if ses_names is None:
-            ses_names = []
-
-        # This will raise error if invalid and cannot convert sub
-        # or ses to `int`.
-        utils.get_values_from_bids_formatted_name(
-            sub_names, "sub", return_as_int=True
-        )
-        utils.get_values_from_bids_formatted_name(
-            ses_names, "ses", return_as_int=True
         )
 
         utils.log("\nMaking folders...")

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -164,6 +164,9 @@ def check_no_duplicate_sub_ses_key_values(
     new_ses_names : list of session names that are being
      checked for duplicates
     """
+    if new_ses_names == []:
+        new_ses_names = None
+
     if new_ses_names is None:
         existing_sub_names = search_sub_or_ses_level(
             project.cfg, base_folder, "local", search_str="*sub-*"

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -120,7 +120,9 @@ def check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
 ) -> None:
     """
     Check a list of subject or session names for duplicate
-    ids (e.g. [sub-001_@DATE@
+    ids (e.g. not allowing ["sub-001", "sub-001_@DATE@"]) and that the
+    values lengths are consistent (e.g. not allowing
+    ["sub-001", "sub-02"]).
     """
     prefix_values = utils.get_values_from_bids_formatted_name(
         names, prefix, return_as_int=False

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -76,7 +76,7 @@ def validate_names(all_names, prefix):
     check_dashes_and_underscore_alternate_correctly(all_names)
 
     check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
-        prefixed_names, prefix
+        names_to_check, prefix
     )
 
 def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -6,7 +6,7 @@ import warnings
 from itertools import compress
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
 
-from datashuttle.configs.canonical_folders import get_keys_that_we_cant_format
+from datashuttle.configs.canonical_folders import canonical_reserved_keywords
 from datashuttle.configs.canonical_tags import tags
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ def check_and_format_names(
     these keys as they intrinsically break the NeuroBlueprint rules.
     However, in practice this is not an issue because you won't make a
     folder with "@*@" in it anyway, this is strictly for searching
-    during upload / download. see canonical_folders.get_keys_that_we_cant_format()
+    during upload / download. see canonical_folders.canonical_reserved_keywords()
     for more information.
 
     Parameters
@@ -50,7 +50,7 @@ def check_and_format_names(
 
     names_to_check, reserved_keywords = [], []
     for name in names:
-        if name in get_keys_that_we_cant_format():
+        if name in canonical_reserved_keywords() or tags("*") in name:
             reserved_keywords.append(name)
         else:
             names_to_check.append(name)
@@ -69,12 +69,6 @@ def validate_names(all_names, prefix):
 
     We cannot validate names with "@*@" tags in.
     """
-    if len(all_names) != len(set(all_names)):
-        utils.log_and_raise_error(
-            "Subject and session names must all be unique (i.e. there are no"
-            " duplicates in list input)."
-        )
-
     if len(all_names) == 0:
         return
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -66,12 +66,15 @@ def validate_names(all_names, prefix):
     """
     Validate a list of subject or session names, ensuring
     they are formatted as per NeuroBlueprint.
+
+    We cannot validate names with "@*@" tags in.
     """
     if len(all_names) != len(set(all_names)):
         utils.log_and_raise_error(
             "Subject and session names must all be unique (i.e. there are no"
             " duplicates in list input)."
         )
+
     if len(names_to_check) == 0:
         return
 
@@ -127,17 +130,19 @@ def check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
     prefix_values = utils.get_values_from_bids_formatted_name(
         names, prefix, return_as_int=False
     )
+    value_len = [len(value) for value in prefix_values]
 
-    leading_zeros = [num_leading_zeros(value) for value in prefix_values]
-    int_values = [int(value) for value in prefix_values]
+    int_values = utils.get_values_from_bids_formatted_name(
+        names, prefix, return_as_int=True
+    )  # can't just convert to the above to int as need extra validation
 
-    if not all_identical(leading_zeros):
+    if not all_identical(value_len):
         utils.log_and_raise_error(
             f"The number of leading zeros within {prefix} names must be "
             f"consistent across all {prefix} names."
         )
 
-    if not all_identical(int_values):
+    if not all_unique(int_values):
         utils.log_and_raise_error(
             f"{prefix} names must all have unique integer ids"
             f" after the {prefix} prefix."

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -131,7 +131,7 @@ def check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
 
     if not all_identical(leading_zeros):
         utils.log_and_raise_error(
-            f"The number of leading zeros within {prefix} names must be"
+            f"The number of leading zeros within {prefix} names must be "
             f"consistent across all {prefix} names."
         )
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -75,14 +75,15 @@ def validate_names(all_names, prefix):
             " duplicates in list input)."
         )
 
-    if len(names_to_check) == 0:
+    if len(all_names) == 0:
         return
 
     check_dashes_and_underscore_alternate_correctly(all_names)
 
     check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
-        names_to_check, prefix
+        all_names, prefix
     )
+
 
 def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:
     """

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -133,7 +133,7 @@ def check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
 
     if not all_identical(value_len):
         utils.log_and_raise_error(
-            f"The number of leading zeros within {prefix} names must be "
+            f"The length of the {prefix} values (e.g. '001') must be "
             f"consistent across all {prefix} names."
         )
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -57,12 +57,12 @@ def check_and_format_names(
 
     formatted_names = format_names(names_to_check, prefix)
 
-    validate_names(formatted_names)
+    validate_names(formatted_names, prefix)
 
     return formatted_names + reserved_keywords
 
 
-def validate_names(all_names):
+def validate_names(all_names, prefix):
     """
     Validate a list of subject or session names, ensuring
     they are formatted as per NeuroBlueprint.
@@ -75,6 +75,9 @@ def validate_names(all_names):
 
     check_dashes_and_underscore_alternate_correctly(all_names)
 
+    check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
+        prefixed_names, prefix
+    )
 
 def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:
     """
@@ -97,11 +100,11 @@ def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:
         [not isinstance(ele, str) for ele in names]
     ):
         utils.log_and_raise_error(
-            "Ensure subject and session names are a list of strings."
+            f"Ensure {prefix} names are a list of strings."
         )
 
     if any([" " in ele for ele in names]):
-        utils.log_and_raise_error("sub or ses names cannot include spaces.")
+        utils.log_and_raise_error(f"{prefix} names cannot include spaces.")
 
     prefixed_names = ensure_prefixes_on_list_of_names(names, prefix)
 
@@ -110,6 +113,41 @@ def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:
     update_names_with_datetime(prefixed_names)
 
     return prefixed_names
+
+
+def check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
+    names: List[str], prefix: Literal["sub", "ses"]
+) -> None:
+    """
+    Check a list of subject or session names for duplicate
+    ids (e.g. [sub-001_@DATE@
+    """
+    prefix_values = utils.get_values_from_bids_formatted_name(
+        names, prefix, return_as_int=False
+    )
+
+    leading_zeros = [num_leading_zeros(value) for value in prefix_values]
+    int_values = [int(value) for value in prefix_values]
+
+    if not all_identical(leading_zeros):
+        utils.log_and_raise_error(
+            f"The number of leading zeros within {prefix} names must be"
+            f"consistent across all {prefix} names."
+        )
+
+    if not all_identical(int_values):
+        utils.log_and_raise_error(
+            f"{prefix} names must all have unique integer ids"
+            f" after the {prefix} prefix."
+        )
+
+
+def all_unique(list_):
+    return len(list_) == len(set(list_))
+
+
+def all_identical(list_):
+    return len(set(list_)) == 1
 
 
 # Handle @TO@ flags  -------------------------------------------------------

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -72,6 +72,8 @@ def validate_names(all_names, prefix):
             "Subject and session names must all be unique (i.e. there are no"
             " duplicates in list input)."
         )
+    if len(names_to_check) == 0:
+        return
 
     check_dashes_and_underscore_alternate_correctly(all_names)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -523,7 +523,7 @@ def get_default_sub_sessions_to_test():
     Canonical subs / sessions for these tests
     """
     subs = ["sub-001", "sub-002", "sub-003"]
-    sessions = ["ses-001_23092022-13h50s", "ses-002", "ses-003"]
+    sessions = ["ses-001_datetime-20220516T135022", "ses-002", "ses-003"]
     return subs, sessions
 
 

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -272,7 +272,7 @@ class TestFileTransfer(BaseTest):
         Finally, check the expected formatting on the subject and session
         is observed on the created and transferred file paths.
         """
-        subs = ["001", f"02{tags('to')}03"]
+        subs = ["001", f"02{tags('to')}003"]
         sessions = [f"ses-01{tags('to')}003_{tags('datetime')}"]
 
         test_utils.make_local_folders_with_files_in(
@@ -290,7 +290,7 @@ class TestFileTransfer(BaseTest):
             project.cfg["local_path"],
             project.cfg["central_path"],
         ]:
-            for sub in ["sub-001", "sub-02", "sub-03"]:
+            for sub in ["sub-001", "sub-002", "sub-003"]:
                 sessions_in_path = test_utils.glob_basenames(
                     (base_local / "rawdata" / sub / "ses*").as_posix()
                 )

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -20,9 +20,7 @@ class TestFormatting(BaseTest):
         with pytest.raises(BaseException) as e:
             formatting.format_names(input, prefix)
 
-        assert f"Ensure {prefix} names are a list of strings." == str(
-            e.value
-        )
+        assert f"Ensure {prefix} names are a list of strings." == str(e.value)
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])
     def test_format_names_duplicate_ele(self, prefix):

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -20,9 +20,8 @@ class TestFormatting(BaseTest):
         with pytest.raises(BaseException) as e:
             formatting.format_names(input, prefix)
 
-        assert (
-            "Ensure subject and session names are "
-            "a list of strings." == str(e.value)
+        assert f"Ensure {prefix} names are a list of strings." == str(
+            e.value
         )
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])
@@ -37,8 +36,8 @@ class TestFormatting(BaseTest):
             )
 
         assert (
-            "Subject and session names must all be unique "
-            "(i.e. there are no duplicates in list input)." == str(e.value)
+            f"{prefix} names must all have unique integer "
+            f"ids after the {prefix} prefix." == str(e.value)
         )
 
     def test_format_names_prefix(self):
@@ -70,7 +69,7 @@ class TestFormatting(BaseTest):
 
     def test_warning_non_consecutive_numbers(self, project):
         project.make_folders(
-            ["sub-01", "sub-2", "sub-04"], ["ses-05", "ses-10"]
+            ["sub-01", "sub-02", "sub-04"], ["ses-05", "ses-10"]
         )
 
         with pytest.warns(UserWarning) as w:
@@ -81,7 +80,7 @@ class TestFormatting(BaseTest):
         )
 
         with pytest.warns(UserWarning) as w:
-            project.get_next_ses_number("sub-2")
+            project.get_next_ses_number("sub-02")
         assert (
             str(w[0].message)
             == "A subject number has been skipped, currently "

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -155,13 +155,9 @@ class TestLogging:
             in log
         )
 
-<<<<<<< HEAD
     def test_make_folders(self, project):
-        subs = ["sub-11", f"sub-002{tags('to')}004"]
-=======
-    def test_make_folders(self, setup_project):
         subs = ["sub-111", f"sub-002{tags('to')}004"]
->>>>>>> e368a22 (Fix tests.)
+
         ses = ["ses-123", "ses-101"]
 
         project.make_folders(subs, ses, datatype="all")
@@ -186,12 +182,7 @@ class TestLogging:
         assert "Made folder at path:" in log
 
         assert (
-            str(
-                Path("local")
-                / project.project_name
-                / "rawdata"
-                / "sub-111"
-            )
+            str(Path("local") / project.project_name / "rawdata" / "sub-111")
             in log
         )
         assert (

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -155,8 +155,13 @@ class TestLogging:
             in log
         )
 
+<<<<<<< HEAD
     def test_make_folders(self, project):
         subs = ["sub-11", f"sub-002{tags('to')}004"]
+=======
+    def test_make_folders(self, setup_project):
+        subs = ["sub-111", f"sub-002{tags('to')}004"]
+>>>>>>> e368a22 (Fix tests.)
         ses = ["ses-123", "ses-101"]
 
         project.make_folders(subs, ses, datatype="all")
@@ -166,22 +171,27 @@ class TestLogging:
         assert "Formatting Names..." in log
 
         assert (
-            "\n\nVariablesState:\nlocals: {'sub_names': ['sub-11', "
+            "\n\nVariablesState:\nlocals: {'sub_names': ['sub-111', "
             "'sub-002@TO@004'], 'ses_names': ['ses-123', 'ses-101'], "
             "'datatype': 'all'}\ncfg: {'local_path':" in log
         )
 
-        assert f"sub_names: ['sub-11', 'sub-002{tags('to')}004']" in log
+        assert f"sub_names: ['sub-111', 'sub-002{tags('to')}004']" in log
         assert "ses_names: ['ses-123', 'ses-101']" in log
         assert (
-            "formatted_sub_names: ['sub-11', 'sub-002', 'sub-003', 'sub-004']"
+            "formatted_sub_names: ['sub-111', 'sub-002', 'sub-003', 'sub-004']"
             in log
         )
         assert "formatted_ses_names: ['ses-123', 'ses-101']" in log
         assert "Made folder at path:" in log
 
         assert (
-            str(Path("local") / project.project_name / "rawdata" / "sub-11")
+            str(
+                Path("local")
+                / project.project_name
+                / "rawdata"
+                / "sub-111"
+            )
             in log
         )
         assert (

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -90,14 +90,14 @@ class TestMakeFolders(BaseTest):
         a dict that indicates if each subfolder is used (to avoid
         circular testing from the project itself).
         """
-        subs = ["11", "sub-002", "30303"]
+        subs = ["00011", "sub-00002", "30303"]
 
         project.make_folders(subs)
 
         test_utils.check_folder_tree_is_correct(
             project,
             base_folder=test_utils.get_top_level_folder_path(project),
-            subs=["sub-11", "sub-002", "sub-30303"],
+            subs=["sub-00011", "sub-00002", "sub-30303"],
             sessions=[],
             folder_used=test_utils.get_all_folders_used(),
         )
@@ -112,13 +112,15 @@ class TestMakeFolders(BaseTest):
         This is highlighted in an assert in check_and_cd_folder()
         """
         subs = ["sub-001", "sub-002"]
-        sessions = ["ses-001", "50432"]
+
+        sessions = ["ses-00001", "50432"]
 
         project.make_folders(subs, sessions, "all")
+
         base_folder = test_utils.get_top_level_folder_path(project)
 
         for sub in subs:
-            for ses in ["ses-001", "ses-50432"]:
+            for ses in ["ses-00001", "ses-50432"]:
                 test_utils.check_and_cd_folder(
                     join(base_folder, sub, ses, "ephys")
                 )
@@ -324,8 +326,8 @@ class TestMakeFolders(BaseTest):
         """
         project.cfg.top_level_folder = folder_name
 
-        subs = ["sub-001", "sub-2"]
-        sessions = ["ses-001", "ses-03"]
+        subs = ["sub-001", "sub-002"]
+        sessions = ["ses-001", "ses-003"]
 
         project.make_folders(subs, sessions, "all")
 
@@ -412,7 +414,7 @@ class TestMakeFolders(BaseTest):
         assert new_num == 4
         assert old_num == 3
 
-        project.make_folders(sub, ["04", "0005"])
+        project.make_folders(sub, ["004", "005"])
         new_num, old_num = project.get_next_ses_number(sub)
         assert new_num == 6
         assert old_num == 5

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -59,7 +59,7 @@ class TestUnit:
         with pytest.raises(BaseException) as e:
             formatting.check_and_format_names(names, prefix)
 
-        assert str(e.value) == "sub or ses names cannot include spaces."
+        assert str(e.value) == f"{prefix} names cannot include spaces."
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])
     def test_process_to_keyword_in_sub_input(self, prefix):
@@ -208,7 +208,7 @@ class TestUnit:
         names = [f"{prefix}-001", f"{prefix}-02", f"{prefix}-003"]
 
         with pytest.raises(BaseException) as e:
-            formatting.format_names(names, prefix)
+            formatting.check_and_format_names(names, prefix)
 
         assert (
             str(e.value)
@@ -225,7 +225,7 @@ class TestUnit:
         names = [f"{prefix}-001", f"{prefix}-002", f"{prefix}-001_@DATE@"]
 
         with pytest.raises(BaseException) as e:
-            formatting.format_names(names, prefix)
+            formatting.check_and_format_names(names, prefix)
 
         assert (
             str(e.value) == f"{prefix} names must all have unique "

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -199,6 +199,39 @@ class TestUnit:
             assert formatting.num_leading_zeros("sub-" + "1".zfill(i + 1)) == i
             assert formatting.num_leading_zeros("ses-" + "1".zfill(i + 1)) == i
 
+    @pytest.mark.parametrize("prefix", ["sub", "ses"])
+    def test_inconsistent_leading_zeros_in_list_of_names(self, prefix):
+        """
+        Ensure a list of sub / ses names that contain inconsistent leading zeros
+        (e.g. ["sub-001", "sub-02"]) leads to an error.
+        """
+        names = [f"{prefix}-001", f"{prefix}-02", f"{prefix}-003"]
+
+        with pytest.raises(BaseException) as e:
+            formatting.format_names(names, prefix)
+
+        assert (
+            str(e.value)
+            == f"The number of leading zeros within {prefix} names must "
+            f"be consistent across all {prefix} names."
+        )
+
+    @pytest.mark.parametrize("prefix", ["sub", "ses"])
+    def test_duplicate_ids_in_list_of_names(self, prefix):
+        """
+        Ensure a list of sub / ses names that contain duplicate sub / ses
+        ids (e.g. ["sub-001", "sub-001_@DATE@"]) leads to an error.
+        """
+        names = [f"{prefix}-001", f"{prefix}-002", f"{prefix}-001_@DATE@"]
+
+        with pytest.raises(BaseException) as e:
+            formatting.format_names(names, prefix)
+
+        assert (
+            str(e.value) == f"{prefix} names must all have unique "
+            f"integer ids after the {prefix} prefix."
+        )
+
     # ----------------------------------------------------------------------
     # Utlis
     # ----------------------------------------------------------------------

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -212,8 +212,7 @@ class TestUnit:
 
         assert (
             str(e.value)
-            == f"The number of leading zeros within {prefix} names must "
-            f"be consistent across all {prefix} names."
+            == f"The length of the {prefix} values (e.g. '001') must be consistent across all {prefix} names."
         )
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])


### PR DESCRIPTION
This PR requires #206 as currently reserved keywords (e.g. `all_non_ses`) are also checked, leading to error.

Other PRs (#148, #204) that add validation check the names within a list against the rest of the entire project. However,
there was a blind spot in that sub / ses names within the list themselves were not checked, in particular
for duplicate ids or inconsistent leading zeros.

This PR adds this check at the level of making the subject directories. I don't think there is any other situation where
this check needs to be performed. Unless, it could be performed as an extra sanity-check when transferring data.

All this logic will be factored out at some point for #198 so maybe then is a better time to think about the structure.
