### PR TITLE
Add zulip chat icon to website.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,7 +136,14 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
             # The type of image to be used (see below for details)
             "type": "fontawesome",
-        }
+        },
+        {
+            "name": "Zulip (chat)",
+            "url": "https://neuroinformatics.zulipchat.com/#narrow/stream/405999-DataShuttle",
+            # required
+            "icon": "fa-solid fa-comments",
+            "type": "fontawesome",
+        },
     ],
     "logo": {
         "text": f"Datashuttle v{release}",

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -6,7 +6,8 @@ This website includes the documentation and API documentation for DataShuttle.
 
 For additional information, please visit the [GitHub Page](https://github.com/neuroinformatics-unit/datashuttle).
 
-Any feedback is much appreciated, please open at [GitHub Issue](https://github.com/neuroinformatics-unit/datashuttle/issues) or join our [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/405999-DataShuttle) if you have any problems or suggestions.
+Any feedback is much appreciated, please open at [GitHub Issue](https://github.com/neuroinformatics-unit/datashuttle/issues)
+or join our [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/405999-DataShuttle) if you have any problems or suggestions.
 
 ## Explore the Documentation
 


### PR DESCRIPTION
Add the link to Datashuttle's zulip chat in the top-right corner of the website.