### PR TITLE
Shorten `DataShuttle` import path.

### DIFF
--- a/datashuttle/__init__.py
+++ b/datashuttle/__init__.py
@@ -1,7 +1,9 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from datashuttle.datashuttle import DataShuttle
+
 try:
-    __version__ = version("{{cookiecutter.package_name}}")
+    __version__ = version("{{datashuttle.package_name}}")
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/datashuttle/__init__.py
+++ b/datashuttle/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import PackageNotFoundError, version
 from datashuttle.datashuttle import DataShuttle
 
 try:
-    __version__ = version("{{datashuttle.package_name}}")
+    __version__ = version("datashuttle")
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -4,8 +4,8 @@ from typing import Any, Callable
 
 import simplejson
 
+from datashuttle import DataShuttle
 from datashuttle.configs import load_configs
-from datashuttle.datashuttle import DataShuttle
 from datashuttle.utils import utils
 
 PROTECTED_TEST_PROJECT_NAME = "ds_protected_test_name"

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from datashuttle import DataShuttle
     from datashuttle.configs.config_class import Configs
-    from datashuttle.datashuttle import DataShuttle
 
 import glob
 import os

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -315,7 +315,7 @@ DataShuttle can be used through the command line interface (as exampled in the *
 To start a project in Python, import DataShuttle and initialise the project class:
 
 ```
-from datashuttle.datashuttle import DataShuttle
+from datashuttle import DataShuttle
 
 project = DataShuttle("my_first_project")
 ```

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,8 +13,6 @@ import yaml
 
 from datashuttle import DataShuttle
 from datashuttle.configs import canonical_configs, canonical_folders
-
-from datashuttle.datashuttle import DataShuttle
 from datashuttle.utils import ds_logger, rclone
 
 # -----------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 import yaml
 
+from datashuttle import DataShuttle
 from datashuttle.configs import canonical_configs, canonical_folders
+
 from datashuttle.datashuttle import DataShuttle
 from datashuttle.utils import ds_logger, rclone
 

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -4,11 +4,12 @@ import warnings
 import pytest
 import test_utils
 
+from datashuttle import DataShuttle
 from datashuttle.configs.canonical_configs import (
     get_canonical_config_dict,
     get_canonical_config_required_types,
 )
-from datashuttle.datashuttle import DataShuttle
+
 from datashuttle.utils import folders
 
 TEST_PROJECT_NAME = "test_configs"

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -9,7 +9,6 @@ from datashuttle.configs.canonical_configs import (
     get_canonical_config_dict,
     get_canonical_config_required_types,
 )
-
 from datashuttle.utils import folders
 
 TEST_PROJECT_NAME = "test_configs"

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 import test_utils
 
+from datashuttle import DataShuttle
 from datashuttle.configs.canonical_tags import tags
-from datashuttle.datashuttle import DataShuttle
 from datashuttle.utils import ds_logger
 
 TEST_PROJECT_NAME = "test_logging"

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -1,7 +1,7 @@
 import pytest
 import test_utils
 
-from datashuttle.datashuttle import DataShuttle
+from datashuttle import DataShuttle
 
 TEST_PROJECT_NAME = "test_persistent_settings"
 


### PR DESCRIPTION
Changes `__init__.py` to allow import datashuttle as `from datashuttle import DataShuttle` rather than `from datashuttle.datashuttle import DataShuttle`. closes #212 

This simpler import is used now across the codebase and docs. As this is the only user-facing class I did not shorten any other import paths to leave these intutive from the package organisation, however we can definately add more if useful.

Also the `__version__` attribute defined in `__init__` was broken so fixed.

so 
- [x] this change is tested.
- [x] this change is reflected in docs.

