### PR TITLE
Remove the `.datashuttle_meta` folder that was created in datatype folders.

### DIFF
--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -109,8 +109,6 @@ def make_datatype_folders(
 
             make_folders(datatype_path, log)
 
-            make_datashuttle_metadata_folder(datatype_path, log)
-
 
 # Make Folders Helpers --------------------------------------------------------
 
@@ -136,18 +134,6 @@ def make_folders(paths: Union[Path, List[Path]], log: bool = True) -> None:
             path_.mkdir(parents=True)
             if log:
                 utils.log(f"Made folder at path: {path_}")
-
-
-def make_datashuttle_metadata_folder(
-    full_path: Path, log: bool = True
-) -> None:
-    """
-    Make a .datashuttle folder (this is created
-    in the local_path for logs and User folder
-    for configs). See make_folders() for arguments.
-    """
-    meta_folder_path = full_path / ".datashuttle_meta"
-    make_folders(meta_folder_path, log)
 
 
 def check_no_duplicate_sub_ses_key_values(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,9 +313,6 @@ def check_folder_tree_is_correct(
                         datatype_path = join(path_to_ses_folder, folder.name)
 
                     check_and_cd_folder(datatype_path)
-                    check_and_cd_folder(
-                        join(datatype_path, ".datashuttle_meta")
-                    )
 
 
 def check_folder_is_used(base_folder, folder, folder_used, key, sub, ses):

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -185,21 +185,6 @@ class TestLogging:
             str(Path("local") / project.project_name / "rawdata" / "sub-11")
             in log
         )
-
-        assert (
-            str(
-                Path(
-                    "local",
-                    project.project_name,
-                    "rawdata",
-                    "sub-11",
-                    "ses-123",
-                    "funcimg",
-                    ".datashuttle_meta",
-                )
-            )
-            in log
-        )
         assert (
             str(
                 Path(


### PR DESCRIPTION
closes #228.

This PR removes the legacy `.datashuttle_meta` that were created in every datatype folder.