### PR TITLE
Raise an error if `.` syntax is passed for `local` or `central` paths.

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -145,11 +145,21 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
         )
 
     for path_type in ["local_path", "central_path"]:
-        if config_dict[path_type].as_posix()[0] == "~":
+        path_name = config_dict[path_type].as_posix()
+        if path_name[0] == "~":
             utils.log_and_raise_error(
                 f"{path_type} must contain the full folder path "
                 "with no ~ syntax."
             )
+
+        # pathlib strips "./" so not checked.
+        for bad_start in [".", "../"]:
+            if path_name.startswith(bad_start):
+                utils.log_and_raise_error(
+                    f"{path_type} must contain the full folder path "
+                    "with no dot syntax."
+                )
+
         project_name = config_dict.project_name
         if config_dict[path_type].stem != project_name:
             utils.log_and_raise_error(

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -54,7 +54,7 @@ class TestConfigs(BaseTest):
         Here check an error is raised when path contains
         incorrect syntax.
 
-        Note pathlib strings "./" so not checked.
+        Note pathlib strips "./" so not checked.
         """
         good_pattern = f"/my/path/{TEST_PROJECT_NAME}"
         if path_type == "local_path":

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -38,9 +38,9 @@ class TestConfigs(BaseTest):
     @pytest.mark.parametrize(
         "bad_pattern",
         [
-            f"~/my/path/{TEST_PROJECT_NAME}",
+            "~/my/path",
             ".",
-            f"../my/path/{TEST_PROJECT_NAME}",
+            "../my/path",
         ],
     )
     @pytest.mark.parametrize("path_type", ["local_path", "central_path"])
@@ -56,7 +56,10 @@ class TestConfigs(BaseTest):
 
         Note pathlib strips "./" so not checked.
         """
-        good_pattern = f"/my/path/{TEST_PROJECT_NAME}"
+        if bad_pattern != ".":
+            bad_pattern = f"{bad_pattern}/{project.project_name}"
+        good_pattern = f"/my/path/{project.project_name}"
+
         if path_type == "local_path":
             local_path = bad_pattern
             central_path = good_pattern


### PR DESCRIPTION
closes #146.

Syntax that is common on macOS / Linux for filepaths e.g. `./folder` for `~/myfolder` do not work by default. They are also [not supported in rclone)[https://forum.rclone.org/t/tilde-expansion-for-local-filesystem/33751], at least `~`. As such raise an error if it is attempted to make a local or central path starting with these characters.

Strangely, `Path(./my/path)` kept been shorted to `/my/path`), not exactly sure why, but for this reason this case is not handleded.
