### PR TITLE
Update pyproject.toml from flake8 to ruff.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "isort",
     "mypy",
     "pre-commit",
-    "flake8",
+    "ruff",
     "setuptools_scm",
     "types-requests",
     "types-PyYAML",


### PR DESCRIPTION
This updates the pyproject.toml dependencies to match pre-commit, using ruff instead of flake8. closes #209