### PR TITLE
Add rclone check function.

### DIFF
--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -139,6 +139,22 @@ def transfer_data(
     return output
 
 
+def perform_rclone_check(cfg: Configs) -> str:
+    """"""
+    local_filepath = cfg.get_base_folder("local").as_posix()
+    central_filepath = cfg.get_base_folder("central").as_posix()
+
+    output = call_rclone(
+        f'{rclone_args("check")} '
+        f'"{local_filepath}" '
+        f'"{cfg.get_rclone_config_name()}:{central_filepath}"'
+        f" --combined -",
+        pipe_std=True,
+    )
+
+    return output.stdout.decode("utf-8")
+
+
 def handle_rclone_arguments(rclone_options, include_list):
     """
     Construct the extra arguments to pass to RClone based on the
@@ -179,5 +195,8 @@ def rclone_args(name: str) -> str:
 
     if name == "progress":
         arg = "--progress"
+
+    if name == "check":
+        arg = "check"
 
     return arg

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 from subprocess import CompletedProcess
+from typing import Dict, List
 
 from datashuttle.configs.config_class import Configs
 from datashuttle.utils import utils
@@ -137,6 +138,41 @@ def transfer_data(
         )
 
     return output
+
+
+# TODO:
+# 1) check all var names
+# 2) document
+# 3) This processing step will add a round of looping.
+def get_local_and_central_file_differences(cfg: Configs) -> Dict:
+    """ """
+    convert_symbols = {
+        "=": "same",
+        "*": "different",
+        "+": "local_only",
+        "-": "central_only",
+        "!": "error",
+    }
+
+    all_results: Dict[str, List]
+    all_results = {val: [] for val in convert_symbols.values()}
+
+    output = perform_rclone_check(cfg)
+    split_output = output.split("\n")
+
+    for result in split_output:
+        if result == "":
+            continue
+
+        symbol = result[0]
+
+        assert result[1] == " ", "format is unexpected."
+        assert symbol in convert_symbols.keys(), "error in check."
+        assert symbol != "!", "error somewhere - investigate"
+
+        all_results[convert_symbols[symbol]].append(result[2:])
+
+    return all_results
 
 
 def perform_rclone_check(cfg: Configs) -> str:

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -140,12 +140,24 @@ def transfer_data(
     return output
 
 
-# TODO:
-# 1) check all var names
-# 2) document
-# 3) This processing step will add a round of looping.
 def get_local_and_central_file_differences(cfg: Configs) -> Dict:
-    """ """
+    """
+    Convert the output of rclone's check (with `--combine`) flag
+    to a dictionary separating each case.
+
+    Rclone output comes as a list of files, separated by newlines,
+    with symbols indicating whether the file paths are same across
+    local and central, different, or found in local / central only.
+
+    Returns
+    -------
+
+    parsed_output : Dict[str, List]
+        A dictionary where the keys are the cases (e.g. "same" across
+        local and central) and the values are lists of paths that
+        fall into these cases. Note the paths are relative to the "rawdata"
+        folder.
+    """
     convert_symbols = {
         "=": "same",
         "*": "different",
@@ -154,29 +166,52 @@ def get_local_and_central_file_differences(cfg: Configs) -> Dict:
         "!": "error",
     }
 
-    all_results: Dict[str, List]
-    all_results = {val: [] for val in convert_symbols.values()}
+    parsed_output: Dict[str, List]
+    parsed_output = {val: [] for val in convert_symbols.values()}
 
-    output = perform_rclone_check(cfg)
-    split_output = output.split("\n")
+    rclone_output = perform_rclone_check(cfg)
+    split_rclone_output = rclone_output.split("\n")
 
-    for result in split_output:
+    for result in split_rclone_output:
         if result == "":
             continue
 
         symbol = result[0]
 
-        assert result[1] == " ", "format is unexpected."
-        assert symbol in convert_symbols.keys(), "error in check."
-        assert symbol != "!", "error somewhere - investigate"
+        assert_rclone_check_output_is_as_expected(
+            result, symbol, convert_symbols
+        )
 
-        all_results[convert_symbols[symbol]].append(result[2:])
+        key = convert_symbols[symbol]
+        parsed_output[key].append(result[2:])
 
-    return all_results
+    return parsed_output
+
+
+def assert_rclone_check_output_is_as_expected(result, symbol, convert_symbols):
+    """
+    Ensure the output of Rclone check is as expected. Currently the "error"
+    case is untested and a test case is required. Once the test case is
+    obtained this should most likely be moved to tests.
+    """
+    assert result[1] == " ", (
+        "`rclone check` output does not contain a "
+        "space as the second character`."
+    )
+    assert symbol in convert_symbols.keys(), "rclone check symbol is unknown."
+    assert symbol != "!", (
+        "Could not complete rlcone check. "
+        "This is unexpected. Please contact DataShuttle "
+        "devs at our GitHub page."
+    )
 
 
 def perform_rclone_check(cfg: Configs) -> str:
-    """"""
+    """
+    Use Rclone's `check` command to build a list of files that
+    are the same ("="), different ("*"), found in local only ("+")
+    or central only ("-"). The output is formatted as "<symbol> <path>\n".
+    """
     local_filepath = cfg.get_base_folder("local").as_posix()
     central_filepath = cfg.get_base_folder("central").as_posix()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -562,6 +562,10 @@ def clear_capsys(capsys):
 
 def write_file(path_, contents="", append=False):
     key = "a" if append else "w"
+
+    if not path_.parent.is_dir():
+        os.makedirs(path_.parent, exist_ok=True)
+
     with open(path_, key) as file:
         file.write(contents)
 

--- a/tests/tests_integration/test_transfer_checks.py
+++ b/tests/tests_integration/test_transfer_checks.py
@@ -9,9 +9,23 @@ from datashuttle.utils.rclone import get_local_and_central_file_differences
 
 
 class TestTransferChecks(BaseTest):
-    """ """
-
     def test_rclone_check(self, project):
+        """
+        Test rclone.get_local_and_central_file_differences(). This function
+        returns a dictionary where values are list of paths and keys
+        separate based on differences between local and central projects.
+
+        A file is either in local only, in central only, found in
+        both and the same or found in both and different. RClone does
+        not currently return why the different files are different, just
+        that they are different (see question):
+        https://forum.rclone.org/t/rclone-check-find-which-file-is-newer-if-there-is-a-difference/42853
+
+        This test first builds a project in which files are found in
+        all of the above cases. It then runs
+        `get_local_and_central_file_differences()` and checks the output is
+        as expected.
+        """
         (local := project.cfg["local_path"] / "rawdata").mkdir(parents=True)
         (central := project.cfg["central_path"] / "rawdata").mkdir(
             parents=True
@@ -34,6 +48,7 @@ class TestTransferChecks(BaseTest):
         ]
         # fmt: on
 
+        # Build the project according to the above spec
         for folder_info in folder_structure:
             path_, type_ = folder_info
 
@@ -67,6 +82,7 @@ class TestTransferChecks(BaseTest):
 
         results = get_local_and_central_file_differences(project.cfg)
 
+        # Check the results are sorted into cases correctly.
         for folder_info in folder_structure:
             path_, type_ = folder_info
 

--- a/tests/tests_integration/test_transfer_checks.py
+++ b/tests/tests_integration/test_transfer_checks.py
@@ -1,0 +1,80 @@
+import os
+import shutil
+from pathlib import Path
+
+import test_utils
+from base import BaseTest
+
+from datashuttle.utils.rclone import get_local_and_central_file_differences
+
+
+class TestTransferChecks(BaseTest):
+    """ """
+
+    def test_rclone_check(self, project):
+        (local := project.cfg["local_path"] / "rawdata").mkdir(parents=True)
+        (central := project.cfg["central_path"] / "rawdata").mkdir(
+            parents=True
+        )
+
+        # fmt: off
+        folder_structure = [
+            ["sub-001/ses-001/ephys/local_only_1.txt",          "local_only"],
+            ["sub-001/ses-001/behav/same_2.txt",                "same"],
+            ["sub-001/ses-002/anat/local_only_3.txt",           "local_only"],
+            ["sub-001/ses-002/anat/central_only_4.txt",         "central_only"],
+            ["sub-001/ses-003/ephys/newer_in_central_5.txt",    "newer_in_central"],
+            ["sub-002/ses-002/anat/same_6.txt",                 "same"],
+            ["sub-003/ses-003/behav/newer_in_central_7.txt",    "newer_in_central"],
+            ["sub-003/ses-004/funcimg/newer_in_local_8.txt",    "newer_in_local"],
+            ["sub-004/ses-005/behav/newer_in_local_9.txt",      "newer_in_local"],
+            ["sub-005/ses-001/ephys/same_10.txt",               "same"],
+            ["sub-005/ses-001/ephys/local_only_11.txt",         "local_only"],
+            ["sub-005/ses-001/ephys/central_only_12.txt",       "central_only"],
+        ]
+        # fmt: on
+
+        for folder_info in folder_structure:
+            path_, type_ = folder_info
+
+            if type_ == "local_only":
+                test_utils.write_file(local / path_)
+
+            elif type_ == "central_only":
+                test_utils.write_file(central / path_)
+
+            elif type_ == "same":
+                test_utils.write_file(local / path_)
+                os.makedirs(central / Path(path_).parent, exist_ok=True)
+                shutil.copy(local / path_, central / path_)
+
+            else:
+                if type_ == "newer_in_local":
+                    test_utils.write_file(local / path_)
+                    os.makedirs(central / Path(path_).parent, exist_ok=True)
+                    shutil.copy(local / path_, central / path_)
+                    test_utils.write_file(
+                        local / path_, "new text", append=True
+                    )
+
+                elif type_ == "newer_in_central":
+                    test_utils.write_file(local / path_)
+                    os.makedirs(central / Path(path_).parent, exist_ok=True)
+                    shutil.copy(local / path_, central / path_)
+                    test_utils.write_file(
+                        central / path_, "new text", append=True
+                    )
+
+        results = get_local_and_central_file_differences(project.cfg)
+
+        for folder_info in folder_structure:
+            path_, type_ = folder_info
+
+            if type_ in ["newer_in_local", "newer_in_central"]:
+                type_ = "different"
+
+            for results_type, results_paths in results.items():
+                if results_type == type_:
+                    assert path_ in results_paths
+                else:
+                    assert path_ not in results_paths


### PR DESCRIPTION
This PR wraps [Rclone's check](https://rclone.org/commands/rclone_check/) command. This is a nice command that checks a source directory (in our case `local_path` against a target directory (in our case `central_path`) and returns a list of all files and whether they are:

- same across source and target
- different across source and target
- found in source only
- found in target only

It outputs this in a relatively parseable way. This PR introduces:

1) function to directly wrap the `rclone check` call
2) function to parse the output into a dict of paths separated based on the above aases
3) testing function

This PR includes a test, and is internal so no docs required. This function is aimed to be used as part of the TUI filetree to indicate  differences between local and central filesystems - anything that will case this easier please let me know!
