### PR TITLE
Type hint datatype as `Union[List[str], str]`.

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -6,7 +6,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import paramiko
 import yaml
@@ -159,7 +159,7 @@ class DataShuttle:
         self,
         sub_names: Union[str, list],
         ses_names: Optional[Union[str, list]] = None,
-        datatype: str = "all",
+        datatype: Union[List[str], str] = "all",
     ) -> None:
         """
         Create a subject / session folder tree in the project
@@ -294,7 +294,7 @@ class DataShuttle:
         self,
         sub_names: Union[str, list],
         ses_names: Union[str, list],
-        datatype: str = "all",
+        datatype: Union[List[str], str] = "all",
         dry_run: bool = False,
         init_log: bool = True,
     ) -> None:
@@ -368,7 +368,7 @@ class DataShuttle:
         self,
         sub_names: Union[str, list],
         ses_names: Union[str, list],
-        datatype: str = "all",
+        datatype: Union[List[str], str] = "all",
         dry_run: bool = False,
         init_log: bool = True,
     ) -> None:

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -25,7 +25,7 @@ def make_folder_trees(
     cfg: Configs,
     sub_names: Union[str, list],
     ses_names: Union[str, list],
-    datatype: str,
+    datatype: Union[List[str], str],
     log: bool = True,
 ) -> None:
     """

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -291,7 +291,7 @@ def ensure_prefixes_on_list_of_names(
 
 
 def check_datatype_is_valid(
-    cfg: Configs, datatype: str, error_on_fail: bool
+    cfg: Configs, datatype: Union[List[str], str], error_on_fail: bool
 ) -> bool:
     """
     Check the passed datatype is valid (must


### PR DESCRIPTION
Previously datatype argument (e.g.`upload`, `download`, `make_sub_folders` was typed as `datatype: str` but it also accepted list. closes #214 