### PR TITLE
Remove `use_` datatype e.g. `use_behav` configurations.

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -520,34 +520,6 @@ def construct_parser():
         action="store_true",
         help=help("flag_default_false"),
     )
-    make_config_file_parser.add_argument(
-        "--use-ephys",
-        "--use_ephys",
-        required=False,
-        action="store_true",
-        help=help("flag_default_false"),
-    )
-    make_config_file_parser.add_argument(
-        "--use-behav",
-        "--use_behav",
-        required=False,
-        action="store_true",
-        help=help("flag_default_false"),
-    )
-    make_config_file_parser.add_argument(
-        "--use-funcimg",
-        "--use_funcimg",
-        required=False,
-        action="store_true",
-        help=help("flag_default_false"),
-    )
-    make_config_file_parser.add_argument(
-        "--use-histology",
-        "--use_histology",
-        required=False,
-        action="store_true",
-        help=help("flag_default_false"),
-    )
 
     make_config_file_parser = subparsers.add_parser(
         "update-config",

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -599,7 +599,7 @@ def construct_parser():
         type=str,
         nargs="+",
         required=False,
-        default="all",  # TODO: this is not nice, should read the default from API NOT duplicate in CLI
+        default="",  # TODO: this is not nice, should read the default from API NOT duplicate in CLI
         help=help("required_str_single_or_multiple_or_all"),
     )
 

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -54,7 +54,7 @@ def get_flags() -> List[str]:
     Return all configs that are bool flags. This is used in
     testing and type checking config inputs.
     """
-    return get_datatypes() + [
+    return [
         "overwrite_old_files",
         "show_transfer_progress",
     ]

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -38,24 +38,15 @@ def get_canonical_config_dict() -> dict:
         "show_transfer_progress": None,
     }
 
-    datatype_configs = get_datatypes(as_dict=True)
-    config_dict.update(datatype_configs)
-
     return config_dict
 
 
-def get_datatypes(as_dict: bool = False):
+def get_datatypes() -> List[str]:
     """
-    Canonical list of datatype flags. This is used
-    to define get_canonical_config_dict() as well
-    as in testing.
+    Canonical list of datatype flags based on
+    NeuroBlueprint.
     """
-    keys = ["use_ephys", "use_behav", "use_funcimg", "use_histology"]
-
-    if as_dict:
-        return dict(zip(keys, [None] * len(keys)))
-    else:
-        return keys
+    return ["ephys", "behav", "funcimg", "histology"]
 
 
 def get_flags() -> List[str]:
@@ -83,10 +74,6 @@ def get_canonical_config_required_types() -> dict:
         "overwrite_old_files": bool,
         "transfer_verbosity": Literal["v", "vv"],
         "show_transfer_progress": bool,
-        "use_ephys": bool,
-        "use_behav": bool,
-        "use_funcimg": bool,
-        "use_histology": bool,
     }
 
     assert (
@@ -167,12 +154,6 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
                 f"The last folder in the passed {path_type} should be {project_name}.\n"
                 f"The passed path was {config_dict[path_type]}"
             )
-
-    if not any([config_dict[key] for key in get_datatypes()]):
-        utils.log_and_raise_error(
-            f"At least one datatype must be True in "
-            f"configs, from: {' '.join(get_datatypes())}."
-        )
 
     # Check SSH settings
     if config_dict["connection_method"] == "ssh" and (

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -36,40 +36,23 @@ def get_datatype_folders(cfg: Configs) -> dict:
         This should always match the canonical name, but left as
         an option for rare cases in which advanced users want to change it.
 
-    used : whether the folder is used or not (see make_config_file)
-        if False, the folder will not be made in make_folders
-        even if selected.
-
     level : "sub" or "ses", level to make the folder at.
-
-    Notes
-    ------
-
-    In theory, adding a new  folder should only require
-    adding an entry to this dictionary. However, this will not
-    update configs e.g. use_xxx. This has not been
-    directly tested yet, but if it does not work when attempted
-    it should be configured to from then on.
     """
     return {
         "ephys": Folder(
             name="ephys",
-            used=cfg["use_ephys"],
             level="ses",
         ),
         "behav": Folder(
             name="behav",
-            used=cfg["use_behav"],
             level="ses",
         ),
         "funcimg": Folder(
             name="funcimg",
-            used=cfg["use_funcimg"],
             level="ses",
         ),
         "histology": Folder(
             name="histology",
-            used=cfg["use_histology"],
             level="sub",
         ),
     }

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -180,11 +180,7 @@ class DataShuttle:
                 folders are made.
         datatype :
                 The datatype to make in the sub / ses folders.
-                (e.g. "ephys", "behav", "histology"). Only datatypes
-                that are enabled in the configs (e.g. use_behav) will be
-                created. If "all" is selected, folders will be created
-                for all datatype enabled in config. Use empty string "" for
-                none.
+                (e.g. "ephys", "behav", "histology").
 
         Notes
         -----
@@ -616,10 +612,6 @@ class DataShuttle:
         overwrite_old_files: bool = False,
         transfer_verbosity: str = "v",
         show_transfer_progress: bool = False,
-        use_ephys: bool = False,
-        use_behav: bool = False,
-        use_funcimg: bool = False,
-        use_histology: bool = False,
     ) -> None:
         """
         Initialise the configurations for datashuttle to use on the
@@ -680,18 +672,6 @@ class DataShuttle:
 
         show_transfer_progress :
             If true, the real-time progress of file transfers will be printed.
-
-        use_ephys :
-            if True, will allow ephys folder creation
-
-        use_funcimg :
-            if True, will allow funcimg folder creation
-
-        use_histology :
-            if True, will allow histology folder creation
-
-        use_behav :
-            if True, will allow behav folder creation
         """
         self._start_log(
             "make-config-file",
@@ -712,10 +692,6 @@ class DataShuttle:
                 "overwrite_old_files": overwrite_old_files,
                 "transfer_verbosity": transfer_verbosity,
                 "show_transfer_progress": show_transfer_progress,
-                "use_ephys": use_ephys,
-                "use_behav": use_behav,
-                "use_funcimg": use_funcimg,
-                "use_histology": use_histology,
             },
         )
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -159,7 +159,7 @@ class DataShuttle:
         self,
         sub_names: Union[str, list],
         ses_names: Optional[Union[str, list]] = None,
-        datatype: Union[List[str], str] = "all",
+        datatype: str = "",
     ) -> None:
         """
         Create a subject / session folder tree in the project
@@ -182,7 +182,8 @@ class DataShuttle:
                 The datatype to make in the sub / ses folders.
                 (e.g. "ephys", "behav", "histology"). If "all"
                 is selected, all datatypes permitted in
-                NeuroBlueprint will be created.
+                NeuroBlueprint will be created. If "" is passed
+                no datatype will be created.
 
         Notes
         -----

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -180,7 +180,9 @@ class DataShuttle:
                 folders are made.
         datatype :
                 The datatype to make in the sub / ses folders.
-                (e.g. "ephys", "behav", "histology").
+                (e.g. "ephys", "behav", "histology"). If "all"
+                is selected, all datatypes permitted in
+                NeuroBlueprint will be created.
 
         Notes
         -----

--- a/datashuttle/utils/folder_class.py
+++ b/datashuttle/utils/folder_class.py
@@ -9,9 +9,7 @@ class Folder:
     def __init__(
         self,
         name: str,
-        used: bool,
         level: str,
     ):
         self.name = name
-        self.used = used
         self.level = level

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -104,7 +104,7 @@ def make_datatype_folders(
     datatype_items = cfg.get_datatype_items(datatype)
 
     for datatype_key, datatype_folder in datatype_items:  # type: ignore
-        if datatype_folder.used and datatype_folder.level == level:
+        if datatype_folder.level == level:
             datatype_path = sub_or_ses_level_path / datatype_folder.name
 
             make_folders(datatype_path, log)

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -68,8 +68,6 @@ The command `make-config-file` is used for the initial setup of the project. The
 
 `connection_method`: `local_filesystem` or `ssh`. Local filesystem can be used if the *central* storage is mounted to the local machine. Otherwise `ssh` can be used.
 
-Finally, the *datatype* flags `--use_ephys`, `--use_funcimg`, `--use_histology`, `--use_behav` set the types of data required for the project on the local machine. While individual flags are optional, at least one must be chosen when initialising the project.
-
 ### Optional Arguments
 
 If connection method is `ssh`, the `central_host_id`, `central_host_username` must be set, and a one-time SSH setup command run (see the [SSH section](#ssh) for details).
@@ -134,11 +132,10 @@ Another example call, which creates a range of subject and session folders, is s
 ```
 datashuttle \
 my_first_project \
-make-folders -sub 001@TO@003 -ses 010_@TIME@ -dt all
-```
 
-When the `all` argument is used for `--datatype` (`-dt`), the folders created depend on the *datatypes* specified during *configuration* setup. For example, if
-`--use_behav`, `--use_funcimg`, `--use_histology` were set during *configuration* setup, the folder tree from the above command (assuming the time is `4.02.48 PM`), would look like:
+make-sub-folders -sub 001@TO@003 -ses 010_@TIME@ -dt behav funcimg histology
+
+When the `all` argument is used for `--datatype` (`-dt`), the folders created depend on the *datatypes* specified during *configuration* setup.
 
 ```
 ├── sub-001/
@@ -330,9 +327,6 @@ project.make_config_file(
 	central_host_username="username",
 	overwrite_old_files=True,
 	transfer_verbosity="v",
-	use_ephys=True,
-	use_behav=True,
-	use_histology=True,
 )
 ```
 

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -90,7 +90,7 @@ ssh \
 --central_host_id ssh.swc.ucl.ac.uk \
 --central_host_username username \
 --transfer_verbosity v \
---use-ephys --use-behav --use-histology --overwrite_old_files
+--overwrite_old_files
 ```
 
 
@@ -134,8 +134,6 @@ datashuttle \
 my_first_project \
 
 make-sub-folders -sub 001@TO@003 -ses 010_@TIME@ -dt behav funcimg histology
-
-When the `all` argument is used for `--datatype` (`-dt`), the folders created depend on the *datatypes* specified during *configuration* setup.
 
 ```
 ├── sub-001/

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -93,8 +93,6 @@ class TestCommandLineInterface(BaseTest):
         CLI to make config file with defaults and check
         the internal arguments are ordered and in
         the expected form. Strip flags that are always false.
-        Note use_behav is always on as a required argument,
-        as at least one use_x argument must be true.
 
         Note any bool option is automatically included in the kwargs
         output from the CLI and passed to API. This is because initially
@@ -382,7 +380,7 @@ class TestCommandLineInterface(BaseTest):
             base_folder=test_utils.get_top_level_folder_path(project),
             subs=subs,
             sessions=ses,
-            folder_used=test_utils.get_default_folder_used(),
+            folder_used=test_utils.get_all_folders_used(),
         )
 
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
@@ -436,10 +434,7 @@ class TestCommandLineInterface(BaseTest):
             base_path_to_check=os.path.join(
                 base_path_to_check, project.cfg.top_level_folder
             ),
-            datatype_to_transfer=[
-                flag.split("use_")[1]
-                for flag in canonical_configs.get_datatypes()
-            ],
+            datatype_to_transfer=canonical_configs.get_datatypes(),
             subs_to_upload=subs,
             ses_to_upload=sessions,
         )
@@ -495,7 +490,7 @@ class TestCommandLineInterface(BaseTest):
         Check that error from API are propagated to CLI
         """
         _, stderr = test_utils.run_cli(
-            f"make_config_file {clean_project_name} {clean_project_name} ssh --use_behav",
+            f"make_config_file {clean_project_name} {clean_project_name} ssh",
             clean_project_name,
         )
 

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -87,7 +87,6 @@ class TestConfigs(BaseTest):
                 no_cfg_project.project_name,
                 no_cfg_project.project_name,
                 "ssh",
-                use_behav=True,
             )
 
         assert (
@@ -112,7 +111,6 @@ class TestConfigs(BaseTest):
             tmp_path / "test_local_path" / no_cfg_project.project_name,
             tmp_path / "test_central_path" / no_cfg_project.project_name,
             "local_filesystem",
-            use_behav=True,
         )
 
         if argument_type in ["central_host_id", "both"]:
@@ -249,7 +247,7 @@ class TestConfigs(BaseTest):
             tmp_path, project.project_name
         )
 
-        del missing_key_configs["use_histology"]
+        del missing_key_configs["transfer_verbosity"]
 
         test_utils.dump_config(missing_key_configs, bad_configs_path)
 
@@ -258,7 +256,7 @@ class TestConfigs(BaseTest):
 
         assert (
             str(e.value) == "Loading Failed. "
-            "The key 'use_histology' was not found in "
+            "The key 'transfer_verbosity' was not found in "
             "the config. Config file was not updated."
         )
 
@@ -271,7 +269,7 @@ class TestConfigs(BaseTest):
         wrong_key_configs = test_utils.get_test_config_arguments_dict(
             tmp_path, project.project_name
         )
-        wrong_key_configs["use_mismology"] = "wrong"
+        wrong_key_configs["transfer_merbosity"] = "wrong"
         test_utils.dump_config(wrong_key_configs, bad_configs_path)
 
         with pytest.raises(BaseException) as e:
@@ -279,12 +277,15 @@ class TestConfigs(BaseTest):
 
         assert (
             str(e.value) == "The config contains an "
-            "invalid key: use_mismology. "
+            "invalid key: transfer_merbosity. "
             "Config file was not updated."
         )
 
     def test_supplied_config_file_bad_types(self, project, tmp_path):
-        """ """
+        """
+        Test the situation when configs with incorrect types are passed
+        in a supplied config.
+        """
         bad_configs_path = project._datashuttle_path / "bad_config.yaml"
 
         for key in project.cfg.keys():
@@ -323,8 +324,19 @@ class TestConfigs(BaseTest):
                     f"Config file was not updated."
                 )
 
-    def test_supplied_config_file_changes_wrong_order(self, project, tmp_path):
-        bad_order_configs_path = project._datashuttle_path / "new_configs.yaml"
+    def test_supplied_config_file_changes_wrong_order(
+        self, project, tmp_path
+    ):
+        """
+        Test the situation when a config file is passed with variables in
+        the wrong order.
+
+        TODO: why should this matter? They should be able to be in
+        any order and just converted to dict?
+        """
+        bad_order_configs_path = (
+            project._datashuttle_path / "new_configs.yaml"
+        )
         good_order_configs = test_utils.get_test_config_arguments_dict(
             tmp_path, project.project_name
         )
@@ -410,7 +422,6 @@ class TestConfigs(BaseTest):
             tmp_path / "project_1",
             tmp_path / "project_1",
             "local_filesystem",
-            use_behav=True,
         )
 
         # project 2 will not be found, because it does not
@@ -422,7 +433,6 @@ class TestConfigs(BaseTest):
             tmp_path / "project_3",
             tmp_path / "project_3",
             "local_filesystem",
-            use_behav=True,
         )
 
         (

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -72,7 +72,6 @@ class TestConfigs(BaseTest):
                 local_path,
                 central_path,
                 "local_filesystem",
-                use_behav=True,
             )
 
         assert "must contain the full folder path with no " in str(e.value)

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -324,9 +324,7 @@ class TestConfigs(BaseTest):
                     f"Config file was not updated."
                 )
 
-    def test_supplied_config_file_changes_wrong_order(
-        self, project, tmp_path
-    ):
+    def test_supplied_config_file_changes_wrong_order(self, project, tmp_path):
         """
         Test the situation when a config file is passed with variables in
         the wrong order.
@@ -334,9 +332,7 @@ class TestConfigs(BaseTest):
         TODO: why should this matter? They should be able to be in
         any order and just converted to dict?
         """
-        bad_order_configs_path = (
-            project._datashuttle_path / "new_configs.yaml"
-        )
+        bad_order_configs_path = project._datashuttle_path / "new_configs.yaml"
         good_order_configs = test_utils.get_test_config_arguments_dict(
             tmp_path, project.project_name
         )

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -47,7 +47,7 @@ class TestFileTransfer(BaseTest):
             os.path.join(base_path_to_check, project.cfg.top_level_folder),
             subs,
             sessions,
-            test_utils.get_default_folder_used(),
+            test_utils.get_all_folders_used(),
         )
 
     def test_empty_folder_is_not_transferred(self, project):
@@ -128,7 +128,7 @@ class TestFileTransfer(BaseTest):
                 os.path.join(base_path_to_check, project.cfg.top_level_folder),
                 subs,
                 sessions,
-                test_utils.get_default_folder_used(),
+                test_utils.get_all_folders_used(),
             )
 
     @pytest.mark.parametrize(

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -432,7 +432,8 @@ class TestFileTransfer(BaseTest):
             Path("rawdata") / "sub-001" / "histology" / "test_file.txt"
         )
 
-        project.make_folders("sub-001")
+        project.make_folders("sub-001", datatype="histology")
+
         local_test_file_path = project.cfg["local_path"] / path_to_test_file
         central_test_file_path = (
             project.cfg["central_path"] / path_to_test_file
@@ -531,7 +532,9 @@ class TestFileTransfer(BaseTest):
 
     def setup_specific_file_or_folder_files(self, project):
         """ """
-        project.make_folders(["sub-001", "sub-002"], "ses-003")
+        project.make_folders(
+            ["sub-001", "sub-002"], "ses-003", ["behav", "ephys"]
+        )
 
         path_to_test_file_behav = (
             Path("rawdata")

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -108,7 +108,6 @@ class TestLogging:
             tmp_path / clean_project_name,
             clean_project_name,
             "local_filesystem",
-            use_behav=True,
         )
 
         log = self.read_log_file(project.cfg.logging_path)

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -113,7 +113,8 @@ class TestMakeFolders(BaseTest):
         """
         subs = ["sub-001", "sub-002"]
         sessions = ["ses-001", "50432"]
-        project.make_folders(subs, sessions)
+
+        project.make_folders(subs, sessions, "all")
         base_folder = test_utils.get_top_level_folder_path(project)
 
         for sub in subs:
@@ -193,7 +194,8 @@ class TestMakeFolders(BaseTest):
         # Make the folders
         sub = "sub-001"
         ses = "ses-001"
-        project.make_folders(sub, ses)
+
+        project.make_folders(sub, ses, "all")
 
         # Check the folders were not made / made.
         base_folder = test_utils.get_top_level_folder_path(project)
@@ -328,7 +330,7 @@ class TestMakeFolders(BaseTest):
         subs = ["sub-001", "sub-2"]
         sessions = ["ses-001", "ses-03"]
 
-        project.make_folders(subs, sessions)
+        project.make_folders(subs, sessions, "all")
 
         # Check folder tree is made in the desired top level folder
         test_utils.check_working_top_level_folder_only_exists(

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -164,7 +164,7 @@ class TestMakeFolders(BaseTest):
         subs = ["sub-001", "sub-002"]
         sessions = ["ses-001", "ses-002"]
 
-        project.make_sub_folders(subs, sessions, datatypes_to_make)
+        project.make_folders(subs, sessions, datatypes_to_make)
 
         # Check folder tree is not made but all others are
         test_utils.check_folder_tree_is_correct(


### PR DESCRIPTION
This PR removes `use_behav` etc arguments from datashuttle and tests. This PR is required for #229.

Now, the user must specifically pass the datatype to make each time for the API / CLI. By default, `datatype=""` meaning so datatype folders will be created. If `all` is passed, then every possible datatype will be made.

This means the user will always have to re-type the datatype. However, with the TUI we can make this simple in the GUI, and in general the API is envisioned to be used for scripting, for which this will not be a problem. 



