### PR TITLE
Add more exception types (not just raising `BaseException`).

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 from pathlib import Path
 from typing import Literal, Union, get_args, get_origin
 
-from datashuttle.utils import folders, utils
+from datashuttle.utils import utils
 from datashuttle.utils.custom_exceptions import ConfigError
 
 

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -8,6 +8,7 @@ import yaml
 
 from datashuttle.configs import canonical_configs, canonical_folders
 from datashuttle.utils import folders, utils
+from datashuttle.utils.custom_exceptions import ConfigError
 
 
 class Configs(UserDict):
@@ -127,7 +128,9 @@ class Configs(UserDict):
         new_info : value to update the config too
         """
         if option_key not in self:
-            utils.log_and_raise_error(f"'{option_key}' is not a valid config.")
+            utils.log_and_raise_error(
+                f"'{option_key}' is not a valid config.", ConfigError
+            )
 
         original_value = copy.deepcopy(self[option_key])
 
@@ -157,7 +160,8 @@ class Configs(UserDict):
         else:
             self[option_key] = original_value
             utils.log_and_raise_error(
-                f"\n{check_change['error']}\n{option_key} was not updated."
+                f"\n{check_change['error']}\n{option_key} was not updated.",
+                ConfigError,
             )
 
     def safe_check_current_dict_is_valid(self) -> dict:
@@ -205,7 +209,8 @@ class Configs(UserDict):
 
                 else:
                     utils.log_and_raise_error(
-                        "Option must be 'path_to_str' or 'str_to_path'"
+                        "Option must be 'path_to_str' or 'str_to_path'",
+                        ValueError,
                     )
 
     def make_path(self, base: str, sub_folders: Union[str, list]) -> Path:

--- a/datashuttle/configs/load_configs.py
+++ b/datashuttle/configs/load_configs.py
@@ -8,6 +8,7 @@ from . import canonical_configs
 from .config_class import Configs
 
 ConfigValueTypes = Union[Path, str, bool, None]
+from datashuttle.utils.custom_exceptions import ConfigError
 
 # -----------------------------------------------------------------------------
 # Load Supplied Config
@@ -56,7 +57,8 @@ def make_config_file_attempt_load(
             f"Config file failed to load. Check file "
             f"formatting at {config_path.as_posix()}. If "
             f"cannot load, re-initialise configs with "
-            f"make_config_file()"
+            f"make_config_file()",
+            ConfigError,
         )
 
     return new_cfg
@@ -149,7 +151,8 @@ def handle_bool(key: str, value: ConfigValueTypes) -> ConfigValueTypes:
         if isinstance(value, str):
             if value not in ["True", "False", "true", "false"]:
                 utils.raise_error(
-                    f"Input value for '{key}' must be True or False"
+                    f"Input value for '{key}' must be True or False",
+                    ValueError,
                 )
 
             value = value in ["True", "true"]

--- a/datashuttle/configs/load_configs.py
+++ b/datashuttle/configs/load_configs.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from typing import Optional, Union, overload
 
 from datashuttle.utils import utils
+from datashuttle.utils.custom_exceptions import ConfigError
 
 from . import canonical_configs
 from .config_class import Configs
 
 ConfigValueTypes = Union[Path, str, bool, None]
-from datashuttle.utils.custom_exceptions import ConfigError
 
 # -----------------------------------------------------------------------------
 # Load Supplied Config
@@ -152,7 +152,7 @@ def handle_bool(key: str, value: ConfigValueTypes) -> ConfigValueTypes:
             if value not in ["True", "False", "true", "false"]:
                 utils.raise_error(
                     f"Input value for '{key}' must be True or False",
-                    ValueError,
+                    ConfigError,
                 )
 
             value = value in ["True", "true"]

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -21,6 +21,10 @@ from datashuttle.utils import (
     ssh,
     utils,
 )
+from datashuttle.utils.custom_exceptions import (
+    ConfigError,
+    NeuroBlueprintError,
+)
 from datashuttle.utils.data_transfer import TransferData
 from datashuttle.utils.decorators import (  # noqa
     check_configs_set,
@@ -77,7 +81,7 @@ class DataShuttle:
     def __init__(self, project_name: str, print_startup_message: bool = True):
         if " " in project_name:
             utils.log_and_raise_error(
-                "'project_name' must not include spaces."
+                "'project_name' must not include spaces.", ValueError
             )
 
         self.project_name = project_name
@@ -145,7 +149,8 @@ class DataShuttle:
             utils.raise_error(
                 f"Folder name: {folder_name} "
                 f"is not in permitted top-level folder"
-                f" names: {canonical_top_level_folders}"
+                f" names: {canonical_top_level_folders}",
+                ValueError,
             )
 
         self.cfg.top_level_folder = folder_name
@@ -755,7 +760,8 @@ class DataShuttle:
 
         if not self.cfg:
             utils.log_and_raise_error(
-                "Must have a config loaded before updating configs."
+                "Must have a config loaded before updating configs.",
+                ConfigError,
             )
 
         new_info = load_configs.handle_bool(option_key, new_info)
@@ -1009,7 +1015,10 @@ class DataShuttle:
             e.g. "sub-" or "ses-"
         """
         if prefix not in ["sub", "ses"]:
-            utils.log_and_raise_error("'prefix' must be 'sub' or 'ses'.")
+            utils.log_and_raise_error(
+                "'prefix' must be 'sub' or 'ses'.",
+                NeuroBlueprintError,
+            )
 
         if isinstance(names, str):
             names = [names]
@@ -1142,7 +1151,8 @@ class DataShuttle:
         """
         if not self.cfg or not self.cfg["local_path"].is_dir():
             utils.log_and_raise_error(
-                "Project folder does not exist. Logs were not moved."
+                "Project folder does not exist. Logs were not moved.",
+                FileNotFoundError,
             )
 
         ds_logger.close_log_filehandler()
@@ -1230,7 +1240,8 @@ class DataShuttle:
         if setting_name not in settings:
             utils.raise_error(
                 f"Setting key {setting_name} not found in "
-                f"settings dictionary"
+                f"settings dictionary",
+                KeyError,
             )
 
         settings[setting_name] = setting_value

--- a/datashuttle/utils/custom_exceptions.py
+++ b/datashuttle/utils/custom_exceptions.py
@@ -1,4 +1,4 @@
-class ConfigError(BaseException):
+class ConfigError(Exception):
     pass
 
 

--- a/datashuttle/utils/custom_exceptions.py
+++ b/datashuttle/utils/custom_exceptions.py
@@ -2,5 +2,5 @@ class ConfigError(Exception):
     pass
 
 
-class NeuroBlueprintError(BaseException):
+class NeuroBlueprintError(Exception):
     pass

--- a/datashuttle/utils/custom_exceptions.py
+++ b/datashuttle/utils/custom_exceptions.py
@@ -1,0 +1,6 @@
+class ConfigError(BaseException):
+    pass
+
+
+class NeuroBlueprintError(BaseException):
+    pass

--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -268,21 +268,24 @@ class TransferData:
             [name in ["all", "all_sub"] for name in self.sub_names]
         ):
             utils.log_and_raise_error(
-                "'sub_names' must only include 'all' or 'all_subs' if these options are used."
+                "'sub_names' must only include 'all' or 'all_subs' if these options are used.",
+                ValueError,
             )
 
         if len(self.ses_names) > 1 and any(
             [name in ["all", "all_ses"] for name in self.ses_names]
         ):
             utils.log_and_raise_error(
-                "'ses_names' must only include 'all' or 'all_ses' if these options are used."
+                "'ses_names' must only include 'all' or 'all_ses' if these options are used.",
+                ValueError,
             )
 
         if len(self.datatype) > 1 and any(
             [name in ["all", "all_datatype"] for name in self.datatype]
         ):
             utils.log_and_raise_error(
-                "'datatype' must only include 'all' or 'all_datatype' if these options are used."
+                "'datatype' must only include 'all' or 'all_datatype' if these options are used.",
+                ValueError,
             )
 
     # -----------------------------------------------------------------------------

--- a/datashuttle/utils/decorators.py
+++ b/datashuttle/utils/decorators.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from datashuttle.utils.custom_exceptions import ConfigError
 from datashuttle.utils.utils import log_and_raise_error
 
 
@@ -18,7 +19,8 @@ def requires_ssh_configs(func):
             log_and_raise_error(
                 "Cannot setup SSH connection, 'central_host_id' "
                 "or 'central_host_username' is not set in "
-                "the configuration file."
+                "the configuration file.",
+                ConfigError,
             )
         else:
             return func(*args, **kwargs)
@@ -38,7 +40,8 @@ def check_configs_set(func):
         if args[0].cfg is None:
             log_and_raise_error(
                 "Must set configs with make_config_file() "
-                "before using this function."
+                "before using this function.",
+                ConfigError,
             )
         else:
             return func(*args, **kwargs)

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
 
 from datashuttle.configs import canonical_folders, canonical_tags
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 from . import folders, formatting, ssh, utils
 
@@ -230,16 +231,16 @@ def check_new_subject_does_not_duplicate_existing(
             f"Cannot make folders. Multiple {prefix} ids "
             f"exist: {matched_existing_names}. This should"
             f"never happen. Check the {prefix} ids and ensure unique {prefix} "
-            f"ids (e.g. sub-001) appear only once."
-        )
+            f"ids (e.g. sub-001) appear only once.",
+        NeuroBlueprintError)
 
     if len(matched_existing_names) == 1:
         if new_name != matched_existing_names[0]:
             utils.log_and_raise_error(
                 f"Cannot make folders. A {prefix} already exists "
                 f"with the same {prefix} id as {new_name}. "
-                f"The existing folder is {matched_existing_names[0]}."
-            )
+                f"The existing folder is {matched_existing_names[0]}.",
+            NeuroBlueprintError)
 
 
 # -----------------------------------------------------------------------------
@@ -290,7 +291,8 @@ def search_sub_or_ses_level(
     if ses and not sub:
         utils.log_and_raise_error(
             "cannot pass session to "
-            "search_sub_or_ses_level() without subject"
+            "search_sub_or_ses_level() without subject",
+            ValueError,
         )
 
     if sub:
@@ -614,7 +616,10 @@ def get_next_sub_or_ses_number(
     all_folders = list(set(folder_names["local"] + folder_names["central"]))
 
     if len(all_folders) == 0:
-        utils.raise_error("No folders found. Cannot suggest the next number.")
+        # This will be removed in another PR.
+        utils.raise_error(
+            "No folders found. Cannot suggest the next number.", BaseException
+        )
 
     all_value_nums = utils.get_values_from_bids_formatted_name(
         all_folders,
@@ -660,8 +665,10 @@ def get_existing_project_paths_and_names() -> Tuple[List[str], List[Path]]:
             utils.raise_error(
                 f"There are two config files in project"
                 f"{folder_name} at path {datashuttle_path}. There "
-                f"should only ever be one config per project. "
+                f"should only ever be one config per project. ",
+                RuntimeError,
             )
+
         elif len(config_file) == 1:
             existing_project_paths.append(datashuttle_path / folder_name)
             existing_project_names.append(folder_name)

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -12,10 +12,9 @@ import warnings
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
 
-from datashuttle.configs import canonical_folders, canonical_tags
-from datashuttle.utils.custom_exceptions import NeuroBlueprintError
-
+from ..configs import canonical_folders, canonical_tags
 from . import folders, formatting, ssh, utils
+from .custom_exceptions import NeuroBlueprintError
 
 # -----------------------------------------------------------------------------
 # Make Folders
@@ -618,9 +617,9 @@ def get_next_sub_or_ses_number(
     all_folders = list(set(folder_names["local"] + folder_names["central"]))
 
     if len(all_folders) == 0:
-        # This will be removed in another PR.
         utils.raise_error(
-            "No folders found. Cannot suggest the next number.", BaseException
+            "No folders found. Cannot suggest the next number.",
+            NeuroBlueprintError,
         )
 
     all_value_nums = utils.get_values_from_bids_formatted_name(
@@ -633,7 +632,7 @@ def get_next_sub_or_ses_number(
     if not utils.integers_are_consecutive(all_value_nums):
         warnings.warn(
             f"A subject number has been skipped, "
-            f"currently used subject numbers are: {all_value_nums}"
+            f"currently used subject numbers are: {all_value_nums}",
         )
 
     # calculate next sub number
@@ -668,9 +667,8 @@ def get_existing_project_paths_and_names() -> Tuple[List[str], List[Path]]:
                 f"There are two config files in project"
                 f"{folder_name} at path {datashuttle_path}. There "
                 f"should only ever be one config per project. ",
-                RuntimeError,
+                NeuroBlueprintError,
             )
-
         elif len(config_file) == 1:
             existing_project_paths.append(datashuttle_path / folder_name)
             existing_project_names.append(folder_name)

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -232,7 +232,8 @@ def check_new_subject_does_not_duplicate_existing(
             f"exist: {matched_existing_names}. This should"
             f"never happen. Check the {prefix} ids and ensure unique {prefix} "
             f"ids (e.g. sub-001) appear only once.",
-        NeuroBlueprintError)
+            NeuroBlueprintError,
+        )
 
     if len(matched_existing_names) == 1:
         if new_name != matched_existing_names[0]:
@@ -240,7 +241,8 @@ def check_new_subject_does_not_duplicate_existing(
                 f"Cannot make folders. A {prefix} already exists "
                 f"with the same {prefix} id as {new_name}. "
                 f"The existing folder is {matched_existing_names[0]}.",
-            NeuroBlueprintError)
+                NeuroBlueprintError,
+            )
 
 
 # -----------------------------------------------------------------------------

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
 
 from datashuttle.configs.canonical_folders import canonical_reserved_keywords
 from datashuttle.configs.canonical_tags import tags
-
 from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 if TYPE_CHECKING:
@@ -106,7 +105,9 @@ def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:
         )
 
     if any([" " in ele for ele in names]):
-        utils.log_and_raise_error(f"{prefix} names cannot include spaces.", NeuroBlueprintError)
+        utils.log_and_raise_error(
+            f"{prefix} names cannot include spaces.", NeuroBlueprintError
+        )
 
     prefixed_names = ensure_prefixes_on_list_of_names(names, prefix)
 
@@ -138,13 +139,15 @@ def check_names_for_duplicate_ids_and_inconsistent_leading_zeros(
     if not all_identical(value_len):
         utils.log_and_raise_error(
             f"The length of the {prefix} values (e.g. '001') must be "
-            f"consistent across all {prefix} names."
+            f"consistent across all {prefix} names.",
+            NeuroBlueprintError,
         )
 
     if not all_unique(int_values):
         utils.log_and_raise_error(
             f"{prefix} names must all have unique integer ids"
-            f" after the {prefix} prefix."
+            f" after the {prefix} prefix.",
+            NeuroBlueprintError,
         )
 
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
 from datashuttle.configs.canonical_folders import canonical_reserved_keywords
 from datashuttle.configs.canonical_tags import tags
 
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
+
 if TYPE_CHECKING:
     from datashuttle.configs.config_class import Configs
 
@@ -100,11 +102,11 @@ def format_names(names: List, prefix: Literal["sub", "ses"]) -> List[str]:
         [not isinstance(ele, str) for ele in names]
     ):
         utils.log_and_raise_error(
-            f"Ensure {prefix} names are a list of strings."
+            f"Ensure {prefix} names are a list of strings.", TypeError
         )
 
     if any([" " in ele for ele in names]):
-        utils.log_and_raise_error(f"{prefix} names cannot include spaces.")
+        utils.log_and_raise_error(f"{prefix} names cannot include spaces.", NeuroBlueprintError)
 
     prefixed_names = ensure_prefixes_on_list_of_names(names, prefix)
 
@@ -185,7 +187,8 @@ def update_names_with_range_to_flag(
 
             if tags("to") not in tag_number:
                 utils.log_and_raise_error(
-                    f"{tags('to')} flag must be between two numbers in the {prefix} tag."
+                    f"{tags('to')} flag must be between two numbers in the {prefix} tag.",
+                    ValueError,
                 )
 
             left_number, right_number = tag_number.split(tags("to"))
@@ -193,7 +196,8 @@ def update_names_with_range_to_flag(
             if int(left_number) >= int(right_number):
                 utils.log_and_raise_error(
                     f"Number of the {prefix} to the  left of {tags('to')} flag "
-                    f"must be smaller than the number to the right."
+                    f"must be smaller than the number to the right.",
+                    ValueError,
                 )
 
             names_with_new_number_inserted = (
@@ -220,7 +224,8 @@ def check_name_is_formatted_correctly(name: str, prefix: str) -> None:
     if not re.fullmatch(expected_format, first_key_value_pair):
         utils.log_and_raise_error(
             f"The name: {name} is not in required format for {tags('to')} keyword. "
-            f"The start must be  be {prefix}-<NUMBER>{tags('to')}<NUMBER>)."
+            f"The start must be  be {prefix}-<NUMBER>{tags('to')}<NUMBER>).",
+            ValueError,
         )
 
 
@@ -374,7 +379,8 @@ def check_datatype_is_valid(
             f"datatype: '{datatype}' "
             f"is not valid. Must be one of"
             f" {list(cfg.datatype_folders.keys())}. or 'all'"
-            f" No folders were made."
+            f" No folders were made.",
+            NeuroBlueprintError,
         )
 
     return is_valid
@@ -391,7 +397,8 @@ def check_dashes_and_underscore_alternate_correctly(all_names):
         if dashes_underscores[0] != 1:
             utils.log_and_raise_error(
                 "The first delimiter of 'sub' or 'ses' "
-                "must be dash not underscore e.g. sub-001."
+                "must be dash not underscore e.g. sub-001.",
+                NeuroBlueprintError,
             )
 
         if len(dashes_underscores) % 2 != 0:
@@ -400,7 +407,8 @@ def check_dashes_and_underscore_alternate_correctly(all_names):
         if any([ele == 0 for ele in utils.diff(dashes_underscores)]):
             utils.log_and_raise_error(
                 "Subject and session names must contain alternating dashes and "
-                "underscores (used for separating key-value pairs)."
+                "underscores (used for separating key-value pairs).",
+                NeuroBlueprintError,
             )
 
 

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -54,7 +54,8 @@ def setup_ssh_key(
             f"Try running using the command-line-interface with "
             f"'datashuttle {cfg.project_name} "
             f"setup-ssh-connection-to-central-server' "
-            f"or in a terminal rather than IDE console."
+            f"or in a terminal rather than IDE console.",
+            RuntimeError,
         )
 
     generate_and_write_ssh_key(cfg.ssh_key_path)
@@ -115,7 +116,8 @@ def connect_client(
             f"3) The central_host_id: {cfg['central_host_id']} is"
             f" correct.\n"
             f"4) The central username:"
-            f" {cfg['central_host_username']}, and password are correct."
+            f" {cfg['central_host_username']}, and password are correct.",
+            ConnectionError,
         )
 
 

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -64,7 +64,7 @@ def get_user_input(message: str) -> str:
 
 def raise_error(message: str, exception) -> None:
     """
-    Temporary centralized way to raise and error
+    Centralized way to raise an error
     """
     raise exception(message)
 
@@ -105,9 +105,6 @@ def log_and_raise_error_not_exists_or_not_yaml(path_to_config: Path) -> None:
 
     if path_to_config.suffix not in [".yaml", ".yml"]:
         log_and_raise_error("The config file must be a YAML file.", ValueError)
-
-
-# TODO: test this method
 
 
 @overload

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -4,9 +4,11 @@ import logging
 import re
 import traceback
 from pathlib import Path
-from typing import List, Literal, Union, overload
+from typing import Any, List, Literal, Union, overload
 
 from rich import print as rich_print
+
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 # --------------------------------------------------------------------------------------
 # General Utils
@@ -31,14 +33,14 @@ def log_and_message(message: str, use_rich: bool = False) -> None:
     print_message_to_user(message, use_rich)
 
 
-def log_and_raise_error(message: str) -> None:
+def log_and_raise_error(message: str, exception: Any) -> None:
     """
     Log the message before raising the same message as an error.
     """
     logger = logging.getLogger("datashuttle")
     logger.error(f"\n\n{' '.join(traceback.format_stack(limit=5))}")
     logger.error(message)
-    raise_error(message)
+    raise_error(message, exception)
 
 
 def print_message_to_user(message: Union[str, list], use_rich=False) -> None:
@@ -60,11 +62,11 @@ def get_user_input(message: str) -> str:
     return input_
 
 
-def raise_error(message: str) -> None:
+def raise_error(message: str, exception) -> None:
     """
     Temporary centralized way to raise and error
     """
-    raise BaseException(message)
+    raise exception(message)
 
 
 def get_path_after_base_folder(base_folder: Path, path_: Path) -> Path:
@@ -97,10 +99,12 @@ def log_and_raise_error_not_exists_or_not_yaml(path_to_config: Path) -> None:
     supplied config path is indeed .yaml.
     """
     if not path_to_config.exists():
-        log_and_raise_error(f"No file found at: {path_to_config}.")
+        log_and_raise_error(
+            f"No file found at: {path_to_config}.", FileNotFoundError
+        )
 
     if path_to_config.suffix not in [".yaml", ".yml"]:
-        log_and_raise_error("The config file must be a YAML file.")
+        log_and_raise_error("The config file must be a YAML file.", ValueError)
 
 
 # TODO: test this method
@@ -139,22 +143,26 @@ def get_values_from_bids_formatted_name(
     all_values = []
     for name in all_names:
         if key not in name:
-            raise_error(f"The key {key} is not found in {name}")
+            raise_error(f"The key {key} is not found in {name}", KeyError)
 
         value = get_value_from_key_regexp(name, key)
 
         if len(value) > 1:
             raise_error(
                 f"There is more than instance of {key} in {name}. "
-                f"BIDS names must contain only one instance of "
-                f"each key."
+                f"NeuroBlueprint names must contain only one instance of "
+                f"each key.",
+                NeuroBlueprintError,
             )
 
         if return_as_int:
             try:
                 value_to_append = int(value[0])
             except ValueError:
-                raise_error(f"Invalid character in subject number: {name}")
+                raise_error(
+                    f"Invalid character in subject number: {name}",
+                    NeuroBlueprintError,
+                )
         else:
             value_to_append = value[0]
 

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -10,6 +10,7 @@ from datashuttle.configs.canonical_configs import (
     get_canonical_config_required_types,
 )
 from datashuttle.utils import folders
+from datashuttle.utils.custom_exceptions import ConfigError
 
 
 class TestConfigs(BaseTest):
@@ -67,7 +68,7 @@ class TestConfigs(BaseTest):
             local_path = good_pattern
             central_path = bad_pattern
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ConfigError) as e:
             project.make_config_file(
                 local_path,
                 central_path,
@@ -81,7 +82,7 @@ class TestConfigs(BaseTest):
         Check that program will assert if not all ssh options
         are set on make_config_file
         """
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ConfigError) as e:
             no_cfg_project.make_config_file(
                 no_cfg_project.project_name,
                 no_cfg_project.project_name,
@@ -124,7 +125,7 @@ class TestConfigs(BaseTest):
             no_cfg_project.update_config("connection_method", "ssh")
             assert no_cfg_project.cfg["connection_method"] == "ssh"
         else:
-            with pytest.raises(BaseException) as e:
+            with pytest.raises(ConfigError) as e:
                 no_cfg_project.update_config("connection_method", "ssh")
 
             assert (
@@ -221,7 +222,7 @@ class TestConfigs(BaseTest):
 
         non_existant_path = project._datashuttle_path / "fake.file"
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(FileNotFoundError) as e:
             project.supply_config_file(non_existant_path, warn=False)
 
         assert str(e.value) == f"No file found at: {non_existant_path}."
@@ -232,7 +233,7 @@ class TestConfigs(BaseTest):
         with open(wrong_filetype_path, "w"):
             pass
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ValueError) as e:
             project.supply_config_file(wrong_filetype_path, warn=False)
 
         assert str(e.value) == "The config file must be a YAML file."
@@ -250,7 +251,7 @@ class TestConfigs(BaseTest):
 
         test_utils.dump_config(missing_key_configs, bad_configs_path)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ConfigError) as e:
             project.supply_config_file(bad_configs_path, warn=False)
 
         assert (
@@ -271,7 +272,7 @@ class TestConfigs(BaseTest):
         wrong_key_configs["transfer_merbosity"] = "wrong"
         test_utils.dump_config(wrong_key_configs, bad_configs_path)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ConfigError) as e:
             project.supply_config_file(bad_configs_path, warn=False)
 
         assert (
@@ -299,7 +300,7 @@ class TestConfigs(BaseTest):
 
             test_utils.dump_config(bad_type_configs, bad_configs_path)
 
-            with pytest.raises(BaseException) as e:
+            with pytest.raises(ConfigError) as e:
                 project.supply_config_file(bad_configs_path, warn=False)
 
             required_types = get_canonical_config_required_types()
@@ -344,7 +345,7 @@ class TestConfigs(BaseTest):
 
         test_utils.dump_config(bad_order_configs, bad_order_configs_path)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ConfigError) as e:
             project.supply_config_file(bad_order_configs_path, warn=False)
 
         assert (
@@ -381,7 +382,7 @@ class TestConfigs(BaseTest):
             Path(bad_name_configs[path_type]) / bad_name
         )
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ConfigError) as e:
             no_cfg_project.make_config_file(**bad_name_configs)
 
         assert (

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -5,6 +5,7 @@ import pytest
 from base import BaseTest
 
 from datashuttle.utils import formatting
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 
 class TestFormatting(BaseTest):
@@ -17,7 +18,7 @@ class TestFormatting(BaseTest):
         Test that names passed in incorrect type
         (not str, list) raise appropriate error.
         """
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(TypeError) as e:
             formatting.format_names(input, prefix)
 
         assert f"Ensure {prefix} names are a list of strings." == str(e.value)
@@ -28,7 +29,7 @@ class TestFormatting(BaseTest):
         Test that appropriate error is raised when duplicate name
         is passed to format_names().
         """
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_and_format_names(
                 ["1", "2", "3", "3", "4"], prefix
             )

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -10,6 +10,10 @@ import test_utils
 from datashuttle import DataShuttle
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.utils import ds_logger
+from datashuttle.utils.custom_exceptions import (
+    ConfigError,
+    NeuroBlueprintError,
+)
 
 # a symbol that will create an error when trying to make a file with this name.
 # this is only tested in windows as nearly any char is allowed for macos and linux
@@ -326,7 +330,7 @@ class TestLogging:
 
     def test_logs_check_update_config_error(self, project):
         """"""
-        with pytest.raises(BaseException):
+        with pytest.raises(ConfigError):
             project.update_config("connection_method", "ssh")
 
         log = self.read_log_file(project.cfg.logging_path)
@@ -347,7 +351,7 @@ class TestLogging:
         project.make_folders("sub-001", datatype="all")
         self.delete_log_files(project.cfg.logging_path)
 
-        with pytest.raises(BaseException):
+        with pytest.raises(NeuroBlueprintError):
             project.make_folders("sub-01", datatype="all")
 
         log = self.read_log_file(project.cfg.logging_path)
@@ -369,7 +373,7 @@ class TestLogging:
         )
         configs["local_path"] = BAD_WINDOWS_FILECHAR
 
-        with pytest.raises(BaseException):
+        with pytest.raises(ConfigError):
             project.make_config_file(**configs)
 
         tmp_path_logs = glob.glob(str(project._temp_log_path / "*.log"))
@@ -408,7 +412,7 @@ class TestLogging:
 
         # Try to set local_path to a folder that cannot be made.
         # The existing local project exists, so put the log there
-        with pytest.raises(BaseException):
+        with pytest.raises(ConfigError):
             self.run_supply_or_update_configs(
                 project, supply_or_update, BAD_WINDOWS_FILECHAR, tmp_path
             )
@@ -427,7 +431,7 @@ class TestLogging:
         # in the temp log file.
         project.cfg["local_path"] = Path("folder_that_does_not_exist")
 
-        with pytest.raises(BaseException):
+        with pytest.raises(ConfigError):
             self.run_supply_or_update_configs(
                 project, supply_or_update, BAD_WINDOWS_FILECHAR, tmp_path
             )

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -9,6 +9,7 @@ from base import BaseTest
 
 from datashuttle.configs import canonical_folders
 from datashuttle.configs.canonical_tags import tags
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 
 class TestMakeFolders(BaseTest):
@@ -26,7 +27,7 @@ class TestMakeFolders(BaseTest):
         subs = ["sub-001_id-123", "sub-002_id-124"]
         project.make_folders(subs)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-001_id-125")
 
         assert (
@@ -40,7 +41,7 @@ class TestMakeFolders(BaseTest):
         sessions = ["ses-001_date-1605", "ses-002_date-1606"]
         project.make_folders(subs, sessions)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-001_id-123", "ses-002_date-1607")
 
         assert (
@@ -58,7 +59,7 @@ class TestMakeFolders(BaseTest):
         """
         project.make_folders("sub-001")
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-1")
 
         assert (
@@ -69,7 +70,7 @@ class TestMakeFolders(BaseTest):
 
         project.make_folders("sub-001", "ses-3")
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-001", "ses-003")
 
         assert (
@@ -85,24 +86,24 @@ class TestMakeFolders(BaseTest):
         project.make_folders("sub-001")
 
         for bad_sub_name in ["sub-1", "sub-1_@DATE", "sub-001_extra-key"]:
-            with pytest.raises(BaseException) as e:
+            with pytest.raises(NeuroBlueprintError) as e:
                 project.make_folders(bad_sub_name, "ses-001")
             assert "Cannot make folders. A sub already exists" in str(e.value)
 
         project.make_folders("sub-001", "ses-001")
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-001", "ses-001_extra-key", "behav")
         assert (
             "Cannot make folders. A ses already exists with the same ses id as ses-001"
             in str(e.value)
         )
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-001_extra-key", "ses-001", "behav")
         assert "Cannot make folders. A sub already exists " in str(e.value)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders(
                 "sub-001_extra-key", "ses-001_@DATE@", "behav"
             )
@@ -114,7 +115,7 @@ class TestMakeFolders(BaseTest):
 
         # Finally check that in a list of subjects, only the correct subject
         # with duplicate session is caught.
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders(
                 ["sub-001", "sub-002"], "ses-002_@DATE@", "ephys"
             )
@@ -462,14 +463,14 @@ class TestMakeFolders(BaseTest):
         assert old_num == 5
 
     def test_invalid_sub_and_ses_name(self, project):
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub_100")
 
         assert "Invalid character in subject number: sub-sub_100" in str(
             e.value
         )
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.make_folders("sub-001", "ses_100")
 
         assert "Invalid character in subject number: ses-ses_100" in str(

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -4,6 +4,7 @@ import pytest
 
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.utils import formatting, utils
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 
 class TestUnit:
@@ -56,7 +57,7 @@ class TestUnit:
     )
     def test_spaces_in_format_names(self, prefix_and_names):
         prefix, names = prefix_and_names
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_and_format_names(names, prefix)
 
         assert str(e.value) == f"{prefix} names cannot include spaces."
@@ -114,7 +115,7 @@ class TestUnit:
     ):
         bad_input = bad_input.replace("prefix", prefix)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(ValueError) as e:
             formatting.update_names_with_range_to_flag([bad_input], prefix)
 
         assert (
@@ -126,7 +127,7 @@ class TestUnit:
     def test_formatting_check_dashes_and_underscore_alternate_correctly(self):
         """"""
         all_names = ["sub_001_date-010101"]
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_dashes_and_underscore_alternate_correctly(
                 all_names
             )
@@ -142,7 +143,7 @@ class TestUnit:
         )
 
         all_names = ["sub-001-date_101010"]
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_dashes_and_underscore_alternate_correctly(
                 all_names
             )
@@ -150,14 +151,14 @@ class TestUnit:
         assert str(e.value) == alternate_error
 
         all_names = ["sub-001_ses-002-suffix"]
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_dashes_and_underscore_alternate_correctly(
                 all_names
             )
         assert str(e.value) == alternate_error
 
         all_names = ["sub-001_ses-002-task-check"]
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_dashes_and_underscore_alternate_correctly(
                 all_names
             )
@@ -207,12 +208,12 @@ class TestUnit:
         """
         names = [f"{prefix}-001", f"{prefix}-02", f"{prefix}-003"]
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_and_format_names(names, prefix)
 
         assert (
-            str(e.value)
-            == f"The length of the {prefix} values (e.g. '001') must be consistent across all {prefix} names."
+            str(e.value) == f"The length of the {prefix} values (e.g. '001') "
+            f"must be consistent across all {prefix} names."
         )
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])
@@ -223,7 +224,7 @@ class TestUnit:
         """
         names = [f"{prefix}-001", f"{prefix}-002", f"{prefix}-001_@DATE@"]
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_and_format_names(names, prefix)
 
         assert (


### PR DESCRIPTION
closes #246. It is useful to have a central function in which all errors are raised, for example if needing to tear down any functionality (e.g. close loggers) before raising an error.

Previously this centralisation meant that only `BaseException` was raised. Now, the central error-raising functions take the type of exception to raise, and raise this. These means API users can catch specific exception types.

This PR also introduces two custom exceptions, `NeuroBlueprintError` (related to violations of NeuroBlueprint standard) and `ConfigError` (related to user passing bad configs).

Updated relevant tests, docs not required.
