### PR TITLE
Replace `update-config` with `update-config-file` that takes multiple options at once. [3]

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -22,6 +22,7 @@ from datashuttle.utils import utils
 from datashuttle.utils.custom_exceptions import ConfigError
 
 
+# TODO: this can be merged with get_canonical_config_required_types()
 def get_canonical_config_dict() -> dict:
     """
     Canonical list of required keys
@@ -112,6 +113,7 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
                 f"Config file was not updated.",
                 ConfigError,
             )
+
     for key in config_dict.keys():
         if key not in canonical_dict.keys():
             utils.log_and_raise_error(

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -94,7 +94,7 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
     Central function for performing checks on a
     DataShuttle Configs UserDict class. This should
     be run after any change to the configs (e.g.
-    make_config_file, update_config, supply_config_file).
+    make_config_file, update_config_file(), supply_config_file).
 
     This will raise assert if condition is not met.
 

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -8,7 +8,6 @@ import yaml
 
 from datashuttle.configs import canonical_configs, canonical_folders
 from datashuttle.utils import folders, utils
-from datashuttle.utils.custom_exceptions import ConfigError
 
 
 class Configs(UserDict):

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -2,7 +2,7 @@ import copy
 from collections import UserDict
 from collections.abc import ItemsView, KeysView, ValuesView
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Optional, Union, cast
 
 import yaml
 
@@ -105,64 +105,6 @@ class Configs(UserDict):
         self.convert_str_and_pathlib_paths(config_dict, "str_to_path")
 
         self.data = config_dict
-
-    # -------------------------------------------------------------------------
-    # Update Configs
-    # -------------------------------------------------------------------------
-
-    def update_an_entry(self, option_key: str, new_info: Any) -> None:
-        """
-        Convenience function to update individual entry of configuration
-        file. The config file, and currently loaded self.cfg will be
-        updated.
-
-        In case an update is breaking, set to new value,
-        test validity and revert if breaking change.
-
-        Parameters
-        ----------
-
-        option_key : dictionary key of the option to change,
-            see make_config_file()
-
-        new_info : value to update the config too
-        """
-        if option_key not in self:
-            utils.log_and_raise_error(
-                f"'{option_key}' is not a valid config.", ConfigError
-            )
-
-        original_value = copy.deepcopy(self[option_key])
-
-        if option_key in self.keys_str_on_file_but_path_in_class:
-            new_info = Path(new_info)
-
-        self[option_key] = new_info
-
-        check_change = self.safe_check_current_dict_is_valid()
-
-        if check_change["passed"]:
-            self.dump_to_file()
-            utils.log_and_message(
-                f"{option_key} has been updated to {new_info}"
-            )
-
-            if option_key in ["connection_method", "central_path"]:
-                if self["connection_method"] == "ssh":
-                    utils.log_and_message(
-                        f"SSH will be used to connect to project folder at: {self['central_path']}"
-                    )
-                elif self["connection_method"] == "local_filesystem":
-                    utils.log_and_message(
-                        f"Local filesystem will be used to connect to project "
-                        f"folder at: {self['central_path'].as_posix()}"
-                    )
-        else:
-            self[option_key] = original_value
-            utils.log_and_raise_error(
-                f"\n{check_change['error']}\n{option_key} was not updated.",
-                ConfigError,
-            )
 
     def safe_check_current_dict_is_valid(self) -> dict:
         """

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -771,7 +771,8 @@ class DataShuttle:
             ds_logger.close_log_filehandler()
         else:
             utils.log_and_raise_error(
-                f"{check_change['error']}\nConfigs were not updated."
+                f"{check_change['error']}\nConfigs were not updated.",
+                ConfigError,
             )
 
     def supply_config_file(

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -5,6 +5,7 @@ import glob
 import json
 import os
 import shutil
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -700,6 +701,14 @@ class DataShuttle:
             store_in_temp_folder=True,
         )
 
+        if self._config_path.is_file():
+            warnings.warn(
+                "A config file already exists. This function will completely"
+                "overwrite the existing config file, and any arguments not"
+                "passed to `make-config-file` will be set to the function defaults."
+                "Use `update-config-file` to selectively update settings."
+            )
+
         self.cfg = Configs(
             self.project_name,
             self._config_path,
@@ -730,45 +739,6 @@ class DataShuttle:
         )
         self._log_successful_config_change()
         self._move_logs_from_temp_folder()
-
-        ds_logger.close_log_filehandler()
-
-    @check_configs_set
-    def update_config(
-        self, option_key: str, new_info: Union[Path, str, bool, None]
-    ) -> None:
-        """
-        Update a single config entry. This will overwrite the existing
-        entry in the saved configs file and be used for all future
-        datashuttle sessions.
-
-        Parameters
-        ----------
-
-        option_key :
-            dictionary key of the option to change,
-            see make_config_file() for available keys.
-
-        new_info :
-            value to update the config too
-        """
-        if not self.cfg:
-            utils.log_and_raise_error(
-                "Must have a config loaded before updating configs.",
-                ConfigError,
-            )
-
-        self._start_log(
-            "update-config",
-            local_vars=locals(),
-        )
-
-        new_info = load_configs.handle_bool(option_key, new_info)
-
-        self.cfg.update_an_entry(option_key, new_info)
-        self._set_attributes_after_config_load()
-
-        self._log_successful_config_change()
 
         ds_logger.close_log_filehandler()
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -572,7 +572,7 @@ class DataShuttle:
         """
         Setup a connection to the central server using SSH.
         Assumes the central_host_id and central_host_username
-        are set in configs (see make_config_file() and update_config())
+        are set in configs (see make_config_file() and update_config_file())
 
         First, the server key will be displayed, requiring
         verification of the server ID. This will store the
@@ -646,7 +646,7 @@ class DataShuttle:
         on the local machine. Use show_config_path() to
         get the full path to the saved config file.
 
-        Use update_config() to update a single config, and
+        Use update_config_file() to update a single config, and
         supply_config() to use an existing config file.
 
         Parameters
@@ -754,7 +754,6 @@ class DataShuttle:
             local_vars=locals(),
         )
 
-        #    # tests - pass bad options, especially paths
         for option, value in kwargs.items():
             if option in self.cfg.keys_str_on_file_but_path_in_class:
                 kwargs[option] = Path(value)

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -742,6 +742,39 @@ class DataShuttle:
 
         ds_logger.close_log_filehandler()
 
+    def update_config_file(self, **kwargs):
+        """ """
+        if not self.cfg:
+            utils.log_and_raise_error(
+                "Must have a config loaded before updating configs."
+            )
+
+        self._start_log(
+            "update-config-file",
+            local_vars=locals(),
+        )
+
+        #    # tests - pass bad options, especially paths
+        for option, value in kwargs.items():
+            if option in self.cfg.keys_str_on_file_but_path_in_class:
+                kwargs[option] = Path(value)
+
+        new_cfg = copy.deepcopy(self.cfg)
+        new_cfg.update(**kwargs)
+
+        check_change = new_cfg.safe_check_current_dict_is_valid()
+
+        if check_change["passed"]:
+            self.cfg = new_cfg
+            self._set_attributes_after_config_load()
+            self.cfg.dump_to_file()
+            self._log_successful_config_change(message=True)
+            ds_logger.close_log_filehandler()
+        else:
+            utils.log_and_raise_error(
+                f"{check_change['error']}\nConfigs were not updated."
+            )
+
     def supply_config_file(
         self, input_path_to_config: str, warn: bool = True
     ) -> None:

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -159,7 +159,19 @@ To interact with Datashuttle, a cross-platform command line interface (CLI)
 and a Python API are available (see [API](API_Reference) and [CLI](CLI_Reference)
 for reference documentation).
 
-To setup, we can use the `make-config-file` command to tell Datashuttle our project details.
+To set up, we can use the `make-config-file` command to tell Datashuttle our project details.
+
+::: {dropdown} Updating an existing configuration file.
+:color: info
+:icon: info
+
+`make-config-file` should be used when first setting up a project's configs. To update
+an existing config file, use `update-config-file` with the arguments to be updated.
+
+Using `make-config-file` will completely overwrite any existing configurations, including
+setting any optional arguments that are not passed to factory default values.
+
+:::
 
 We need to tell Datashuttle:
 
@@ -243,8 +255,7 @@ The optional arguments **overwrite_old_files**, **transfer_verbosity** and
 **show_transfer_progress** determine how data transfer is performed
 (see the [Data Transfer](#data-transfer) section for details).
 
-Settings can be edited at any time with the `update-config` command.
-Alternatively, custom config files can be supplied using the `supply-config`
+Custom config files can be supplied using the `supply-config`
 command (this simplifies setting up projects across multiple *local* machines).
 
 
@@ -819,7 +830,7 @@ In this case, files in which the  timestamp of the target directory (e.g. *centr
 in our example) will be overwritten if their timestamp is
 older than the corresponding file in the source directory.
 
-The configuration can be changed with the `update-config` command.
+The configuration can be changed with the `update-config-file` command.
 
 ### Additional Transfer Configurations
 

--- a/tests/ssh_test_utils.py
+++ b/tests/ssh_test_utils.py
@@ -8,7 +8,7 @@ def setup_project_for_ssh(
     project, central_path, central_host_id, central_host_username
 ):
     """
-    Setup the project configs to use SSH connection
+    Set up the project configs to use SSH connection
     to central
     """
     project.update_config(

--- a/tests/ssh_test_utils.py
+++ b/tests/ssh_test_utils.py
@@ -11,13 +11,12 @@ def setup_project_for_ssh(
     Set up the project configs to use SSH connection
     to central
     """
-    project.update_config(
-        "central_path",
-        central_path,
+    project.update_config_file(
+        central_path=central_path,
     )
-    project.update_config("central_host_id", central_host_id)
-    project.update_config("central_host_username", central_host_username)
-    project.update_config("connection_method", "ssh")
+    project.update_config_file(central_host_id=central_host_id)
+    project.update_config_file(central_host_username=central_host_username)
+    project.update_config_file(connection_method="ssh")
 
     rclone.setup_central_as_rclone_target(
         "ssh",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,18 +59,18 @@ def setup_project_default_configs(
     )  # TODO: can delete this?
     os.makedirs(new_local_path, exist_ok=True)
 
-    project.update_config("local_path", new_local_path)
+    project.update_config_file(local_path=new_local_path)
 
     if local_path:
         os.makedirs(local_path, exist_ok=True)
-        project.update_config("local_path", local_path)
+        project.update_config_file(local_path=local_path)
 
         delete_all_folders_in_local_path(project)
         project.cfg.make_and_get_logging_path()
 
     if central_path:
         os.makedirs(central_path, exist_ok=True)
-        project.update_config("central_path", central_path)
+        project.update_config_file(central_path=central_path)
         delete_all_folders_in_project_path(project, "central")
         project.cfg.make_and_get_logging_path()
 
@@ -524,16 +524,16 @@ def swap_local_and_central_paths(project, swap_last_folder_only=False):
         new_local_path = local_path.parent / central_path.name
         os.makedirs(new_local_path, exist_ok=True)
 
-        project.update_config("local_path", new_local_path)
-        project.update_config(
-            "central_path", central_path.parent / local_path.name
+        project.update_config_file(local_path=new_local_path)
+        project.update_config_file(
+            central_path=central_path.parent / local_path.name
         )
     else:
         os.makedirs(local_path, exist_ok=True)
         os.makedirs(central_path, exist_ok=True)
 
-        project.update_config("local_path", central_path)
-        project.update_config("central_path", local_path)
+        project.update_config_file(local_path=central_path)
+        project.update_config_file(central_path=local_path)
 
     return central_path
 

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -270,22 +270,15 @@ class TestCommandLineInterface(BaseTest):
         ]
         assert kwargs_["ses_names"] == ["5", "06", "007"]
 
-    # ----------------------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------
     # Test CLI Functionality
-    # ----------------------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------
 
     @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_update_config(self, clean_project_name, sep, tmp_path):
+    def test_update_config_file(self, clean_project_name, sep, tmp_path):
         """
-        See test_update_config in test_configs.py.
-
-        There is not a _variables (above) test for update_config
-        because the arguments are converted to string
-        in the body of project.update_config(), so that logging
-        can capture everything. Thus, testing the variables
-        that are json.dumps() for the test environment are not
-        type-converted. As such, just test the whole
-        workflow here, with both separators.
+        Set up a project then up all configs with new configs
+        and check these are all loaded correctly.
         """
         default_configs = test_utils.get_test_config_arguments_dict(
             tmp_path, clean_project_name, set_as_defaults=True
@@ -304,17 +297,18 @@ class TestCommandLineInterface(BaseTest):
         config_path = test_utils.get_config_path_with_cli(clean_project_name)
         test_utils.move_some_keys_to_end_of_dict(not_set_configs)
 
+        argument_list = ""
         for key, value in not_set_configs.items():
             format_value = (
                 test_utils.add_quotes(value) if "path" in key else value
             )
+            argument_list += f"--{key} {format_value} "
 
-            test_utils.run_cli(
-                f" update{sep}config {key} {format_value}", clean_project_name
-            )
-            default_configs[key] = value
+        test_utils.run_cli(
+            f" update{sep}config{sep}file {argument_list}", clean_project_name
+        )
 
-            test_utils.check_config_file(config_path, default_configs)
+        test_utils.check_config_file(config_path, not_set_configs)
 
     def test_make_config_file_defaults(
         self,

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -237,7 +237,7 @@ class TestConfigs(BaseTest):
     # Test Update Config File
     # -------------------------------------------------------------
 
-    def test_update_config_file(self, no_cfg_project, tmp_path):
+    def test_update_config_file__(self, no_cfg_project, tmp_path):
         """
         Set the configs as default, and then update them to
         new configs and check they are updated properly.
@@ -259,7 +259,7 @@ class TestConfigs(BaseTest):
         test_utils.move_some_keys_to_end_of_dict(not_set_configs)
 
         # ensure str is convert to Path
-        not_set_configs["local_path"] = str(not_set_configs)
+        not_set_configs["local_path"] = str(not_set_configs["local_path"])
 
         project.update_config_file(**not_set_configs)
 

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -258,6 +258,9 @@ class TestConfigs(BaseTest):
 
         test_utils.move_some_keys_to_end_of_dict(not_set_configs)
 
+        # ensure str is convert to Path
+        not_set_configs["local_path"] = str(not_set_configs)
+
         project.update_config_file(**not_set_configs)
 
         test_utils.check_configs(project, not_set_configs)

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -372,9 +372,11 @@ class TestFileTransfer(BaseTest):
             project, ["sub-001"], ["ses-002"], ["behav"]
         )
 
-        project.update_config("overwrite_old_files", overwrite_old_files)
-        project.update_config("transfer_verbosity", "vv")
-        project.update_config("show_transfer_progress", show_transfer_progress)
+        project.update_config_file(overwrite_old_files=overwrite_old_files)
+        project.update_config_file(transfer_verbosity="vv")
+        project.update_config_file(
+            show_transfer_progress=show_transfer_progress
+        )
 
         test_utils.clear_capsys(capsys)
         project.upload_all(dry_run=dry_run)
@@ -404,7 +406,7 @@ class TestFileTransfer(BaseTest):
         see test_rclone_options()
         """
         project.make_folders(["sub-001"], ["ses-002"], ["behav"])
-        project.update_config("transfer_verbosity", transfer_verbosity)
+        project.update_config_file(transfer_verbosity=transfer_verbosity)
 
         test_utils.clear_capsys(capsys)
         project.upload_all()
@@ -446,7 +448,7 @@ class TestFileTransfer(BaseTest):
         time_written = os.path.getatime(local_test_file_path)
 
         if overwrite_old_files:
-            project.update_config("overwrite_old_files", True)
+            project.update_config_file(overwrite_old_files=True)
 
         project.upload_all()
 

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -133,7 +133,7 @@ class TestFormatting(BaseTest):
         )
         os.makedirs(new_central_path, exist_ok=True)
 
-        project.update_config("central_path", new_central_path)
+        project.update_config_file(central_path=new_central_path)
         os.makedirs(project.cfg["central_path"] / "rawdata" / bad_sub_name)
         shutil.rmtree(project.cfg["local_path"] / "rawdata" / bad_sub_name)
         self.check_inconsistent_sub_or_ses_value_length_warning(project, "sub")
@@ -184,7 +184,7 @@ class TestFormatting(BaseTest):
         )
         os.makedirs(new_central_path, exist_ok=True)
 
-        project.update_config("central_path", new_central_path)
+        project.update_config_file(central_path=new_central_path)
         os.makedirs(
             project.cfg["central_path"] / "rawdata" / "sub-001" / bad_ses_name
         )


### PR DESCRIPTION
This PR replaces the only `update-config` function for updating a single config (one at a time) with a new version that takes a dict of kwargs as an input and updates them all. 