### PR TITLE
[TUI] Implement Project Selection Splashscreen (4)

### DIFF
--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -167,7 +167,6 @@ class TabScreen(Screen):
                 self.query_one("#subject").value = str(event.path.stem)
             if event.path.stem.startswith("ses-"):
                 self.query_one("#session").value = str(event.path.stem)
-                self.query_one("#subject").value = str(event.path.parent.stem)
         self.prev_click_time = click_time
 
     def on_button_pressed(self, event: Button.Pressed):

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -40,10 +40,10 @@ class ProjectSelect(Screen):
         yield Label("Select project", id="name_label")
         for name in self.project_names:
             yield Button(name, id=name)
-        yield Button("New project", id="new_project")
+        yield Button("New project", id="project_select_new_project_button")
 
     def on_button_pressed(self, event: Button.Pressed):
-        if event.button.id == "new_project":
+        if event.button.id == "project_select_new_project_button":
             pass
         else:
             app.project = DataShuttle(str(event.button.id))

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -37,6 +37,10 @@ class ProjectSelect(Screen):
 
     def compose(self):
         yield Label("DataShuttle", id="main_title")
+        yield Input(
+            id="project_select_error_input",
+            placeholder="For testing, errors are shown here.",
+        )
         yield Label("Select project", id="name_label")
         for name in self.project_names:
             yield Button(name, id=name)
@@ -46,7 +50,13 @@ class ProjectSelect(Screen):
         if event.button.id == "project_select_new_project_button":
             pass
         else:
-            app.project = DataShuttle(str(event.button.id))
+            try:
+                app.project = DataShuttle(
+                    str(event.button.id)
+                )  # TODO: handle error
+            except BaseException as e:
+                self.query_one("#project_select_error_input").value = str(e)
+                return
             app.push_screen(TabScreen())
 
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -23,7 +23,10 @@ from datashuttle.utils.folders import get_existing_project_paths_and_names
 
 
 class QuitScreen(ModalScreen):
-    """Screen with a dialog to quit."""
+    """
+    Screen that renders a modal dialog window (a pop up window that
+    means no other widgets can be changed until it is closed).
+    """
 
     def __init__(self, message):
         super(QuitScreen, self).__init__()
@@ -189,21 +192,16 @@ class TuiApp(App):
     """
     The main app page for the DataShuttle TUI.
 
+    This Screen contains DataShuttle's project selection splashscreen.
+    From here, the user can select an existing project or begin
+    initializing a new project.
+
     Running this application in a main block as below
     if __name__ == __main__:
          app = MyApp()
          app.run()
 
     Initialises the TUI event loop and starts the application.
-
-    COMBINED WITH
-
-    This Screen contains DataShuttle's project selection splashscreen.
-    From here, the user can select an existing project or begin
-    initializing a new project.
-
-    TODO: the responsibility for this window is to return a valid project
-    or indicate a new project must be made.
     """
 
     tui_path = Path(__file__).parent

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -142,8 +142,6 @@ class TabScreen(Screen):
             with TabPane("Transfer", id="tabscreen_transfer_tab"):
                 yield Label("Transfer; Seems to work!")
 
-    # yield Footer()
-
     def on_directory_tree_directory_selected(
         self, event: DirectoryTree.DirectorySelected
     ):

--- a/datashuttle/tui/css/project_select.tcss
+++ b/datashuttle/tui/css/project_select.tcss
@@ -1,0 +1,27 @@
+ProjectSelect {
+    align: center middle;
+}
+ProjectSelect > #main_title {
+    border: hkey $primary;
+    content-align: center middle;
+    text-style: italic bold;
+    color: $text;
+    width: 49%;
+    padding: 1 0 0 0;
+    height: 5;
+    margin: 0 0 2 0;
+}
+ProjectSelect > Label {
+    margin: 0 0 1 0;
+}
+ProjectSelect > Button {
+    width: 50%;
+    content-align: left middle;
+    margin: 0 0 1 0;
+    background: $primary-background
+}
+ProjectSelect > #new_project {
+    text-style: italic;
+    outline: none;
+    background: $primary-background-lighten-1;
+}

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -5,7 +5,7 @@ TabScreen > TabbedContent {
     width: 90%;
     height: 100%
 }
-TabScreen > #return {
+TabScreen > #tabscreen_main_menu_button {
     layer: top;
     dock: right;
     margin: 2 1 0 0;
@@ -18,7 +18,7 @@ DirectoryTree > .directory-tree--folder:focus {
     color: $success;
 }
 
-#FileTree {
+#tabscreen_directorytree {
     dock: left;
     width: 45%;
     padding: 1 2 1 2;
@@ -26,11 +26,11 @@ DirectoryTree > .directory-tree--folder:focus {
     border: tall wide $panel-lighten-1;
 }
 
-#FileTree:focus .tree--cursor {
-    background: $panel;
+#tabscreen_directorytree:focus .tree--cursor {
+    background: $panel-lighten-2;
 }
 
-#FileTree:focus .tree--guides-selected {
+#tabscreen_directorytree:focus .tree--guides-selected {
     color: $success;
     background: $panel;
 }
@@ -40,18 +40,18 @@ DirectoryTree > .directory-tree--folder:focus {
 /* Unfortunately there is a bug with Input and hover, the response is very slow.
 and it also effects other widgets */
 
-#create > Input {
+#tabscreen_create_tab > Input {
     border: tall $panel-lighten-1;
 }
 
 /* Labels ------------------------------------------------------------------- */
 
-#create > Label {
+#tabscreen_create_tab > Label {
     width: 100%;
     margin: 1 0 1 1;
     text-style: bold;
 }
-#create > #sub_label {
+#tabscreen_create_tab > #tabscreen_subject_label {
     margin: 1 0 1 1;
     text-style: bold;
 }
@@ -59,13 +59,13 @@ and it also effects other widgets */
 
 /* Toggle Buttons ----------------------------------------------------------- */
 
-#create > TypeBox {
+#tabscreen_create_tab > TabScreenCheckboxes {
     layout: grid;
     grid-size: 4 1;
     grid-columns: 15;
     grid_rows: 5;
 }
-TypeBox > ToggleButton {
+TabScreenCheckboxes > ToggleButton {
     margin: 0 0 2 1 ;
     content-align: left middle;
     width: 15;
@@ -74,16 +74,16 @@ TypeBox > ToggleButton {
     border: transparent;
 }
 
-TypeBox > ToggleButton:focus {
+TabScreenCheckboxes > ToggleButton:focus {
     border: transparent;
 }
-TypeBox > ToggleButton:focus > .toggle--label {
+TabScreenCheckboxes > ToggleButton:focus > .toggle--label {
     text-style: none;
 }
-TypeBox > ToggleButton.-on > .toggle--button {
+TabScreenCheckboxes > ToggleButton.-on > .toggle--button {
     color: $success;
 }
-TypeBox > ToggleButton:hover > .toggle--button {
+TabScreenCheckboxes > ToggleButton:hover > .toggle--button {
     background: $panel-lighten-3;
 }
 

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -1,3 +1,18 @@
+TabScreen {
+    align: center middle;
+}
+TabbedContent {
+    width: 70%;
+    height: 100%
+}
+TabScreen > #return {
+    layer: top;
+    dock: right;
+    margin: 2 1 0 0;
+}
+TabScreen > Header {
+    margin: 0 0 1 0;
+}
 #FileTree {
     dock: left;
     width: 35%;

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -1,8 +1,8 @@
 TabScreen {
     align: center middle;
 }
-TabbedContent {
-    width: 70%;
+TabScreen > TabbedContent {
+    width: 90%;
     height: 100%
 }
 TabScreen > #return {
@@ -13,29 +13,92 @@ TabScreen > #return {
 TabScreen > Header {
     margin: 0 0 1 0;
 }
+
+DirectoryTree > .directory-tree--folder:focus {
+    color: $success;
+}
+
 #FileTree {
     dock: left;
-    width: 35%;
+    width: 45%;
     padding: 1 2 1 2;
     margin: 0 4 0 0;
+    border: tall wide $panel-lighten-1;
 }
+
+#FileTree:focus .tree--cursor {
+    background: $panel;
+}
+
+#FileTree:focus .tree--guides-selected {
+    color: $success;
+    background: $panel;
+}
+
+
+/* Input ------------------------------------------------------------------- */
+/* Unfortunately there is a bug with Input and hover, the response is very slow.
+and it also effects other widgets */
+
+#create > Input {
+    border: tall $panel-lighten-1;
+}
+
+/* Labels ------------------------------------------------------------------- */
+
 #create > Label {
     width: 100%;
     margin: 1 0 1 1;
     text-style: bold;
 }
 #create > #sub_label {
-    margin: 0 0 1 1;
+    margin: 1 0 1 1;
+    text-style: bold;
 }
+
+
+/* Toggle Buttons ----------------------------------------------------------- */
+
 #create > TypeBox {
     layout: grid;
-    grid-size: 2 2;
-    grid-columns: 25;
-    min-height: 5;
+    grid-size: 4 1;
+    grid-columns: 15;
+    grid_rows: 5;
 }
 TypeBox > ToggleButton {
-    height: 3;
-    margin: 0 0 3 1;
+    margin: 0 0 2 1 ;
     content-align: left middle;
-    width: 18;
+    width: 15;
+    background: $surface;
+    padding: 0 0;
+    border: transparent;
+}
+
+TypeBox > ToggleButton:focus {
+    border: transparent;
+}
+TypeBox > ToggleButton:focus > .toggle--label {
+    text-style: none;
+}
+TypeBox > ToggleButton.-on > .toggle--button {
+    color: $success;
+}
+TypeBox > ToggleButton:hover > .toggle--button {
+    background: $panel-lighten-3;
+}
+
+/* Buttons ----------------------------------------------------------- */
+
+Button {
+    background: $panel;
+    border-top: tall $panel-lighten-1;
+    border-bottom: tall $panel-lighten-1;
+    border-left: tall $panel-lighten-1;
+    border-right: tall $panel-lighten-1;
+}
+Button:focus {
+    text-style: bold;
+}
+Button:hover {
+    background: $panel-lighten-2;
 }

--- a/datashuttle/tui/css/tab_content.tcss
+++ b/datashuttle/tui/css/tab_content.tcss
@@ -28,6 +28,7 @@ DirectoryTree > .directory-tree--folder:focus {
 
 #tabscreen_directorytree:focus .tree--cursor {
     background: $panel-lighten-2;
+}
 
 #tabscreen_directorytree:focus .tree--guides-selected {
     color: $success;

--- a/datashuttle/tui/css/tui_app.tcss
+++ b/datashuttle/tui/css/tui_app.tcss
@@ -1,5 +1,6 @@
 #test_id {
     align: center middle;
+    overflow: scroll;
 }
 #test_id > #main_title {
     border: hkey $primary;
@@ -18,8 +19,19 @@
     width: 50%;
     content-align: left middle;
     margin: 0 0 1 0;
-    background: $primary-background
+    background: $panel;
+    border-top: tall $panel-lighten-1;
+    border-bottom: tall $panel-lighten-1;
+    border-left: tall $panel-lighten-1;
+    border-right: tall $panel-lighten-1;
 }
+#test_id > Button:focus {
+    text-style: bold;
+}
+#test_id > Button:hover {
+    background: $panel-lighten-2;
+}
+
 #test_id > Input {
     width: 50%;
     content-align: left middle;
@@ -31,4 +43,30 @@
     text-style: italic;
     outline: none;
     background: $primary-background-lighten-1;
+}
+
+
+QuitScreen {
+    align: center middle;
+}
+
+QuitScreen > #dialog {
+    height: 15;
+    width: 65;
+    border: thick $background 80%;
+    background: $surface;
+    align: center middle;
+ }
+
+#label_x {
+    align: center middle;
+    overflow: hidden scroll;
+}
+
+#real_label {
+    text-align: center;
+}
+
+#button_x {
+    align: center bottom
 }

--- a/datashuttle/tui/css/tui_app.tcss
+++ b/datashuttle/tui/css/tui_app.tcss
@@ -20,6 +20,13 @@
     margin: 0 0 1 0;
     background: $primary-background
 }
+#test_id > Input {
+    width: 50%;
+    content-align: left middle;
+    margin: 0 0 1 0;
+    background: $primary-background
+}
+
 #test_id > #new_project {
     text-style: italic;
     outline: none;

--- a/datashuttle/tui/css/tui_app.tcss
+++ b/datashuttle/tui/css/tui_app.tcss
@@ -1,8 +1,8 @@
-#test_id {
+#mainwindow_top_container {
     align: center middle;
     overflow: scroll;
 }
-#test_id > #main_title {
+#mainwindow_top_container > #mainwindow_main_title_label {
     border: hkey $primary;
     content-align: center middle;
     text-style: italic bold;
@@ -12,10 +12,10 @@
     height: 5;
     margin: 0 0 2 0;
 }
-#test_id > Label {
+#mainwindow_top_container > Label {
     margin: 0 0 1 0;
 }
-#test_id > Button {
+#mainwindow_top_container > Button {
     width: 50%;
     content-align: left middle;
     margin: 0 0 1 0;
@@ -25,21 +25,21 @@
     border-left: tall $panel-lighten-1;
     border-right: tall $panel-lighten-1;
 }
-#test_id > Button:focus {
+#mainwindow_top_container > Button:focus {
     text-style: bold;
 }
-#test_id > Button:hover {
+#mainwindow_top_container > Button:hover {
     background: $panel-lighten-2;
 }
 
-#test_id > Input {
+#mainwindow_top_container > Input {
     width: 50%;
     content-align: left middle;
     margin: 0 0 1 0;
     background: $primary-background
 }
 
-#test_id > #new_project {
+#mainwindow_top_container > #mainwindow_select_new_project_button {
     text-style: italic;
     outline: none;
     background: $primary-background-lighten-1;
@@ -50,7 +50,7 @@ QuitScreen {
     align: center middle;
 }
 
-QuitScreen > #dialog {
+QuitScreen > #quitscreen_top_container {
     height: 15;
     width: 65;
     border: thick $background 80%;
@@ -58,15 +58,15 @@ QuitScreen > #dialog {
     align: center middle;
  }
 
-#label_x {
+#quitscreen_message_container {
     align: center middle;
     overflow: hidden scroll;
 }
 
-#real_label {
+#quitscreen_message_label {
     text-align: center;
 }
 
-#button_x {
+#quitscreen_ok_button {
     align: center bottom
 }

--- a/datashuttle/tui/css/tui_app.tcss
+++ b/datashuttle/tui/css/tui_app.tcss
@@ -1,7 +1,7 @@
-ProjectSelect {
+#test_id {
     align: center middle;
 }
-ProjectSelect > #main_title {
+#test_id > #main_title {
     border: hkey $primary;
     content-align: center middle;
     text-style: italic bold;
@@ -11,16 +11,16 @@ ProjectSelect > #main_title {
     height: 5;
     margin: 0 0 2 0;
 }
-ProjectSelect > Label {
+#test_id > Label {
     margin: 0 0 1 0;
 }
-ProjectSelect > Button {
+#test_id > Button {
     width: 50%;
     content-align: left middle;
     margin: 0 0 1 0;
     background: $primary-background
 }
-ProjectSelect > #new_project {
+#test_id > #new_project {
     text-style: italic;
     outline: none;
     background: $primary-background-lighten-1;

--- a/datashuttle/tui/css/tui_app.tcss
+++ b/datashuttle/tui/css/tui_app.tcss
@@ -53,8 +53,8 @@ QuitScreen {
 QuitScreen > #quitscreen_top_container {
     height: 15;
     width: 65;
-    border: thick $background 80%;
-    background: $surface;
+    border: thick rgb(140, 12, 0);
+    background: $primary-background;
     align: center middle;
  }
 


### PR DESCRIPTION
## Description

This PR implements a new project selection splashscreen (`ProjectSelect`) for the DataShuttle TUI. This screen detects DataShuttle projects present on the local filesystem and and dynamically displays these as clickable buttons. Clicking on any project then yields a new `TabScreen` Screen object containing a `TabbedContent` widget (w/ Create and Transfer tabs) preconfigured for the selected project. The user can then easily return to the project selection splashscreen by clicking the `Return` button located at the top-right of the `TabbedContent` screen. `ProjectSelect` screen also features a dummy "New Projects" button, which will later be used to instantiate the "New project configuration" screen.

## References

Closes #217

## Checklist:

- [X] The code has been tested locally
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
