### PR TITLE
[TUI] Implement Create Tab Functions (3)

### DIFF
--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -39,6 +39,10 @@ class TypeBox(Static):
             yield Checkbox(type.title(), id=type, value=1)
 
     def on_checkbox_changed(self):
+        """
+        When a checkbox is clicked, update the `type_out` attribute
+        with the datatypes to pass to `make_folders` datatype argument.
+        """
         type_dict = {
             type: self.query_one(f"#{type}").value for type in self.type_config
         }

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -29,9 +29,9 @@ class TypeBox(Static):
         super(TypeBox, self).__init__()
 
         self.type_config = [
-            k.removeprefix("use_")
-            for k, v in zip(project_cfg.data.keys(), project_cfg.data.values())
-            if "use_" in k and v is True
+            key.removeprefix("use_")
+            for key, value in zip(project_cfg.data.keys(), project_cfg.data.values())
+            if "use_" in key and value is True
         ]
 
     def compose(self):

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -112,6 +112,7 @@ class TuiApp(App):
                 yield Label("Datatype(s)")
                 yield TypeBox(self.project.cfg)
                 yield Button("Make Folders", id="make_folder")
+                yield Input(id="create_page_errors", placeholder="Errors are printed here.")
             with TabPane("Transfer", id="transfer"):
                 yield Label("Transfer; Seems to work!")
         yield Footer()
@@ -144,11 +145,16 @@ class TuiApp(App):
         if event.button.id == "make_folder":
             sub_dir = self.query_one("#subject").value
             ses_dir = self.query_one("#session").value
-            self.project.make_folders(
-                sub_names=sub_dir,
-                ses_names=ses_dir,
-                datatype=self.query_one("TypeBox").type_out,
-            )
+
+            try:
+                self.project.make_folders(
+                    sub_names=sub_dir,
+                    ses_names=ses_dir,
+                    datatype=self.query_one("TypeBox").type_out,
+                )
+            except BaseException as e:
+                self.query_one('#create_page_errors').value = str(e)
+
             self.query_one("#FileTree").reload()
 
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -47,7 +47,7 @@ class TypeBox(Static):
             type: self.query_one(f"#{type}").value for type in self.type_config
         }
         self.type_out = [
-            x for x, v in zip(type_dict.keys(), type_dict.values()) if v == 1
+            datatype for datatype, is_on in zip(type_dict.keys(), type_dict.values()) if is_on
         ]
 
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -114,6 +114,7 @@ class TuiApp(App):
                 self.query_one("#subject").value = str(event.path.stem)
             if event.path.stem.startswith("ses-"):
                 self.query_one("#session").value = str(event.path.stem)
+                self.query_one("#subject").value = str(event.path.parent.stem)
         self.prev_time = click_time
 
     def on_button_pressed(self, event: Button.Pressed):

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -113,7 +113,7 @@ class TuiApp(App):
             if event.path.stem.startswith("ses-"):
                 self.query_one("#session").value = str(event.path.stem)
                 self.query_one("#subject").value = str(event.path.parent.stem)
-        self.prev_time = click_time
+        self.prev_click_time = click_time
 
     def on_button_pressed(self, event: Button.Pressed):
         """

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -155,10 +155,9 @@ class TuiApp(App):
                     ses_names=ses_dir,
                     datatype=self.query_one("TypeBox").type_out,
                 )
+                self.query_one("#FileTree").reload()
             except BaseException as e:
                 self.query_one("#errors_on_create_page").value = str(e)
-
-            self.query_one("#FileTree").reload()
 
 
 if __name__ == "__main__":

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -23,6 +23,8 @@ class TypeBox(Static):
     """
     Dynamically-populated checkbox widget for convenient datatype selection during folder creation.
     """
+    type_out = reactive("all")
+
     def __init__(self, project_cfg):
         super(TypeBox, self).__init__()
 
@@ -31,8 +33,6 @@ class TypeBox(Static):
             for k, v in zip(project_cfg.data.keys(), project_cfg.data.values())
             if "use_" in k and v is True
         ]
-
-        self.type_out = reactive("all")  # I'm not sure what this is supposed to do or if I have broken it :'D
 
     def compose(self):
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -17,7 +17,7 @@ from textual.widgets import (
     TabPane,
 )
 
-from datashuttle.datashuttle import DataShuttle
+from datashuttle import DataShuttle
 
 # Change this to any local DataShuttle project for testing!
 project = DataShuttle("test_project")
@@ -118,13 +118,13 @@ class TuiApp(App):
     def on_button_pressed(self, event: Button.Pressed):
         """
         Enables the Make Folder button to read out current input values
-        and use these to call project.make_sub_folders().
+        and use these to call project.make_folders().
         """
 
         if event.button.id == "make_folder":
             sub_dir = self.query_one("#subject").value
             ses_dir = self.query_one("#session").value
-            project.make_sub_folders(
+            project.make_folders(
                 sub_names=sub_dir,
                 ses_names=ses_dir,
                 datatype=self.query_one("TypeBox").type_out,

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -101,7 +101,6 @@ class TuiApp(App):
         """
         Composes widgets to the TUI in the order specified.
         """
-
         yield Header()
         with TabbedContent():
             with TabPane("Create", id="create"):
@@ -115,7 +114,10 @@ class TuiApp(App):
                 yield Label("Datatype(s)")
                 yield TypeBox(self.project.cfg)
                 yield Button("Make Folders", id="make_folder")
-                yield Input(id="create_page_errors", placeholder="Errors are printed here.")
+                yield Input(
+                    id="errors_on_create_page",
+                    placeholder="Errors are printed here.",
+                )
             with TabPane("Transfer", id="transfer"):
                 yield Label("Transfer; Seems to work!")
         yield Footer()
@@ -129,7 +131,6 @@ class TuiApp(App):
         with directory name. Double-click time is set to the
         Windows default (500 ms).
         """
-
         click_time = monotonic()
         if click_time - self.prev_click_time < 0.5:
             if event.path.stem.startswith("sub-"):
@@ -144,7 +145,6 @@ class TuiApp(App):
         Enables the Make Folder button to read out current input values
         and use these to call project.make_folders().
         """
-
         if event.button.id == "make_folder":
             sub_dir = self.query_one("#subject").value
             ses_dir = self.query_one("#session").value
@@ -156,7 +156,7 @@ class TuiApp(App):
                     datatype=self.query_one("TypeBox").type_out,
                 )
             except BaseException as e:
-                self.query_one('#create_page_errors').value = str(e)
+                self.query_one("#errors_on_create_page").value = str(e)
 
             self.query_one("#FileTree").reload()
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -19,9 +19,26 @@ from textual.widgets import (
 
 from datashuttle import DataShuttle
 
+
 class TypeBox(Static):
     """
-    Dynamically-populated checkbox widget for convenient datatype selection during folder creation.
+    Dynamically-populated checkbox widget for convenient datatype
+    selection during folder creation.
+
+    Parameters
+    ---------
+
+    project_config: ConfigsClass
+        Configuration dictionary from datashuttle (i.e. `project.cfg`).
+
+    Attributes
+    ----------
+
+    type_out:
+        List of datatypes (e.g. "behav" that will be passed to `make-folders`.)
+
+    type_config:
+        List of datatypes that were set as 'True' during datashuttle project setup
     """
     type_out = reactive("all")
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -29,9 +29,9 @@ class TypeBox(Static):
         super(TypeBox, self).__init__()
 
         self.type_config = [
-            key.removeprefix("use_")
-            for key, value in zip(project_cfg.keys(), project_cfg.values())
-            if "use_" in key and value is True
+            config.removeprefix("use_")
+            for config, is_on in zip(project_cfg.keys(), project_cfg.values())
+            if "use_" in config and is_on
         ]
 
     def compose(self):

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -3,15 +3,51 @@ from time import monotonic
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.reactive import reactive
 from textual.widgets import (
+    Button,
+    Checkbox,
     DirectoryTree,
     Footer,
     Header,
     Input,
     Label,
+    Static,
     TabbedContent,
     TabPane,
 )
+
+from datashuttle.datashuttle import DataShuttle
+
+project = DataShuttle(
+    "test_project"
+)  # Change this to any local DataShuttle project for testing!
+
+
+class TypeBox(Static):
+    """
+    Dynamically-populated checkbox widget for convenient datatype selection during folder creation.
+    """
+
+    type_config = [
+        k.removeprefix("use_")
+        for k, v in zip(project.cfg.data.keys(), project.cfg.data.values())
+        if "use_" in k and v is True
+    ]
+
+    def compose(self):
+        for type in self.type_config:
+            yield Checkbox(type.title(), id=type, value=1)
+
+    type_out = reactive("all")
+
+    def on_checkbox_changed(self, event: Checkbox.Changed):
+        type_dict = {
+            type: self.query_one(f"#{type}").value for type in self.type_config
+        }
+        self.type_out = [
+            x for x, v in zip(type_dict.keys(), type_dict.values()) if v == 1
+        ]
 
 
 class TuiApp(App):
@@ -45,12 +81,18 @@ class TuiApp(App):
         yield Header()
         with TabbedContent():
             with TabPane("Create", id="create"):
-                yield DirectoryTree(str(Path().home()), id="FileTree")
-                yield Label("Folder Name")
-                yield Input(
-                    placeholder="Double-click on any folder to fill this field.",
-                    id="subject",
+                yield DirectoryTree(
+                    str(project.cfg.data["local_path"]), id="FileTree"
                 )
+                yield Label("Subject(s)", id="sub_label")
+                yield Input(id="subject", placeholder="e.g. sub-001")
+
+                # delete/move before committing
+                yield Label("Session(s)")
+                yield Input(id="session", placeholder="e.g. ses-001")
+                yield Label("Datatype(s)")
+                yield TypeBox()
+                yield Button("Make Folders", id="make_folder")
             with TabPane("Transfer", id="transfer"):
                 yield Label("Transfer; Seems to work!")
         yield Footer()
@@ -66,9 +108,24 @@ class TuiApp(App):
         """
 
         click_time = monotonic()
-        if click_time - self.prev_click_time < 0.5:
-            self.query_one("#subject").value = str(event.path)
-        self.prev_click_time = click_time
+
+        if click_time - self.prev_time < 0.5:
+            if event.path.stem.startswith("sub-"):
+                self.query_one("#subject").value = str(event.path.stem)
+            if event.path.stem.startswith("ses-"):
+                self.query_one("#session").value = str(event.path.stem)
+        self.prev_time = click_time
+
+    def on_button_pressed(self, event: Button.Pressed):
+        if event.button.id == "make_folder":
+            sub_dir = self.query_one("#subject").value
+            ses_dir = self.query_one("#session").value
+            project.make_sub_folders(
+                sub_names=sub_dir,
+                ses_names=ses_dir,
+                datatype=self.query_one("TypeBox").type_out,
+            )
+            self.query_one("#FileTree").reload()
 
 
 if __name__ == "__main__":

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -19,9 +19,8 @@ from textual.widgets import (
 
 from datashuttle.datashuttle import DataShuttle
 
-project = DataShuttle(
-    "test_project"
-)  # Change this to any local DataShuttle project for testing!
+# Change this to any local DataShuttle project for testing!
+project = DataShuttle("test_project")
 
 
 class TypeBox(Static):
@@ -108,8 +107,7 @@ class TuiApp(App):
         """
 
         click_time = monotonic()
-
-        if click_time - self.prev_time < 0.5:
+        if click_time - self.prev_click_time < 0.5:
             if event.path.stem.startswith("sub-"):
                 self.query_one("#subject").value = str(event.path.stem)
             if event.path.stem.startswith("ses-"):
@@ -118,6 +116,11 @@ class TuiApp(App):
         self.prev_time = click_time
 
     def on_button_pressed(self, event: Button.Pressed):
+        """
+        Enables the Make Folder button to read out current input values
+        and use these to call project.make_sub_folders().
+        """
+
         if event.button.id == "make_folder":
             sub_dir = self.query_one("#subject").value
             ses_dir = self.query_one("#session").value

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -126,10 +126,10 @@ class TuiApp(App):
         self, event: DirectoryTree.DirectorySelected
     ):
         """
-        After double-clicking a directory within the directory-tree
-        widget, replaces contents of the \'Subject\' input widget
-        with directory name. Double-click time is set to the
-        Windows default (500 ms).
+        Enables double-clicking a directory within the directory-tree
+        widget to replace contents of the \'Subject\' and/or \'Session\'
+        input widgets depending on the prefix of the directory selected.
+        Double-click time is set to the Windows default duration (500 ms).
         """
         click_time = monotonic()
         if click_time - self.prev_click_time < 0.5:

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -30,7 +30,7 @@ class TypeBox(Static):
 
         self.type_config = [
             key.removeprefix("use_")
-            for key, value in zip(project_cfg.data.keys(), project_cfg.data.values())
+            for key, value in zip(project_cfg.keys(), project_cfg.values())
             if "use_" in key and value is True
         ]
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -35,11 +35,10 @@ class TypeBox(Static):
         ]
 
     def compose(self):
-
         for type in self.type_config:
             yield Checkbox(type.title(), id=type, value=1)
 
-    def on_checkbox_changed(self, event: Checkbox.Changed):
+    def on_checkbox_changed(self):
         type_dict = {
             type: self.query_one(f"#{type}").value for type in self.type_config
         }

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -16,11 +16,11 @@
     layout: grid;
     grid-size: 2 2;
     grid-columns: 25;
+    min-height: 5;
 }
-TypeBox > Checkbox {
-    width: 18;
+TypeBox > ToggleButton {
+    height: 3;
+    margin: 0 0 3 1;
     content-align: left middle;
-}
-#make_folder {
-    margin: 1 0 0 0;
+    width: 18;
 }

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -1,20 +1,26 @@
-Screen {
-    padding: 0;
-}
-TabbedContent {
-    width: 100%;
-}
 #FileTree {
     dock: left;
     width: 35%;
-    padding: 1 2;
+    padding: 1 2 1 2;
     margin: 0 4 0 0;
 }
 #create > Label {
     width: 100%;
-    margin: 0 0 1 1;
+    margin: 1 0 1 1;
     text-style: bold;
 }
-#create > Input {
-    color: $text;
+#create > #sub_label {
+    margin: 0 0 1 1;
+}
+#create > TypeBox {
+    layout: grid;
+    grid-size: 2 2;
+    grid-columns: 25;
+}
+TypeBox > Checkbox {
+    width: 18;
+    content-align: left middle;
+}
+#make_folder {
+    margin: 1 0 0 0;
 }


### PR DESCRIPTION
## Description

This PR adds several major features to the TUI's Create tab. This tab now takes sub- and ses-level inputs + contains a checkbox for datatype selection. Clicking Make Folders runs ```project.make_sub_folders``` using these inputs and updates the ```DirectoryTree``` widget. 

`Checkbox` widgets are yielded dynamically to only display datatypes that have been configured for the active project. Subject and session-level `Input` widgets can now also be automatically populated by double-clicking sub- and ses-level directories on the DirectoryTree, respectively. Double-clicking directories whose names do not begin with "sub-" or "ses-" now no longer updates the ```Input``` widget values.

**NOTE:** The "active project" is currently hard-coded to one titled 'test_project'. If you'd like to do some testing, note that this can be easily swapped for any other project by editing the DataShuttle call at the top of the script.

## References

Follows from PR #193 and #215, closes #187.

## Checklist:

- [X] The code has been tested locally
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
