### PR TITLE
[TUI] Add DirectoryTree and Input widgets to Create Tab (2)

### DIFF
--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -1,8 +1,17 @@
 from pathlib import Path
+from time import monotonic
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.widgets import Footer, Header, Label, TabbedContent, TabPane
+from textual.widgets import (
+    DirectoryTree,
+    Footer,
+    Header,
+    Input,
+    Label,
+    TabbedContent,
+    TabPane,
+)
 
 
 class TuiApp(App):
@@ -20,7 +29,7 @@ class TuiApp(App):
     TITLE = "DataShuttle"
 
     # Set path to TCSS
-    tui_path = Path(__file__).parents[0]
+    tui_path = Path(__file__).parent
     CSS_PATH = tui_path / "css" / "tab_content.tcss"
 
     # Set key-bindings
@@ -33,12 +42,31 @@ class TuiApp(App):
         yield Header()
         with TabbedContent():
             with TabPane("Create", id="create"):
-                yield Label("Create", id="create_text")
+                yield DirectoryTree(str(Path().home()), id="FileTree")
+                yield Label("Folder Name")
+                yield Input(
+                    placeholder="Double-click on any folder to fill this field.",
+                    id="subject",
+                )
             with TabPane("Transfer", id="transfer"):
                 yield Label("Transfer; Seems to work!")
         yield Footer()
 
+    prev_time = 0.0
+
+    def on_directory_tree_directory_selected(
+        self, event: DirectoryTree.DirectorySelected
+    ):
+        """
+        After double-clicking a directory within the directory-tree widget, replaces contents of the \'Subject\'
+        Input widget with directory name
+        """
+
+        click_time = monotonic()
+        if click_time - self.prev_time < 0.5:
+            self.query_one("#subject").value = str(event.path)
+        self.prev_time = click_time
+
 
 if __name__ == "__main__":
-    app = TuiApp()
-    app.run()
+    TuiApp().run()

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -66,7 +66,7 @@ class TuiApp(App):
         """
 
         click_time = monotonic()
-        if click_time - self.prev_time < 0.5:
+        if click_time - self.prev_click_time < 0.5:
             self.query_one("#subject").value = str(event.path)
         self.prev_click_time = click_time
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -28,17 +28,20 @@ class TuiApp(App):
 
     TITLE = "DataShuttle"
 
-    # Set path to TCSS
     tui_path = Path(__file__).parent
     CSS_PATH = tui_path / "css" / "tab_content.tcss"
 
-    # Set key-bindings
     BINDINGS = [
         Binding("ctrl+d", "toggle_dark", "Toggle Dark Mode", priority=True)
     ]
 
-    # Compose window
+    prev_click_time = 0.0
+
     def compose(self) -> ComposeResult:
+        """
+        Composes widgets to the TUI in the order specified.
+        """
+
         yield Header()
         with TabbedContent():
             with TabPane("Create", id="create"):
@@ -52,20 +55,20 @@ class TuiApp(App):
                 yield Label("Transfer; Seems to work!")
         yield Footer()
 
-    prev_time = 0.0
-
     def on_directory_tree_directory_selected(
         self, event: DirectoryTree.DirectorySelected
     ):
         """
-        After double-clicking a directory within the directory-tree widget, replaces contents of the \'Subject\'
-        Input widget with directory name
+        After double-clicking a directory within the directory-tree
+        widget, replaces contents of the \'Subject\' input widget
+        with directory name. Double-click time is set to the
+        Windows default (500 ms).
         """
 
         click_time = monotonic()
         if click_time - self.prev_time < 0.5:
             self.query_one("#subject").value = str(event.path)
-        self.prev_time = click_time
+        self.prev_click_time = click_time
 
 
 if __name__ == "__main__":

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -2,8 +2,19 @@ Screen {
     padding: 0;
 }
 TabbedContent {
-    width: 100%
+    width: 100%;
 }
-#create_text {
-    text-style: italic;
+#FileTree {
+    dock: left;
+    width: 35%;
+    padding: 1 2;
+    margin: 0 4 0 0;
+}
+#create > Label {
+    width: 100%;
+    margin: 0 0 1 1;
+    text-style: bold;
+}
+#create > Input {
+    color: $text;
 }


### PR DESCRIPTION
## Description

This PR adds a functional directory-tree viewer and single user input field to the create tab. Double-clicking any directory on the DirectoryTree widget prints the directory path to the Input widget. The DirectoryTree root is currently set to the current User's home directory, but this can be easily adjusted by passing any absolute path (as a string) to the DirectoryTree widget as its first positional argument.

## References

Follows from PR #193, and closes #186.

## Checklist:

- [X] The code has been tested locally
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
