### PR TITLE
Do not create folders above project name [1]

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -162,6 +162,14 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
                 ConfigError,
             )
 
+    if not (config_dict["local_path"].parent.is_dir()):
+        utils.log_and_raise_error(
+            f"The local path {config_dict['local_path'].parent} that the project "
+            f"folder will reside in does not yet exist. Please ensure the  path shown "
+            f"in this message exists before continuing. Also make sure the "
+            f"`central_path`, is correct, as datashuttle cannot check it at this stage."
+        )
+
     # Check SSH settings
     if config_dict["connection_method"] == "ssh" and (
         not config_dict["central_host_id"]

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -226,14 +226,17 @@ def check_folder_above_project_name_exists(config_dict: Configs):
             extra_warning = ""
 
         utils.log_and_raise_error(
-            f"{base_error_message('local_path')} {extra_warning}"
+            f"{base_error_message('local_path')} {extra_warning}",
+            FileNotFoundError,
         )
 
     if (
         config_dict["connection_method"] == "local_filesystem"
         and not config_dict["central_path"].parent.is_dir()
     ):
-        utils.log_and_raise_error(base_error_message("central_path"))
+        utils.log_and_raise_error(
+            base_error_message("central_path"), FileNotFoundError
+        )
 
 
 def check_config_types(config_dict: Configs) -> None:

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -8,7 +8,11 @@ from typing import Any, List, Literal, Union, overload
 
 from rich import print as rich_print
 
+<<<<<<< HEAD
 from datashuttle.utils.custom_exceptions import NeuroBlueprintError
+=======
+from . import ds_logger
+>>>>>>> e6938d3 (Close logger before raising exception.)
 
 # --------------------------------------------------------------------------------------
 # General Utils
@@ -66,6 +70,7 @@ def raise_error(message: str, exception) -> None:
     """
     Centralized way to raise an error
     """
+    ds_logger.close_log_filehandler()
     raise exception(message)
 
 

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -8,11 +8,8 @@ from typing import Any, List, Literal, Union, overload
 
 from rich import print as rich_print
 
-<<<<<<< HEAD
+from datashuttle.utils import ds_logger
 from datashuttle.utils.custom_exceptions import NeuroBlueprintError
-=======
-from . import ds_logger
->>>>>>> e6938d3 (Close logger before raising exception.)
 
 # --------------------------------------------------------------------------------------
 # General Utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,7 @@ def setup_project_default_configs(
     default_configs = get_test_config_arguments_dict(
         tmp_path, project_name, set_as_defaults=True
     )
+    os.makedirs(default_configs["local_path"], exist_ok=True)
 
     project.make_config_file(**default_configs)
 
@@ -52,11 +53,15 @@ def setup_project_default_configs(
 
     warnings.filterwarnings("default")
 
-    project.update_config(
-        "local_path", project._datashuttle_path / "base_folder" / project_name
-    )
+    new_local_path = (
+        project._datashuttle_path / "base_folder" / project_name
+    )  # TODO: can delete this?
+    os.makedirs(new_local_path, exist_ok=True)
+
+    project.update_config("local_path", new_local_path)
 
     if local_path:
+        os.makedirs(local_path, exist_ok=True)
         project.update_config("local_path", local_path)
 
         delete_all_folders_in_local_path(project)
@@ -196,6 +201,7 @@ def get_test_config_arguments_dict(
         "central_path": f"{tmp_path}/a/re al/central_ local/folder/{project_name}",
         "connection_method": "local_filesystem",
     }
+    os.makedirs(dict_["local_path"], exist_ok=True)
 
     if required_arguments_only:
         return dict_
@@ -223,6 +229,7 @@ def get_test_config_arguments_dict(
                 "show_transfer_progress": True,
             }
         )
+        os.makedirs(dict_["local_path"], exist_ok=True)
 
     return dict_
 
@@ -504,14 +511,16 @@ def swap_local_and_central_paths(project, swap_last_folder_only=False):
     local_path = copy.deepcopy(project.cfg["local_path"])
     central_path = copy.deepcopy(project.cfg["central_path"])
 
+    new_local_path = local_path.parent / central_path.name
+    os.makedirs(new_local_path, exist_ok=True)
+
     if swap_last_folder_only:
-        project.update_config(
-            "local_path", local_path.parent / central_path.name
-        )
+        project.update_config("local_path", new_local_path)
         project.update_config(
             "central_path", central_path.parent / local_path.name
         )
     else:
+        os.makedirs(central_path, exist_ok=True)
         project.update_config("local_path", central_path)
         project.update_config("central_path", local_path)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def setup_project_default_configs(
     default_configs = get_test_config_arguments_dict(
         tmp_path, project_name, set_as_defaults=True
     )
-    os.makedirs(default_configs["local_path"], exist_ok=True)
+    make_project_paths(default_configs)
 
     project.make_config_file(**default_configs)
 
@@ -68,11 +68,17 @@ def setup_project_default_configs(
         project.cfg.make_and_get_logging_path()
 
     if central_path:
+        os.makedirs(central_path, exist_ok=True)
         project.update_config("central_path", central_path)
         delete_all_folders_in_project_path(project, "central")
         project.cfg.make_and_get_logging_path()
 
     return project
+
+
+def make_project_paths(config_dict):
+    for path_name in ["local_path", "central_path"]:
+        os.makedirs(config_dict[path_name], exist_ok=True)
 
 
 def glob_basenames(search_path, recursive=False, exclude=None):
@@ -201,7 +207,7 @@ def get_test_config_arguments_dict(
         "central_path": f"{tmp_path}/a/re al/central_ local/folder/{project_name}",
         "connection_method": "local_filesystem",
     }
-    os.makedirs(dict_["local_path"], exist_ok=True)
+    make_project_paths(dict_)
 
     if required_arguments_only:
         return dict_
@@ -229,7 +235,7 @@ def get_test_config_arguments_dict(
                 "show_transfer_progress": True,
             }
         )
-        os.makedirs(dict_["local_path"], exist_ok=True)
+        make_project_paths(dict_)
 
     return dict_
 
@@ -511,16 +517,18 @@ def swap_local_and_central_paths(project, swap_last_folder_only=False):
     local_path = copy.deepcopy(project.cfg["local_path"])
     central_path = copy.deepcopy(project.cfg["central_path"])
 
-    new_local_path = local_path.parent / central_path.name
-    os.makedirs(new_local_path, exist_ok=True)
+    os.makedirs(central_path, exist_ok=True)
 
     if swap_last_folder_only:
+        new_local_path = local_path.parent / central_path.name
+        os.makedirs(new_local_path, exist_ok=True)
+
         project.update_config("local_path", new_local_path)
         project.update_config(
             "central_path", central_path.parent / local_path.name
         )
     else:
-        os.makedirs(central_path, exist_ok=True)
+        os.makedirs(local_path, exist_ok=True)
         project.update_config("local_path", central_path)
         project.update_config("central_path", local_path)
 

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -69,6 +69,7 @@ class TestConfigs(BaseTest):
             central_path = bad_pattern
 
         os.makedirs(local_path, exist_ok=True)
+        os.makedirs(central_path, exist_ok=True)
 
         with pytest.raises(ConfigError) as e:
             project.make_config_file(
@@ -126,7 +127,12 @@ class TestConfigs(BaseTest):
         are set.
         """
         local_path = tmp_path / "test_local_path" / no_cfg_project.project_name
+        central_path = (
+            tmp_path / "test_central_path" / no_cfg_project.project_name
+        )
+
         os.makedirs(local_path, exist_ok=True)
+        os.makedirs(central_path, exist_ok=True)
 
         no_cfg_project.make_config_file(
             local_path,

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -68,6 +68,8 @@ class TestConfigs(BaseTest):
             local_path = good_pattern
             central_path = bad_pattern
 
+        os.makedirs(local_path, exist_ok=True)
+
         with pytest.raises(ConfigError) as e:
             project.make_config_file(
                 local_path,
@@ -76,6 +78,22 @@ class TestConfigs(BaseTest):
             )
 
         assert "must contain the full folder path with no " in str(e.value)
+
+    def test_bad_local_path(self, no_cfg_project):
+        from pathlib import Path
+
+        non_existant_path = Path("/not/a/real/path/fsdf342sdfsd234")
+
+        with pytest.raises(BaseException) as e:
+            no_cfg_project.make_config_file(
+                f"{non_existant_path.as_posix()}/{no_cfg_project.project_name}",
+                no_cfg_project.project_name,
+                "local_filesystem",
+            )
+
+        assert f"The local path {non_existant_path} that the project" in str(
+            e.value
+        )
 
     def test_no_ssh_options_set_on_make_config_file(self, no_cfg_project):
         """
@@ -107,8 +125,11 @@ class TestConfigs(BaseTest):
         switching on ssh_to_central unless all options
         are set.
         """
+        local_path = tmp_path / "test_local_path" / no_cfg_project.project_name
+        os.makedirs(local_path, exist_ok=True)
+
         no_cfg_project.make_config_file(
-            tmp_path / "test_local_path" / no_cfg_project.project_name,
+            local_path,
             tmp_path / "test_central_path" / no_cfg_project.project_name,
             "local_filesystem",
         )

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -239,6 +239,7 @@ class TestFileTransfer(BaseTest):
         sessions to upload. Check only the selected sessions were uploaded.
         """
         subs, sessions = test_utils.get_default_sub_sessions_to_test()
+
         test_utils.make_and_check_local_project_folders(
             project, subs, sessions, "all"
         )

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -128,12 +128,12 @@ class TestFormatting(BaseTest):
         self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
 
         # Now, have conflicting subject names, but one in local and one in central
-        project.update_config(
-            "central_path",
-            project.cfg["local_path"].parent
-            / "central"
-            / project.project_name,
+        new_central_path = (
+            project.cfg["local_path"].parent / "central" / project.project_name
         )
+        os.makedirs(new_central_path, exist_ok=True)
+
+        project.update_config("central_path", new_central_path)
         os.makedirs(project.cfg["central_path"] / "rawdata" / bad_sub_name)
         shutil.rmtree(project.cfg["local_path"] / "rawdata" / bad_sub_name)
         self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
@@ -179,12 +179,12 @@ class TestFormatting(BaseTest):
 
         # Now, have conflicting session names (in different subject directories)
         # where one subject directory is local and the other is central.
-        project.update_config(
-            "central_path",
-            project.cfg["local_path"].parent
-            / "central"
-            / project.project_name,
+        new_central_path = (
+            project.cfg["local_path"].parent / "central" / project.project_name
         )
+        os.makedirs(new_central_path, exist_ok=True)
+
+        project.update_config("central_path", new_central_path)
         os.makedirs(
             project.cfg["central_path"] / "rawdata" / "sub-001" / bad_ses_name
         )

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -71,11 +71,14 @@ class TestLogging:
     def read_log_file(self, logging_path):
         log_filepath = glob.glob(str(logging_path / "*.log"))
 
-        assert len(log_filepath) == 1, (
-            f"there should only be one log "
-            f"in log output path {logging_path}"
-        )
-        log_filepath = log_filepath[0]
+        try:
+            assert len(log_filepath) == 1, (
+                f"there should only be one log "
+                f"in log output path {logging_path}"
+            )
+            log_filepath = log_filepath[0]
+        except:
+            breakpoint()
 
         with open(log_filepath, "r") as file:
             log = file.read()
@@ -145,11 +148,12 @@ class TestLogging:
             project, tmp_path
         )
         self.delete_log_files(project.cfg.logging_path)
-        orig_project_path = project.cfg.logging_path
 
         project.supply_config_file(new_configs_path, warn=False)
 
-        log = self.read_log_file(orig_project_path)
+        log = self.read_log_file(
+            project.cfg["local_path"] / ".datashuttle" / "logs"
+        )
 
         assert "supply-config-file" in log
         assert "\n\nVariablesState:\nlocals: {'input_path_to_config':" in log
@@ -324,9 +328,9 @@ class TestLogging:
         assert "Using config file from" in log
         assert "Waiting for checks to finish" in log
 
-        # ----------------------------------------------------------------------------------
-        # Test temporary logging path
-        # ----------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------
+    # Test temporary logging path
+    # ----------------------------------------------------------------------------------
 
     def test_temp_log_folder_moved_make_config_file(
         self, clean_project_name, tmp_path
@@ -475,10 +479,9 @@ class TestLogging:
         )
 
         assert (
-            "\n\nVariablesState:\nlocals: {'option_key': 'connection_method', 'new_info': 'ssh', 'store_logs_in_temp_folder': False}\ncfg: {'local_path':"
-            in log
+            "\n\nVariablesState:\nlocals: {'option_key': "
+            "'connection_method', 'new_info': 'ssh'" in log
         )
-        assert "connection_method was not updated" in log
 
     def test_logs_bad_make_folders_error(self, project):
         """"""


### PR DESCRIPTION
The PR causes an error to be raised if the passed `local_path` does not exist. Unfortunately this ended up being slightly more complex than anticipated and leading to a few downstream effects, making this PR sad and bloated :(

This PR:
1)  Implements a `check_folder_above_project_name_exists()` function. This always checks if the `local_path` exists. If `connection_method=="local_filesystem"`, it will also check the `central_path` exists. However, it is not possible to check the `central_path` exists if SSH is used (because it's not guaranteed to be setup). So, if the `local_path` does not exist but connection method is SSH, then a reminder to check the `central_path` is shown, on the assumption the central path might also be wrong.
2) This change lead to a load of tests failing so have ensured that tests make all test paths themselves. Most of these changes can be ignored in review because they are critical to test components (i.e. the tests would fail if something was wrong with them).
3) A benefit of this change is it allows simplification of what was a super unclear behaviour when setting up logs. Previously, if the `local_path` was changed then the log would store in a temporary path and then move the logs to the new path once it had been created. Now, in the case of 'update-config' if `local_path` is changed the logs are just stored in the original `local_path` that definately exists (then, all future logs will be stored in the new `local_path`. In `supply-config-file` and `make-config-file` we cannot be sure the `local_path` exists so logs are stored in temp folder then moved. So the core behaviour is still there but it has been cleaned up.

Please let me know if anything is not clear because I still get confused by the logging behaviour (hopefully it will be clearer now with the changes, but probably difficult to review). This section is also not super critical to review, and behaviour is tested e.g. `test_logs_new_supply_config`. 

This behaviour is tested, I do not think it requires any docs.