### PR TITLE
Add unit test for `test_get_values_from_bids_formatted_name()`.

### DIFF
--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -134,7 +134,8 @@ def get_values_from_bids_formatted_name(
 ) -> Union[List[int], List[str]]:
     """
     Find the values associated with a key from a list of all
-    BIDS-formatted file / folder names.
+    BIDS-formatted file / folder names. This is typically used to
+    find sub / ses values.
     """
     all_values = []
     for name in all_names:
@@ -146,7 +147,7 @@ def get_values_from_bids_formatted_name(
         if len(value) > 1:
             raise_error(
                 f"There is more than instance of {key} in {name}. "
-                f"BIDS names must contain only one instance of "
+                f"NeuroBlueprint names must contain only one instance of "
                 f"each key."
             )
 
@@ -154,7 +155,7 @@ def get_values_from_bids_formatted_name(
             try:
                 value_to_append = int(value[0])
             except ValueError:
-                raise_error(f"Invalid character in subject number: {name}")
+                raise_error(f"Invalid character in {key} number: {name}")
         else:
             value_to_append = value[0]
 

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -146,7 +146,7 @@ def get_values_from_bids_formatted_name(
 
         if len(value) > 1:
             raise_error(
-                f"There is more than instance of {key} in {name}. "
+                f"There is more than one instance of {key} in {name}. "
                 f"NeuroBlueprint names must contain only one instance of "
                 f"each key."
             )

--- a/tests/tests_integration/test_make_folders.py
+++ b/tests/tests_integration/test_make_folders.py
@@ -465,16 +465,12 @@ class TestMakeFolders(BaseTest):
         with pytest.raises(BaseException) as e:
             project.make_folders("sub_100")
 
-        assert "Invalid character in subject number: sub-sub_100" in str(
-            e.value
-        )
+        assert "Invalid character in sub number: sub-sub_100" in str(e.value)
 
         with pytest.raises(BaseException) as e:
             project.make_folders("sub-001", "ses_100")
 
-        assert "Invalid character in subject number: ses-ses_100" in str(
-            e.value
-        )
+        assert "Invalid character in ses number: ses-ses_100" in str(e.value)
 
     # ----------------------------------------------------------------------------------
     # Test Helpers

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -238,7 +238,7 @@ class TestUnit:
         self, key, return_as_int, sort
     ):
         """
-        Unit test the function `test_get_values_from_bids_formatted_name()`
+        Unit test the function `get_values_from_bids_formatted_name()`
         which extracts values from BIDS-like names with a range of
         possible inputs.
         """

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -283,7 +283,7 @@ class TestUnit:
             )
 
         assert (
-            "There is more than instance of date in"
+            "There is more than one instance of date in"
             " sub-001_date-12345_date-23456" in str(e.value)
         )
 

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -231,7 +231,76 @@ class TestUnit:
             f"integer ids after the {prefix} prefix."
         )
 
-    # ----------------------------------------------------------------------
+    @pytest.mark.parametrize("key", ["sub", "ses", "date", "id"])
+    @pytest.mark.parametrize("return_as_int", [True, False])
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_get_values_from_bids_formatted_name(
+        self, key, return_as_int, sort
+    ):
+        """
+        Unit test the function `test_get_values_from_bids_formatted_name()`
+        which extracts values from BIDS-like names with a range of
+        possible inputs.
+        """
+        if return_as_int and key == "id":
+            return
+
+        all_names = [
+            "sub-01_ses-0101_date-123456_id-abcde",
+            "sub-02_ses-0999_date-234567_id-bcdef",
+            "sub-99_ses-1000_date-345678_id-cdefg",
+        ]
+
+        all_expected_values = {
+            "sub": ["01", "02", "99"],
+            "ses": ["0101", "0999", "1000"],
+            "date": ["123456", "234567", "345678"],
+            "id": ["abcde", "bcdef", "cdefg"],
+        }
+
+        values = utils.get_values_from_bids_formatted_name(
+            all_names, key, return_as_int, sort
+        )
+
+        expected_values = all_expected_values[key]
+
+        if return_as_int:
+            expected_values = [int(val) for val in expected_values]
+
+        if sort:
+            expected_values = sorted(expected_values)
+
+        assert values == expected_values
+
+    def test_get_values_from_bids_formatted_name_error(self):
+        """
+        Check errors that catch unpredictable behaviour
+        are displayed correctly.
+        """
+        with pytest.raises(BaseException) as e:
+            utils.get_values_from_bids_formatted_name(
+                ["sub-001_date-12345", "sub-001_date-12345_date-23456"], "date"
+            )
+
+        assert (
+            "There is more than instance of date in"
+            " sub-001_date-12345_date-23456" in str(e.value)
+        )
+
+        with pytest.raises(BaseException) as e:
+            utils.get_values_from_bids_formatted_name(
+                ["sub-a_date-12345", "sub-b_date-12345_date-23456"],
+                "sub",
+                return_as_int=True,
+            )
+        assert "Invalid character in sub number: sub-a_date-12345" == str(
+            e.value
+        )
+
+    # -------------------------------------------------------
+    #
+    #
+    # ---------------
     # Utlis
     # ----------------------------------------------------------------------
 


### PR DESCRIPTION
Adds a unit test for the core function `get_values_from_bids_formatted_name()`. This function extracts values from list of BIDS-like next `["sub-001", "ses-002"]` would return `["001", "002"]` (if `"sub"` key was passed). Some small fixes to the function itself asn related tests.

I convered some different cases but I wonder if there are any edge cases I'm not thinking of.

No documentation or tests are needed.