### PR TITLE
[Validation] (1) Refactor the code that performs validation of `--sub_names` and `--ses_names`.

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 from pathlib import Path
 from typing import Literal, Union, get_args, get_origin
 
-from datashuttle.utils import folders, utils
+from datashuttle.utils import utils
 
 
 def get_canonical_config_dict() -> dict:
@@ -176,7 +176,9 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
         utils.print_message_to_user(
             f"Making project folder at: {config_dict['local_path']}"
         )
-        folders.make_folders(config_dict["local_path"])
+        # TODO: cannot use folders.makefoldesr due to circular import
+        config_dict["local_path"].mkdir(parents=True, exist_ok=True)
+
     except OSError:
         utils.log_and_raise_error(
             f"Could not make project folder at: {config_dict['local_path']}."

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -83,6 +83,14 @@ def get_non_ses_names():
     ]
 
 
+def get_keys_that_we_cant_format():
+    """
+    Key keyword arguments that are passed to `sub_names` or
+    `ses_names` but that we
+    """
+    return get_non_ses_names() + get_non_ses_names() + ["@*@"]
+
+
 def get_top_level_folders():
     return ["rawdata", "derivatives"]
 

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -88,7 +88,7 @@ def get_keys_that_we_cant_format():
     Key keyword arguments that are passed to `sub_names` or
     `ses_names` but that we
     """
-    return get_non_ses_names() + get_non_ses_names() + ["@*@"]
+    return get_non_sub_names() + get_non_ses_names() + ["@*@"]
 
 
 def get_top_level_folders():

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -7,7 +7,6 @@ if TYPE_CHECKING:
 
 from pathlib import Path
 
-from datashuttle.utils import folders
 from datashuttle.utils.folder_class import Folder
 
 
@@ -109,7 +108,8 @@ def get_project_datashuttle_path(project_name: str) -> Tuple[Path, Path]:
     base_path = get_datashuttle_path() / project_name
     temp_logs_path = base_path / "temp_logs"
 
-    folders.make_folders(base_path)
-    folders.make_folders(temp_logs_path)
+    # TODO: cannot use folders.makefoldesr due to circular import
+    base_path.mkdir(parents=True, exist_ok=True)
+    temp_logs_path.mkdir(parents=True, exist_ok=True)
 
     return base_path, temp_logs_path

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -1021,6 +1021,9 @@ class DataShuttle:
         if prefix not in ["sub", "ses"]:
             utils.log_and_raise_error("'prefix' must be 'sub' or 'ses'.")
 
+        if isinstance(names, str):
+            names = [names]
+
         formatted_names = formatting.format_names(names, prefix)
         utils.print_message_to_user(formatted_names)
 

--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -312,27 +312,27 @@ class TransferData:
         see transfer_sub_ses_data()
 
         """
-        sub_or_ses: Literal["sub", "ses"]
+        prefix: Literal["sub", "ses"]
         if sub is None:
-            sub_or_ses = "sub"
+            prefix = "sub"
         else:
-            sub_or_ses = "ses"
+            prefix = "ses"
 
-        if names_checked in [["all"], [f"all_{sub_or_ses}"]]:
+        if names_checked in [["all"], [f"all_{prefix}"]]:
             processed_names = folders.search_sub_or_ses_level(
                 self.cfg,
                 self.base_folder,
                 self.local_or_central,
                 sub,
-                search_str=f"{sub_or_ses}-*",
+                search_str=f"{prefix}-*",
             )[0]
 
             if names_checked == ["all"]:
-                processed_names += [f"all_non_{sub_or_ses}"]
+                processed_names += [f"all_non_{prefix}"]
 
         else:
             processed_names = formatting.check_and_format_names(
-                names_checked, sub_or_ses
+                names_checked, prefix
             )
             processed_names = folders.search_for_wildcards(
                 self.cfg,
@@ -343,7 +343,7 @@ class TransferData:
             )
 
         utils.log_and_message(
-            f"The {sub_or_ses} names to transfer are: {processed_names}"
+            f"The {prefix} names to transfer are: {processed_names}"
         )
 
         return processed_names

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -22,7 +22,7 @@ RESERVED_KEYWORDS = get_non_sub_names() + get_non_ses_names()
 
 def check_and_format_names(
     names: Union[list, str],
-    sub_or_ses: Literal["sub", "ses"],
+    prefix: Literal["sub", "ses"],
 ) -> List[str]:
     """
     Format a list of subject or session names, e.g.
@@ -36,11 +36,11 @@ def check_and_format_names(
     names: str or list containing sub or ses names
                   (e.g. to make folders)
 
-    sub_or_ses: "sub" or "ses" - this defines the prefix checks.
+    prefix: "sub" or "ses" - this defines the prefix checks.
     """
-    formatted_names = format_names(names, sub_or_ses)
+    formatted_names = format_names(names, prefix)
 
-    check_names(formatted_names, sub_or_ses)
+    check_names(formatted_names, prefix)
 
     return formatted_names
 
@@ -81,7 +81,7 @@ def format_names(
 
     prefix: "sub" or "ses" - this defines the prefix checks.
     """
-    assert prefix in ["sub", "ses"], "`sub_or_ses` must be 'sub' or 'ses'."
+    assert prefix in ["sub", "ses"], "`prefix` must be 'sub' or 'ses'."
 
     if type(names) not in [str, list] or any(
         [not isinstance(ele, str) for ele in names]

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import datetime
 import re
 import warnings
 from itertools import compress
-from typing import Any, Dict, List, Literal, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
 
 from datashuttle.configs.canonical_folders import (
     get_non_ses_names,
     get_non_sub_names,
 )
 from datashuttle.configs.canonical_tags import tags
-from datashuttle.configs.config_class import Configs
+
+if TYPE_CHECKING:
+    from datashuttle.configs.config_class import Configs
 
 from . import folders, utils
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -40,13 +40,16 @@ def check_and_format_names(
     """
     formatted_names = format_names(names, prefix)
 
-    check_names(formatted_names, prefix)
+    validate_names(formatted_names)
 
     return formatted_names
 
 
-def check_names(all_names, prefix):
-    """"""
+def validate_names(all_names):
+    """
+    Validate a list of subject or session names, ensuring
+    they are formatted as per NeuroBlueprint.
+    """
     names_to_check = [
         name for name in all_names if name not in RESERVED_KEYWORDS
     ]
@@ -58,10 +61,6 @@ def check_names(all_names, prefix):
         )
 
     check_dashes_and_underscore_alternate_correctly(names_to_check)
-
-    names_to_check = update_names_with_range_to_flag(names_to_check, prefix)
-
-    update_names_with_datetime(names_to_check)
 
 
 def format_names(
@@ -97,6 +96,10 @@ def format_names(
         utils.log_and_raise_error("sub or ses names cannot include spaces.")
 
     prefixed_names = ensure_prefixes_on_list_of_names(names, prefix)
+
+    prefixed_names = update_names_with_range_to_flag(prefixed_names, prefix)
+
+    update_names_with_datetime(prefixed_names)
 
     return prefixed_names
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -42,6 +42,13 @@ def check_and_format_names(
 
     prefix: "sub" or "ses" - this defines the prefix checks.
     """
+    names_to_check, reserved_keywords = [], []
+    for name in names:
+        if name in RESERVED_KEYWORDS:
+            reserved_keywords.append(name)
+        else:
+            names_to_check.append(name)
+
     formatted_names = format_names(names, prefix)
 
     validate_names(formatted_names)
@@ -305,7 +312,7 @@ def ensure_prefixes_on_list_of_names(
 
     new_names = []
     for name in all_names:
-        if name[:n_chars] != prefix and name not in RESERVED_KEYWORDS:
+        if name[:n_chars] != prefix:
             new_names.append(prefix + name)
         else:
             new_names.append(name)

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -4,6 +4,10 @@ import warnings
 from itertools import compress
 from typing import Any, Dict, List, Literal, Union
 
+from datashuttle.configs.canonical_folders import (
+    get_non_ses_names,
+    get_non_sub_names,
+)
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.configs.config_class import Configs
 
@@ -13,12 +17,7 @@ from . import folders, utils
 # Format Sub / Ses Names
 # --------------------------------------------------------------------------------------------------------------------
 
-RESERVED_KEYWORDS = [
-    "all_sub",
-    "all_ses",
-    "all_non_sub",
-    "all_non_ses",
-]  # TODO: add to configs
+RESERVED_KEYWORDS = get_non_sub_names() + get_non_ses_names()
 
 
 def check_and_format_names(
@@ -41,7 +40,28 @@ def check_and_format_names(
     """
     formatted_names = format_names(names, sub_or_ses)
 
+    check_names(formatted_names, sub_or_ses)
+
     return formatted_names
+
+
+def check_names(all_names, prefix):
+    """"""
+    names_to_check = [
+        name for name in all_names if name not in RESERVED_KEYWORDS
+    ]
+
+    if len(names_to_check) != len(set(names_to_check)):
+        utils.log_and_raise_error(
+            "Subject and session names but all be unique (i.e. there are no"
+            " duplicates in list input)."
+        )
+
+    check_dashes_and_underscore_alternate_correctly(names_to_check)
+
+    names_to_check = update_names_with_range_to_flag(names_to_check, prefix)
+
+    update_names_with_datetime(names_to_check)
 
 
 def format_names(
@@ -77,18 +97,6 @@ def format_names(
         utils.log_and_raise_error("sub or ses names cannot include spaces.")
 
     prefixed_names = ensure_prefixes_on_list_of_names(names, prefix)
-
-    if len(prefixed_names) != len(set(prefixed_names)):
-        utils.log_and_raise_error(
-            "Subject and session names but all be unique (i.e. there are no"
-            " duplicates in list input)."
-        )
-
-    check_dashes_and_underscore_alternate_correctly(prefixed_names)
-
-    prefixed_names = update_names_with_range_to_flag(prefixed_names, prefix)
-
-    update_names_with_datetime(prefixed_names)
 
     return prefixed_names
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -42,18 +42,19 @@ def check_and_format_names(
 
     prefix: "sub" or "ses" - this defines the prefix checks.
     """
+    TO_FORMAT = RESERVED_KEYWORDS + "@*@"  # TODO: Move
     names_to_check, reserved_keywords = [], []
     for name in names:
-        if name in RESERVED_KEYWORDS:
+        if name in TO_FORMAT:
             reserved_keywords.append(name)
         else:
             names_to_check.append(name)
 
-    formatted_names = format_names(names, prefix)
+    formatted_names = format_names(names_to_check, prefix)
 
     validate_names(formatted_names)
 
-    return formatted_names
+    return formatted_names + reserved_keywords
 
 
 def validate_names(all_names):

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -54,9 +54,12 @@ def validate_names(all_names):
         name for name in all_names if name not in RESERVED_KEYWORDS
     ]
 
+    # Note this check will fail on formatted @DATETIME@ tags because
+    # ["sub-001_@DATETIME@", "sub-001_@DATETIME@"] will be formatted
+    # slightly different. Remove this in
     if len(names_to_check) != len(set(names_to_check)):
         utils.log_and_raise_error(
-            "Subject and session names but all be unique (i.e. there are no"
+            "Subject and session names must all be unique (i.e. there are no"
             " duplicates in list input)."
         )
 

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -32,10 +32,12 @@ class TestFormatting(BaseTest):
         is passed to format_names().
         """
         with pytest.raises(BaseException) as e:
-            formatting.format_names(["1", "2", "3", "3", "4"], prefix)
+            formatting.check_and_format_names(
+                ["1", "2", "3", "3", "4"], prefix
+            )
 
         assert (
-            "Subject and session names but all be unique "
+            "Subject and session names must all be unique "
             "(i.e. there are no duplicates in list input)." == str(e.value)
         )
 

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -22,7 +22,7 @@ class TestFormatting(BaseTest):
 
         assert (
             "Ensure subject and session names are "
-            "list of strings, or string" == str(e.value)
+            "a list of strings." == str(e.value)
         )
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])
@@ -51,11 +51,11 @@ class TestFormatting(BaseTest):
         prefix = "sub"
 
         # check name is prefixed
-        formatted_names = formatting.format_names("1", prefix)
+        formatted_names = formatting.format_names(["1"], prefix)
         assert formatted_names[0] == "sub-1"
 
         # check existing prefix is not duplicated
-        formatted_names = formatting.format_names("sub-1", prefix)
+        formatted_names = formatting.format_names(["sub-1"], prefix)
         assert formatted_names[0] == "sub-1"
 
         # test mixed list of prefix and unprefixed are prefixed correctly.

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -227,12 +227,10 @@ class TestFileTransfer:
             filter(Path.is_file, all_transferred)
         )
 
-        try:
-            assert sorted(paths_to_transferred_files) == sorted(
-                expected_transferred_paths
-            )
-        except:
-            breakpoint()
+        assert sorted(paths_to_transferred_files) == sorted(
+            expected_transferred_paths
+        )
+
         # Teardown here, because we have session scope.
         try:
             shutil.rmtree(self.central_from_local(project.cfg["local_path"]))

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -227,10 +227,12 @@ class TestFileTransfer:
             filter(Path.is_file, all_transferred)
         )
 
-        assert sorted(paths_to_transferred_files) == sorted(
-            expected_transferred_paths
-        )
-
+        try:
+            assert sorted(paths_to_transferred_files) == sorted(
+                expected_transferred_paths
+            )
+        except:
+            breakpoint()
         # Teardown here, because we have session scope.
         try:
             shutil.rmtree(self.central_from_local(project.cfg["local_path"]))

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -57,7 +57,7 @@ class TestUnit:
     def test_spaces_in_format_names(self, prefix_and_names):
         prefix, names = prefix_and_names
         with pytest.raises(BaseException) as e:
-            formatting.format_names(names, prefix)
+            formatting.check_and_format_names(names, prefix)
 
         assert str(e.value) == "sub or ses names cannot include spaces."
 


### PR DESCRIPTION
blocker for #203, which is rebased on this branch.

This PR does some minor refactoring to the logic that checks subject names and session names (e.g. that are passed to `make_sub_folders` or the transfer functions). 

1) rename `sub_or_ses_names` to `prefix` for consistency across functions
2) split `format_names` into `format_names` and `validate_names`. 

Currently, there are a list of `RESERVED_KEYWORDS` that can be passed to the transfer functions (e.g. `all_non_ses`) that we need to skip formatting and validation of. For formatting, these are skipped when required within the relevant function. For validation, all reserved keywords are stripped from the list before checking. 

There might be a better way to do this, because this is slightly not-robust for the formatting case. it would be possible if writing a new formatting fucntion to forget to check for reserved keywords. Also, the functions that format the tags do not check for the keywords, because they will never contain the tags and pass right through. Nonetheless, it is still weird to even pass the keywords to these functions.

Maybe it is better, similar to validation, to first split the passed list into `to_format` and `reserved_keywords` list. Then the `to_format` can be formatted, and the list rejoined at the end. This will be kind of ugly but I think much more robst. 

