### PR TITLE
[Validation] (3) Validate `--sub-names`  when `--ses_names` is passed.

### DIFF
--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -178,11 +178,11 @@ def check_no_duplicate_sub_ses_key_values(
 
     if new_ses_names is not None:
         for sub in new_sub_names:
-            for new_ses in new_ses_names:
-                existing_names = search_sub_or_ses_level(
-                    project.cfg, base_folder, "local", sub, search_str="*ses-*"
-                )[0]
+            existing_names = search_sub_or_ses_level(
+                project.cfg, base_folder, "local", sub, search_str="*ses-*"
+            )[0]
 
+            for new_ses in new_ses_names:
                 check_new_subject_does_not_duplicate_existing(
                     new_ses, existing_names, "ses"
                 )

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -189,7 +189,7 @@ def check_no_duplicate_sub_ses_key_values(
 
 
 def check_new_subject_does_not_duplicate_existing(
-    new_name: str, existing_names: List[str], sub_or_ses: Literal["sub", "ses"]
+    new_name: str, existing_names: List[str], prefix: Literal["sub", "ses"]
 ) -> None:
     """
     Check that a subject or session does not already exist
@@ -211,10 +211,10 @@ def check_new_subject_does_not_duplicate_existing(
     matched_existing_names = []
     for exist_name in existing_names:
         exist_name_id = utils.get_values_from_bids_formatted_name(
-            [exist_name], sub_or_ses, return_as_int=True
+            [exist_name], prefix, return_as_int=True
         )[0]
         new_name_id = utils.get_values_from_bids_formatted_name(
-            [new_name], sub_or_ses, return_as_int=True
+            [new_name], prefix, return_as_int=True
         )[0]
 
         if exist_name_id == new_name_id:
@@ -227,15 +227,15 @@ def check_new_subject_does_not_duplicate_existing(
     # it is a duplicate.
     if len(matched_existing_names) > 1:
         utils.log_and_raise_error(
-            f"Cannot make folders. Multiple {sub_or_ses} ids exists: {matched_existing_names}. This should"
-            f"never happen. Check the {sub_or_ses} ids and ensure unique {sub_or_ses} "
+            f"Cannot make folders. Multiple {prefix} ids exists: {matched_existing_names}. This should"
+            f"never happen. Check the {prefix} ids and ensure unique {prefix} "
             f"ids (e.g. sub-001) appear only once."
         )
 
     if len(matched_existing_names) == 1:
         if new_name != matched_existing_names[0]:
             utils.log_and_raise_error(
-                f"Cannot make folders. A {sub_or_ses} already exists with the same {sub_or_ses} id as {new_name}. "
+                f"Cannot make folders. A {prefix} already exists with the same {prefix} id as {new_name}. "
                 f"The existing folder is {matched_existing_names[0]}."
             )
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -227,7 +227,8 @@ def check_new_subject_does_not_duplicate_existing(
     # it is a duplicate.
     if len(matched_existing_names) > 1:
         utils.log_and_raise_error(
-            f"Cannot make folders. Multiple {prefix} ids exists: {matched_existing_names}. This should"
+            f"Cannot make folders. Multiple {prefix} ids "
+            f"exist: {matched_existing_names}. This should"
             f"never happen. Check the {prefix} ids and ensure unique {prefix} "
             f"ids (e.g. sub-001) appear only once."
         )
@@ -235,7 +236,8 @@ def check_new_subject_does_not_duplicate_existing(
     if len(matched_existing_names) == 1:
         if new_name != matched_existing_names[0]:
             utils.log_and_raise_error(
-                f"Cannot make folders. A {prefix} already exists with the same {prefix} id as {new_name}. "
+                f"Cannot make folders. A {prefix} already exists "
+                f"with the same {prefix} id as {new_name}. "
                 f"The existing folder is {matched_existing_names[0]}."
             )
 

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -348,14 +348,13 @@ class TestLogging:
         self.delete_log_files(project.cfg.logging_path)
 
         with pytest.raises(BaseException):
-           project.make_folders("sub-01", datatype="all")
+            project.make_folders("sub-01", datatype="all")
 
         log = self.read_log_file(project.cfg.logging_path)
 
         assert (
             "Cannot make folders. A sub already exists with the same sub id as sub-01. "
-            "The existing folder is sub-001"
-            in log
+            "The existing folder is sub-001" in log
         )
 
     @pytest.mark.skipif("not IS_WINDOWS")

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -348,12 +348,13 @@ class TestLogging:
         self.delete_log_files(project.cfg.logging_path)
 
         with pytest.raises(BaseException):
-            project.make_folders("sub-001", datatype="all")
+           project.make_folders("sub-01", datatype="all")
 
         log = self.read_log_file(project.cfg.logging_path)
 
         assert (
-            "Cannot make folders. The key sub-1 (possibly with leading zeros) already exists in the project"
+            "Cannot make folders. A sub already exists with the same sub id as sub-01. "
+            "The existing folder is sub-001"
             in log
         )
 

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -80,10 +80,7 @@ class TestMakeFolders(BaseTest):
     def test_duplicate_sub_when_creating_session(self, project):
         """
         Check the unique case that a duplicate subject is
-        introduced when the session is made, because this
-        was not checked until the function
-        `check_new_subject_does_not_duplicate_existing()`
-        was introduced.
+        introduced when the session is made.
         """
         project.make_folders("sub-001")
 

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -85,40 +85,40 @@ class TestMakeFolders(BaseTest):
         `check_new_subject_does_not_duplicate_existing()`
         was introduced.
         """
-        project.make_sub_folders("sub-001")
+        project.make_folders("sub-001")
 
         for bad_sub_name in ["sub-1", "sub-1_@DATE", "sub-001_extra-key"]:
             with pytest.raises(BaseException) as e:
-                project.make_sub_folders(bad_sub_name, "ses-001")
+                project.make_folders(bad_sub_name, "ses-001")
             assert "Cannot make folders. A sub already exists" in str(e.value)
 
-        project.make_sub_folders("sub-001", "ses-001")
+        project.make_folders("sub-001", "ses-001")
 
         with pytest.raises(BaseException) as e:
-            project.make_sub_folders("sub-001", "ses-001_extra-key", "behav")
+            project.make_folders("sub-001", "ses-001_extra-key", "behav")
         assert (
             "Cannot make folders. A ses already exists with the same ses id as ses-001"
             in str(e.value)
         )
 
         with pytest.raises(BaseException) as e:
-            project.make_sub_folders("sub-001_extra-key", "ses-001", "behav")
+            project.make_folders("sub-001_extra-key", "ses-001", "behav")
         assert "Cannot make folders. A sub already exists " in str(e.value)
 
         with pytest.raises(BaseException) as e:
-            project.make_sub_folders(
+            project.make_folders(
                 "sub-001_extra-key", "ses-001_@DATE@", "behav"
             )
         assert "Cannot make folders. A sub already exists " in str(e.value)
 
-        project.make_sub_folders("sub-001", "ses-001", "behav")
+        project.make_folders("sub-001", "ses-001", "behav")
 
-        project.make_sub_folders("sub-001", ["ses-001", "ses-002"])
+        project.make_folders("sub-001", ["ses-001", "ses-002"])
 
         # Finally check that in a list of subjects, only the correct subject
         # with duplicate session is caught.
         with pytest.raises(BaseException) as e:
-            project.make_sub_folders(
+            project.make_folders(
                 ["sub-001", "sub-002"], "ses-002_@DATE@", "ephys"
             )
         assert (


### PR DESCRIPTION
closes #143

All new subjects and sessions passed to `make_sub_folders` are checked against the entire existing project (local and remote) to ensure there are no duplicates. However, when creating new sessions, the subjects passed to `make_sub_folders` were not re-validated. Therefore it was possible to make duplicate subjects when creating new sessions.

This PR changes the checking logic so that subjects are also checked for duplicates when creating a new session. The main problem is that, of course if you have a `sub-001` and now want to add a session, `make_sub_folders("sub-001", "ses-002")` would throw a dulpicate error for `"sub-001"`. The way around it is to check for existing names that share the subject id. Only throw an error if the passed name does not match exactly.

One change in behaviour is that this means that exact duplidate subject name creation will pass silently. e.g.
```
project.make_sub_folders("sub-001")
project.make_sub_folders("sub-001")
```
is okay. This is probably not ideal, because maybe you want to warn the user the folder they are trying to make already exists, for example when making folders in python this could raise an error and require `exists_ok=True` to not cause an error. In this case, users may try and make `"sub-001`" not realising there is already a "sub-001". However, I think this case is quite unlikely as people will mostly be creating session level too. Then, when they go to save data in `sub-001` manually, they will see there is already data there. So, I think we can not worry too much about this issue. But, if we did want to consider it, we could check that if `ses_names` is empty, we error under all circumstances if a `sub-XXX` matches an existing `sub-XXX` in the project.