### PR TITLE
Change `DataShuttle` public 'shower' functions to getters. [6]

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -193,7 +193,7 @@ def make_folders(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
-    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    filtered_kwargs = remove_nonetype_entries(kwargs)
 
     run_command(project, project.make_folders, **filtered_kwargs)
 
@@ -209,7 +209,7 @@ def upload(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
-    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    filtered_kwargs = remove_nonetype_entries(kwargs)
 
     run_command(
         project,
@@ -243,7 +243,7 @@ def download(project: DataShuttle, args: Any) -> None:
     """"""
     kwargs = make_kwargs(args)
 
-    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    filtered_kwargs = remove_nonetype_entries(kwargs)
 
     run_command(
         project,
@@ -321,37 +321,73 @@ def set_top_level_folder(project: DataShuttle, args: Any) -> None:
 # Get Local Path --------------------------------------------------------------
 
 
-def show_local_path(*args: Any) -> None:
+def get_local_path(*args: Any) -> None:
     """"""
     project = args[0]
-    project.show_local_path()
-
-
-# Get Appdir Path -------------------------------------------------------------
-
-
-def show_datashuttle_path(*args: Any) -> None:
-    """"""
-    project = args[0]
-    project.show_datashuttle_path()
-
-
-# Get Config Path -------------------------------------------------------------
-
-
-def show_config_path(*args: Any) -> None:
-    """"""
-    project = args[0]
-    project.show_config_path()
+    print(project.get_local_path())
 
 
 # Get Central Path ------------------------------------------------------------
 
 
-def show_central_path(*args: Any) -> None:
+def get_central_path(*args: Any) -> None:
     """"""
     project = args[0]
-    project.show_central_path()
+    print(project.get_central_path())
+
+
+# Get DataShuttle Path --------------------------------------------------------
+
+
+def get_datashuttle_path(*args: Any) -> None:
+    """"""
+    project = args[0]
+    print(project.get_datashuttle_path())
+
+
+# Get Config Path -------------------------------------------------------------
+
+
+def get_config_path(*args: Any) -> None:
+    """"""
+    project = args[0]
+    print(project.get_config_path())
+
+
+# Get Config Path -------------------------------------------------------------
+
+
+def get_logging_path(*args: Any) -> None:
+    """"""
+    project = args[0]
+    print(project.get_logging_path())
+
+
+# Get Existing Projects -------------------------------------------------------
+
+
+def get_existing_projects(*args: Any) -> None:
+    """"""
+    project = args[0]
+    print(project.get_existing_projects())
+
+
+# Get Next Sub Number --------------------------------------------------------
+
+
+def get_next_sub_number(*args: Any) -> None:
+    """"""
+    project = args[0]
+    print(project.get_next_sub_number())
+
+
+# Get Next Sub Number --------------------------------------------------------
+
+
+def get_next_ses_number(project: DataShuttle, args: Any) -> None:
+    """"""
+    kwargs = make_kwargs(args)
+    print(project.get_next_ses_number(kwargs["sub"]))
 
 
 # Show Configs ----------------------------------------------------------------
@@ -361,24 +397,6 @@ def show_configs(*args: Any) -> None:
     """"""
     project = args[0]
     project.show_configs()
-
-
-# Validate Project  -----------------------------------------------------------
-
-
-def validate_project(*args: Any) -> None:
-    """"""
-    project = args[0]
-    project.validate_project()
-
-
-# Show Logging Path -----------------------------------------------------------
-
-
-def show_logging_path(*args: Any) -> None:
-    """"""
-    project = args[0]
-    project.show_logging_path()
 
 
 # Show Local Tree -------------------------------------------------------------
@@ -393,34 +411,19 @@ def show_local_tree(*args: Any) -> None:
 # Show Top Level Folder -------------------------------------------------------
 
 
-def show_top_level_folder(*args: Any) -> None:
+def get_top_level_folder(*args: Any) -> None:
     """"""
     project = args[0]
-    project.show_top_level_folder()
+    print(project.get_top_level_folder())
 
 
-def show_existing_projects(*args: Any) -> None:
+# Validate Project  -----------------------------------------------------------
+
+
+def validate_project(*args: Any) -> None:
     """"""
     project = args[0]
-    project.show_existing_projects()
-
-
-# Show Next Sub Number --------------------------------------------------------
-
-
-def show_next_sub_number(*args: Any) -> None:
-    """"""
-    project = args[0]
-    project.show_next_sub_number()
-
-
-# Show Next Sub Number --------------------------------------------------------
-
-
-def show_next_ses_number(project: DataShuttle, args: Any) -> None:
-    """"""
-    kwargs = make_kwargs(args)
-    project.show_next_ses_number(kwargs["sub"])
+    project.validate_project(error_or_warn="warn", local_only=False)
 
 
 # Check Name Processing -------------------------------------------------------
@@ -828,48 +831,105 @@ def construct_parser():
         help=help("required_str"),
     )
 
-    # Show Local Path
+    # Get Local Path
     # -------------------------------------------------------------------------
 
-    show_local_path_parser = subparsers.add_parser(
-        "show-local-path",
-        aliases=["show_local_path"],
-        description=process_docstring(DataShuttle.show_local_path.__doc__),
+    get_local_path_parser = subparsers.add_parser(
+        "get-local-path",
+        aliases=["get_local_path"],
+        description=process_docstring(DataShuttle.get_local_path.__doc__),
         help="",
     )
-    show_local_path_parser.set_defaults(func=show_local_path)
-
-    show_datashuttle_path_parser = subparsers.add_parser(
-        "show-datashuttle-path",
-        aliases=["show_datashuttle_path"],
-        description=process_docstring(
-            DataShuttle.show_datashuttle_path.__doc__
-        ),
-        help="",
-    )
-    show_datashuttle_path_parser.set_defaults(func=show_datashuttle_path)
-
-    # Get Config Path
-    # -------------------------------------------------------------------------
-
-    show_config_path_parser = subparsers.add_parser(
-        "show-config-path",
-        aliases=["show_config_path"],
-        description=process_docstring(DataShuttle.show_config_path.__doc__),
-        help="",
-    )
-    show_config_path_parser.set_defaults(func=show_config_path)
+    get_local_path_parser.set_defaults(func=get_local_path)
 
     # Get Central Path
     # -------------------------------------------------------------------------
 
-    show_central_path_parser = subparsers.add_parser(
-        "show-central-path",
-        aliases=["show_central_path"],
-        description=process_docstring(DataShuttle.show_central_path.__doc__),
+    get_central_path_parser = subparsers.add_parser(
+        "get-central-path",
+        aliases=["get_central_path"],
+        description=process_docstring(DataShuttle.get_central_path.__doc__),
         help="",
     )
-    show_central_path_parser.set_defaults(func=show_central_path)
+    get_central_path_parser.set_defaults(func=get_central_path)
+
+    # Get DataShuttle Path
+    # -------------------------------------------------------------------------
+
+    get_datashuttle_path_parser = subparsers.add_parser(
+        "get-datashuttle-path",
+        aliases=["get_datashuttle_path"],
+        description=process_docstring(
+            DataShuttle.get_datashuttle_path.__doc__
+        ),
+        help="",
+    )
+    get_datashuttle_path_parser.set_defaults(func=get_datashuttle_path)
+
+    # Get Config Path
+    # -------------------------------------------------------------------------
+
+    get_config_path_parser = subparsers.add_parser(
+        "get-config-path",
+        aliases=["get_config_path"],
+        description=process_docstring(DataShuttle.get_config_path.__doc__),
+        help="",
+    )
+    get_config_path_parser.set_defaults(func=get_config_path)
+
+    # Get Logging Path
+    # -------------------------------------------------------------------------
+
+    get_logging_path_parser = subparsers.add_parser(
+        "get-logging-path",
+        aliases=["get_logging_path"],
+        description=process_docstring(DataShuttle.get_logging_path.__doc__),
+        help="",
+    )
+    get_logging_path_parser.set_defaults(func=get_logging_path)
+
+    # Get Existing Projects
+    # -------------------------------------------------------------------------
+
+    get_existing_projects_parser = subparsers.add_parser(
+        "get-existing-projects",
+        aliases=["get_existing_projects"],
+        description=process_docstring(
+            DataShuttle.get_existing_projects.__doc__
+        ),
+        help="",
+    )
+    get_existing_projects_parser.set_defaults(func=get_existing_projects)
+
+    # Get Next Sub Number
+    # -------------------------------------------------------------------------
+
+    get_next_sub_number_parser = subparsers.add_parser(
+        "get-next-sub-number",
+        aliases=["get_next_sub_number"],
+        description="Get the next subject number across "
+        "local and central machines.",
+        help="",
+    )
+    get_next_sub_number_parser.set_defaults(func=get_next_sub_number)
+
+    # Get Next Ses Number
+    # -------------------------------------------------------------------------
+
+    get_next_ses_number_parser = subparsers.add_parser(
+        "get-next-ses-number",
+        aliases=["get_next_ses_number"],
+        description="Get the next session number across "
+        "local and central machines.",
+        help="",
+    )
+    get_next_ses_number_parser.set_defaults(func=get_next_ses_number)
+
+    get_next_ses_number_parser.add_argument(
+        "sub",
+        type=str,
+        help="Required: (str) sub to find latest session for.",
+    )
 
     # Show Configs
     # -------------------------------------------------------------------------
@@ -881,17 +941,6 @@ def construct_parser():
         help="",
     )
     show_configs_parser.set_defaults(func=show_configs)
-
-    # Show Logging Path
-    # -------------------------------------------------------------------------
-
-    show_logging_path_parser = subparsers.add_parser(
-        "show-logging-path",
-        aliases=["show_logging_path"],
-        description=process_docstring(DataShuttle.show_logging_path.__doc__),
-        help="",
-    )
-    show_logging_path_parser.set_defaults(func=show_logging_path)
 
     # Show Local tree
     # -------------------------------------------------------------------------
@@ -907,60 +956,15 @@ def construct_parser():
     # Show Top Level Folder
     # -------------------------------------------------------------------------
 
-    show_top_level_folder_parser = subparsers.add_parser(
-        "show-top-level-folder",
-        aliases=["show_top_level_folder"],
+    get_top_level_folder_parser = subparsers.add_parser(
+        "get-top-level-folder",
+        aliases=["get_top_level_folder"],
         description=process_docstring(
-            DataShuttle.show_top_level_folder.__doc__
+            DataShuttle.get_top_level_folder.__doc__
         ),
         help="",
     )
-    show_top_level_folder_parser.set_defaults(func=show_top_level_folder)
-
-    # Show Existing Projects
-    # -------------------------------------------------------------------------
-
-    show_existing_projects_parser = subparsers.add_parser(
-        "show-existing-projects",
-        aliases=["show_existing_projects"],
-        description=process_docstring(
-            DataShuttle.show_existing_projects.__doc__
-        ),
-        help="",
-    )
-    show_existing_projects_parser.set_defaults(func=show_existing_projects)
-
-    # Show Next Sub Number
-    # -------------------------------------------------------------------------
-
-    show_next_sub_number_parser = subparsers.add_parser(
-        "show-next-sub-number",
-        aliases=["show_next_sub_number"],
-        description=process_docstring(
-            DataShuttle.show_next_sub_number.__doc__
-        ),
-        help="",
-    )
-    show_next_sub_number_parser.set_defaults(func=show_next_sub_number)
-
-    # Show Next Ses Number
-    # -------------------------------------------------------------------------
-
-    show_next_ses_number_parser = subparsers.add_parser(
-        "show-next-ses-number",
-        aliases=["show_next_ses_number"],
-        description=process_docstring(
-            DataShuttle.show_next_ses_number.__doc__
-        ),
-        help="",
-    )
-    show_next_ses_number_parser.set_defaults(func=show_next_ses_number)
-
-    show_next_ses_number_parser.add_argument(
-        "sub",
-        type=str,
-        help="Required: (str) sub to find latest session for.",
-    )
+    get_top_level_folder_parser.set_defaults(func=get_top_level_folder)
 
     # Validate Project
     # -------------------------------------------------------------------------

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -73,7 +73,7 @@ class DataShuttle:
                    and folders are specified in make_config_file().
                    Datashuttle-related files are stored in
                    a .datashuttle folder in the user home
-                   folder. Use show_datashuttle_path() to
+                   folder. Use get_datashuttle_path() to
                    see the path to this folder.
 
     print_startup_message : If `True`, a start-up message displaying the
@@ -111,7 +111,7 @@ class DataShuttle:
 
         if print_startup_message:
             if self.cfg:
-                self.show_top_level_folder()
+                self._display_top_level_folder()
 
         rclone.prompt_rclone_download_if_does_not_exist()
 
@@ -160,7 +160,7 @@ class DataShuttle:
 
         self._update_persistent_setting("top_level_folder", folder_name)
 
-        self.show_top_level_folder()
+        self._display_top_level_folder()
 
     @check_configs_set
     def make_folders(
@@ -221,7 +221,7 @@ class DataShuttle:
         """
         self._start_log("make-folders", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._display_top_level_folder()
 
         utils.log("\nFormatting Names...")
         ds_logger.log_names(["sub_names", "ses_names"], [sub_names, ses_names])
@@ -264,64 +264,6 @@ class DataShuttle:
         )
 
         ds_logger.close_log_filehandler()
-
-    @check_configs_set
-    def get_next_sub_number(
-        self, return_with_prefix: bool = True, local_only: bool = False
-    ) -> str:
-        """
-        Convenience function for get_next_sub_or_ses_number
-        to find the next subject number.
-
-        Parameters
-        ----------
-
-        return_with_prefix : bool
-            If `True`, return with the "sub-" prefix.
-
-        local_only : bool
-            If `True, only get names from `local_path`, otherwise from
-            `local_path` and `central_path`.
-        """
-        return getters.get_next_sub_or_ses_number(
-            self.cfg,
-            sub=None,
-            local_only=local_only,
-            return_with_prefix=return_with_prefix,
-            search_str="sub-*",
-        )
-
-    @check_configs_set
-    def get_next_ses_number(
-        self,
-        sub: str,
-        return_with_prefix: bool = True,
-        local_only: bool = False,
-    ) -> str:
-        """
-        Convenience function for get_next_sub_or_ses_number
-        to find the next session number.
-
-        Parameters
-        ----------
-
-        sub: Optional[str]
-            Name of the subject to find the next session of.
-
-        return_with_prefix : bool
-            If `True`, return with the "ses-" prefix.
-
-        local_only : bool
-            If `True, only get names from `local_path`, otherwise from
-            `local_path` and `central_path`.
-        """
-        return getters.get_next_sub_or_ses_number(
-            self.cfg,
-            sub=sub,
-            local_only=local_only,
-            return_with_prefix=return_with_prefix,
-            search_str="ses-*",
-        )
 
     # -------------------------------------------------------------------------
     # Public File Transfer
@@ -391,7 +333,7 @@ class DataShuttle:
         if init_log:
             self._start_log("upload", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._display_top_level_folder()
 
         TransferData(
             self.cfg,
@@ -428,7 +370,7 @@ class DataShuttle:
         if init_log:
             self._start_log("download", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._display_top_level_folder()
 
         TransferData(
             self.cfg,
@@ -514,7 +456,7 @@ class DataShuttle:
         """
         self._start_log("upload-specific-folder-or-file", local_vars=locals())
 
-        self.show_top_level_folder()
+        self._display_top_level_folder()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local"),
@@ -567,7 +509,7 @@ class DataShuttle:
             "download-specific-folder-or-file", local_vars=locals()
         )
 
-        self.show_top_level_folder()
+        self._display_top_level_folder()
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central"),
@@ -667,7 +609,7 @@ class DataShuttle:
 
         These settings are stored in a config file on the
         datashuttle path (not in the project folder)
-        on the local machine. Use show_config_path() to
+        on the local machine. Use get_config_path() to
         get the full path to the saved config file.
 
         Use update_config_file() to update a single config, and
@@ -853,66 +795,53 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     # -------------------------------------------------------------------------
-    # Public Getters
+    # Getters
     # -------------------------------------------------------------------------
 
     @check_configs_set
-    def show_local_path(self) -> None:
+    def get_local_path(self) -> Path:
         """
-        Print the projects local path.
+        Get the projects local path.
         """
-        utils.print_message_to_user(self.cfg["local_path"].as_posix())
+        return self.cfg["local_path"]
 
-    def show_datashuttle_path(self) -> None:
+    @check_configs_set
+    def get_central_path(self) -> Path:
         """
-        Print the path to the local datashuttle
+        Get the project central path.
+        """
+        return self.cfg["central_path"]
+
+    def get_datashuttle_path(self) -> Path:
+        """
+        Get the path to the local datashuttle
         folder where configs another other
         datashuttle files are stored.
         """
-        utils.print_message_to_user(self._datashuttle_path.as_posix())
+        return self._datashuttle_path
 
     @check_configs_set
-    def show_config_path(self) -> None:
+    def get_config_path(self) -> Path:
         """
-        Print the full path to the DataShuttle config file.
-        This is always formatted to UNIX style.
+        Get the full path to the DataShuttle config file.
         """
-        utils.print_message_to_user(self._config_path.as_posix())
+        return self._config_path
 
     @check_configs_set
-    def show_central_path(self) -> None:
-        """
-        Print the project central path.
-        This is always formatted to UNIX style.
-        """
-        utils.print_message_to_user(self.cfg["central_path"].as_posix())
+    def get_configs(self) -> Configs:
+        return self.cfg
 
     @check_configs_set
-    def show_configs(self) -> None:
+    def get_logging_path(self) -> Path:
         """
-        Print the current configs to the terminal.
+        Get the path where datashuttle logs are written.
         """
-        utils.print_message_to_user(self._get_json_dumps_config())
+        return self.cfg.logging_path
 
     @check_configs_set
-    def show_logging_path(self) -> None:
+    def get_top_level_folder(self) -> Path:
         """
-        Print the path where datashuttle logs are written.
-        """
-        utils.print_message_to_user(self.cfg.logging_path)
-
-    @check_configs_set
-    def show_local_tree(self) -> None:
-        """
-        Print a tree schematic of all files and folders
-        in the local project.
-        """
-        ds_logger.print_tree(self.cfg["local_path"])
-
-    @check_configs_set
-    def show_top_level_folder(self) -> None:
-        """
-        Print the current working top level folder (e.g.
+        Get the current working top level folder (e.g.
         'rawdata', 'derivatives')
 
         The top_level_folder defines in which top level folder new
@@ -925,74 +854,97 @@ class DataShuttle:
         folder), use the 'command upload_entire_project' or
         'download_entire_project'.
         """
-        utils.print_message_to_user(
-            f"\nThe working top level folder is: "
-            f"{self.cfg.top_level_folder}\n"
-        )
+        return self.cfg.top_level_folder
+
+    @staticmethod
+    def get_existing_projects() -> List[Path]:
+        """
+        Get a list of existing project names found on the local machine.
+        This is based on project folders in the "home / .datashuttle" folder
+        that contain valid config.yaml files.
+        """
+        return getters.get_existing_project_paths()
 
     @check_configs_set
-    def show_next_sub_number(self) -> None:
+    def get_next_sub_number(
+        self, return_with_prefix: bool = True, local_only: bool = False
+    ) -> str:
         """
-        Show a suggested value for the next available subject number.
-        The local and central repository will be searched, and the
-        maximum existing subject number + 1 will be suggested.
-
-        In the case where there are multiple 'local' machines interacting
-        with a central central repository, this function will not detect
-        subject numbers of other 'local' machines. For example, if there
-        is one machine for behavioural and another for electrophysiological
-        data collection, connected to a central server that is 'central'.
-        If run on the behavioural data collection machine, this function
-        will suggest the next number based on the subjects found on the
-        behavioural machine and central machine, but not the
-        electrophysiological machine.
-        """
-        suggested_new_num = self.get_next_sub_number()
-
-        utils.print_message_to_user(
-            "Local and Central repository searched. "
-            f"The suggested new subject number is: {suggested_new_num}"
-        )
-
-    @check_configs_set
-    def show_next_ses_number(self, sub: Optional[str]) -> None:
-        """
-        Show a suggested value for the next session number of a
-        given subject. The local and central repository will be
-        searched, and the maximum session number + 1 will be suggested.
-
-        In the case where there are multiple 'local' machines interacting
-        with a central repository, this function will not detect
-        session numbers of other 'local' machines. For example, if there
-        is one machine for behavioural and another for electrophysiological
-        data collection, connected to a central server that is 'central'.
-        If run on the behavioural data collection machine, this function
-        will suggest the next number based on the sessions found on the
-        behavioural machine and central machine, but not the
-        electrophysiological machine.
+        Convenience function for get_next_sub_or_ses_number
+        to find the next subject number.
 
         Parameters
         ----------
 
-        sub : the subject for which to suggest the next available session.
-        """
-        suggested_new_num = self.get_next_ses_number(sub)
+        return_with_prefix : bool
+            If `True`, return with the "sub-" prefix.
 
-        utils.print_message_to_user(
-            f"Local and Central repository searched for sessions for {sub}. "
-            f"The suggested new session number is: {suggested_new_num}"
+        local_only : bool
+            If `True, only get names from `local_path`, otherwise from
+            `local_path` and `central_path`.
+        """
+        return getters.get_next_sub_or_ses_number(
+            self.cfg,
+            sub=None,
+            local_only=local_only,
+            return_with_prefix=return_with_prefix,
+            search_str="sub-*",
         )
 
-    def show_existing_projects(self) -> None:
+    @check_configs_set
+    def get_next_ses_number(
+        self,
+        sub: str,
+        return_with_prefix: bool = True,
+        local_only: bool = False,
+    ) -> str:
         """
-        Print a list of existing project names found on the local machine.
-        This is based on project folders in the "home / .datashuttle" folder
-        that contain valid config.yaml files.
+        Convenience function for get_next_sub_or_ses_number
+        to find the next session number.
+
+        Parameters
+        ----------
+
+        sub: Optional[str]
+            Name of the subject to find the next session of.
+
+        return_with_prefix : bool
+            If `True`, return with the "ses-" prefix.
+
+        local_only : bool
+            If `True, only get names from `local_path`, otherwise from
+            `local_path` and `central_path`.
         """
-        project_names, _ = getters.get_existing_project_paths_and_names()
-        utils.print_message_to_user(
-            f"The existing project names are {project_names}."
+        return getters.get_next_sub_or_ses_number(
+            self.cfg,
+            sub=sub,
+            local_only=local_only,
+            return_with_prefix=return_with_prefix,
+            search_str="ses-*",
         )
+
+    # -------------------------------------------------------------------------
+    # Showers
+    # -------------------------------------------------------------------------
+
+    @check_configs_set
+    def show_configs(self) -> None:
+        """
+        Print the current configs to the terminal.
+        """
+        utils.print_message_to_user(self._get_json_dumps_config())
+
+    @check_configs_set
+    def show_local_tree(self) -> None:
+        """
+        Print a tree schematic of all files and folders
+        in the local project.
+        """
+        ds_logger.print_tree(self.cfg["local_path"])
+
+    # -------------------------------------------------------------------------
+    # Validators
+    # -------------------------------------------------------------------------
 
     @check_configs_set
     def validate_project(
@@ -1044,7 +996,7 @@ class DataShuttle:
         if isinstance(names, str):
             names = [names]
 
-        formatted_names = formatting.format_names(names, prefix)
+        formatted_names = formatting.check_and_format_names(names, prefix)
         utils.print_message_to_user(formatted_names)
 
     # -------------------------------------------------------------------------
@@ -1080,10 +1032,6 @@ class DataShuttle:
             transfer_all_func()
 
         self.cfg.top_level_folder = tmp_current_top_level_folder
-
-    # -------------------------------------------------------------------------
-    # Utils
-    # -------------------------------------------------------------------------
 
     def _get_rclone_config_name(
         self, connection_method: Optional[str] = None
@@ -1215,7 +1163,6 @@ class DataShuttle:
             log=True,
         )
 
-    # -------------------------------------------------------------------------
     # Persistent settings
     # -------------------------------------------------------------------------
 
@@ -1270,3 +1217,14 @@ class DataShuttle:
         with open(self._persistent_settings_path, "r") as settings_file:
             settings = yaml.full_load(settings_file)
         return settings
+
+    @check_configs_set
+    def _display_top_level_folder(self) -> None:
+        """
+        Print the current working top level folder (e.g.
+        'rawdata', 'derivatives')
+        """
+        utils.print_message_to_user(
+            f"\nThe working top level folder is: "
+            f"{self.cfg.top_level_folder}\n"
+        )

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -181,7 +181,7 @@ def get_max_sub_or_ses_num_and_value_length(
     return max_existing_num, num_value_digits
 
 
-def get_existing_project_paths_and_names() -> Tuple[List[str], List[Path]]:
+def get_existing_project_paths() -> List[Path]:
     """
     Return full path and names of datashuttle projects on
     this local machine. A project is determined by a project
@@ -195,7 +195,6 @@ def get_existing_project_paths_and_names() -> Tuple[List[str], List[Path]]:
     )
 
     existing_project_paths = []
-    existing_project_names = []
     for folder_name in all_folders:
         config_file = list(
             (datashuttle_path / folder_name).glob("config.yaml")
@@ -210,9 +209,8 @@ def get_existing_project_paths_and_names() -> Tuple[List[str], List[Path]]:
             )
         elif len(config_file) == 1:
             existing_project_paths.append(datashuttle_path / folder_name)
-            existing_project_names.append(folder_name)
 
-    return existing_project_names, existing_project_paths
+    return existing_project_paths
 
 
 def get_all_sub_and_ses_names(cfg: Configs, local_only: bool) -> Dict:

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -515,7 +515,7 @@ datashuttle my_first_project set-top-level-folder derivatives
 
 The *top-level-folder* setting will remain across Datashuttle sessions.
 
-To see the current *top-level-folder*, the command `show-top-level-folder` can be used.
+To see the current *top-level-folder*, the command `get-top-level-folder` can be used.
 
 :::
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,7 +246,7 @@ def get_all_folders_used():
 
 
 def get_config_path_with_cli(project_name=None):
-    stdout = run_cli(" show_config_path", project_name)
+    stdout = run_cli("get_config_path", project_name)
     path_ = stdout[0].split(".yaml")[0] + ".yaml"
     return path_
 

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -547,6 +547,10 @@ class TestCommandLineInterface(BaseTest):
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_get_paths(self, project, sep):
+        """
+        Check that all CLI commands to return a path
+        show the correct path
+        """
         stdout, _ = test_utils.run_cli(
             f"get{sep}local{sep}path", project.project_name
         )
@@ -574,6 +578,10 @@ class TestCommandLineInterface(BaseTest):
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_get_top_level_folder(self, project, sep):
+        """
+        Check the CLI command to get the top-level-folder
+        shows the correct name.
+        """
         project.set_top_level_folder("derivatives")
 
         stdout, stderr = test_utils.run_cli(
@@ -583,6 +591,10 @@ class TestCommandLineInterface(BaseTest):
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_existing_projects(self, project, sep):
+        """
+        Check that the CLI argument to get existing projects
+        works and returns existing projects (1 is tested).
+        """
         stdout, stderr = test_utils.run_cli(
             f"get{sep}existing{sep}projects", project.project_name
         )
@@ -590,6 +602,10 @@ class TestCommandLineInterface(BaseTest):
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_get_cli_get_next_ses_sub_number(self, project, sep):
+        """
+        Check the CLI arguments to get the next subject
+        or session number, shows the correct sub / ses number.
+        """
         project.make_folders("sub-001", "ses-001")
 
         stdout, _ = test_utils.run_cli(
@@ -604,6 +620,10 @@ class TestCommandLineInterface(BaseTest):
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_show_functions(self, sep, project):
+        """
+        Check that the CLI arguments testing the
+        shower-functions return something sensible.
+        """
         stdout, _ = test_utils.run_cli(
             f"show{sep}configs", project.project_name
         )
@@ -615,13 +635,13 @@ class TestCommandLineInterface(BaseTest):
         )
         assert "sub-001_hello-world" in stdout
 
-        stdout, _ = test_utils.run_cli(
-            f"get{sep}top{sep}level{sep}folder", project.project_name
-        )
-        assert str(project.get_top_level_folder()) in stdout
-
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_validate_project(self, project, sep):
+        """
+        Check the at CLI command to validate project returns
+        some validation, indicating the underlying function
+        is called correctly.
+        """
         project.make_folders("sub-001")
         os.makedirs(project.cfg["central_path"] / "rawdata" / "sub-1")
 
@@ -633,11 +653,21 @@ class TestCommandLineInterface(BaseTest):
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_supply_config_file(self, sep):
+        """
+        Here we use the test environment just to check that the
+        CLI argument to supply a config file is passing
+        the correct argument to the datahuttle API.
+        """
         stdout, _ = test_utils.run_cli(f"supply{sep}config{sep}file some/path")
         assert "some/path" in stdout
 
     @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_clitest(self, project, sep):
+    def test_cli_setup_ssh_connection(self, project, sep):
+        """
+        Test the CLI argument to set up an ssh connection runs,
+        does not check functionality just that it is calling the
+        underlying API properly.
+        """
         _, stderr = test_utils.run_cli(
             f"setup{sep}ssh{sep}connection{sep}to{sep}central{sep}server",
             project.project_name,

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -38,9 +38,9 @@ PROTECTED_TEST_PROJECT_NAME = "ds_protected_test_name"
 
 
 class TestCommandLineInterface(BaseTest):
-    # ----------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Test CLI Variables are read and passed correctly
-    # ----------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     def test_all_commands_appear_in_help(self):
         """
@@ -227,7 +227,8 @@ class TestCommandLineInterface(BaseTest):
         As upload_folder_or_file and download_folder_or_file
         take identical args, test both together"""
         stdout, stderr = test_utils.run_cli(
-            f" {upload_or_download}{sep}specific{sep}folder{sep}or{sep}file /fake/filepath"
+            f" {upload_or_download}{sep}specific{sep}folder{sep}or{sep}file "
+            f"/fake/filepath"
         )
         args_, kwargs_ = self.decode(stdout)
 
@@ -270,9 +271,9 @@ class TestCommandLineInterface(BaseTest):
         ]
         assert kwargs_["ses_names"] == ["5", "06", "007"]
 
-    # ----------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Test CLI Functionality
-    # ----------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_update_config_file(self, clean_project_name, sep, tmp_path):
@@ -364,7 +365,8 @@ class TestCommandLineInterface(BaseTest):
         ses = ["ses-123", "ses-999"]
 
         test_utils.run_cli(
-            f"make_folders --datatype all --sub_names {self.to_cli_input(subs)} --ses_names {self.to_cli_input(ses)} ",
+            f"make_folders --datatype all --sub_names "
+            f"{self.to_cli_input(subs)} --ses_names {self.to_cli_input(ses)} ",
             project.project_name,
         )
 
@@ -389,7 +391,8 @@ class TestCommandLineInterface(BaseTest):
         "_" vs. "-" command separators are not tested here to avoid
         adding another enumeration, as these tests are slow.
         Testing that the command runs with both separators is done above,
-        in test_upload_download_all_variables() and test_upload_download_variables()
+        in test_upload_download_all_variables() and
+        test_upload_download_variables()
         """
         subs, sessions = test_utils.get_default_sub_sessions_to_test()
 
@@ -453,7 +456,8 @@ class TestCommandLineInterface(BaseTest):
         )
 
         test_utils.run_cli(
-            f"{upload_or_download}_specific_folder_or_file {subs[1]}/{sessions[0]}/ephys/**",
+            f"{upload_or_download}_specific_folder_or_file "
+            f"{subs[1]}/{sessions[0]}/ephys/**",
             project.project_name,
         )
 
@@ -463,9 +467,9 @@ class TestCommandLineInterface(BaseTest):
 
         assert path_to_check.is_dir()
 
-    # ----------------------------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Test Errors Propagate from API
-    # ----------------------------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     def test_warning_on_startup_cli(self, clean_project_name):
         """
@@ -499,11 +503,10 @@ class TestCommandLineInterface(BaseTest):
         properly processed names to stdout
         """
         stdout, stderr = test_utils.run_cli(
-            f"check{sep}name{sep}formatting sub --names sub-001 1{tags('to')}02",
+            f"check{sep}name{sep}formatting sub --names 1{tags('to')}03",
             clean_project_name,
         )
-
-        assert "['sub-001', 'sub-01', 'sub-02']" in stdout
+        assert "['sub-01', 'sub-02', 'sub-03']" in stdout
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_set_top_level_folder(self, project, sep):
@@ -515,20 +518,19 @@ class TestCommandLineInterface(BaseTest):
         set-top-level-folder raises an error.
         """
         stdout, _ = test_utils.run_cli(
-            f"show{sep}top{sep}level{sep}folder", project.project_name
+            f"get{sep}top{sep}level{sep}folder", project.project_name
         )
 
         assert "rawdata" in stdout
 
-        stdout, _ = test_utils.run_cli(
+        stdout, stderr = test_utils.run_cli(
             f"set{sep}top{sep}level{sep}folder derivatives",
             project.project_name,
         )
-
         assert "derivatives" in stdout
 
         stdout, _ = test_utils.run_cli(
-            f"show{sep}top{sep}level{sep}folder", project.project_name
+            f"get{sep}top{sep}level{sep}folder", project.project_name
         )
 
         assert "derivatives" in stdout
@@ -542,6 +544,105 @@ class TestCommandLineInterface(BaseTest):
             "Folder name: NOT_RECOGNISED is not in permitted top-level folder names"
             in stderr
         )
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_cli_get_paths(self, project, sep):
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}local{sep}path", project.project_name
+        )
+        assert str(project.get_local_path()) in stdout
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}central{sep}path", project.project_name
+        )
+        assert str(project.get_central_path()) in stdout
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}datashuttle{sep}path", project.project_name
+        )
+        assert str(project.get_datashuttle_path()) in stdout
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}config{sep}path", project.project_name
+        )
+        assert str(project.get_config_path()) in stdout
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}logging{sep}path", project.project_name
+        )
+        assert str(project.get_logging_path()) in stdout
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_cli_get_top_level_folder(self, project, sep):
+        project.set_top_level_folder("derivatives")
+
+        stdout, stderr = test_utils.run_cli(
+            f"get{sep}top{sep}level{sep}folder", project.project_name
+        )
+        assert str(project.get_top_level_folder()) in stdout
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_cli_existing_projects(self, project, sep):
+        stdout, stderr = test_utils.run_cli(
+            f"get{sep}existing{sep}projects", project.project_name
+        )
+        assert str(project.get_existing_projects()[0].as_posix()) in stdout
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_get_cli_get_next_ses_sub_number(self, project, sep):
+        project.make_folders("sub-001", "ses-001")
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}next{sep}sub{sep}number", project.project_name
+        )
+        assert "sub-002" in stdout
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}next{sep}ses{sep}number sub-001", project.project_name
+        )
+        assert "ses-002" in stdout
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_cli_show_functions(self, sep, project):
+        stdout, _ = test_utils.run_cli(
+            f"show{sep}configs", project.project_name
+        )
+        assert str(project.cfg["local_path"].as_posix()) in stdout
+
+        project.make_folders("sub-001_hello-world")
+        stdout, _ = test_utils.run_cli(
+            f"show{sep}local{sep}tree", project.project_name
+        )
+        assert "sub-001_hello-world" in stdout
+
+        stdout, _ = test_utils.run_cli(
+            f"get{sep}top{sep}level{sep}folder", project.project_name
+        )
+        assert str(project.get_top_level_folder()) in stdout
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_cli_validate_project(self, project, sep):
+        project.make_folders("sub-001")
+        os.makedirs(project.cfg["central_path"] / "rawdata" / "sub-1")
+
+        _, stderr = test_utils.run_cli(
+            f"validate{sep}project", project.project_name
+        )
+
+        assert "A sub already exists" in stderr
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_cli_supply_config_file(self, sep):
+        stdout, _ = test_utils.run_cli(f"supply{sep}config{sep}file some/path")
+        assert "some/path" in stdout
+
+    @pytest.mark.parametrize("sep", ["-", "_"])
+    def test_clitest(self, project, sep):
+        _, stderr = test_utils.run_cli(
+            f"setup{sep}ssh{sep}connection{sep}to{sep}central{sep}server",
+            project.project_name,
+        )
+        assert "Cannot setup SSH connection" in stderr
 
     # ----------------------------------------------------------------------------------------------------------
     # Helpers

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -499,12 +499,8 @@ class TestConfigs(BaseTest):
             "local_filesystem",
         )
 
-        (
-            project_names,
-            project_paths,
-        ) = getters.get_existing_project_paths_and_names()
+        project_paths = getters.get_existing_project_paths()
 
-        assert sorted(project_names) == ["project_1", "project_3"]
         assert sorted(project_paths) == [
             (tmp_path / "projects" / "project_1"),
             (tmp_path / "projects" / "project_3"),

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -57,7 +57,7 @@ class TestPersistentSettings(BaseTest):
         assert project_reload.cfg.top_level_folder == "derivatives"
 
         stdout = test_utils.run_cli(
-            " show-top-level-folder", project.project_name
+            " get-top-level-folder", project.project_name
         )
 
-        assert "The working top level folder is: derivatives" in stdout[0]
+        assert "derivatives" in stdout[0]

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -448,7 +448,7 @@ class TestValidation(BaseTest):
 
         # ses-002 is bad for sub-2, ses-003 is bad for sub-4
         sub_names = ["sub-1_id-@", "sub-2_id-b", "sub-4_date-2023"]
-        ses_names = ["ses-002_@DATE@", "ses-003_id-random"]
+        ses_names = ["ses-002_id-11", "ses-003_id-random"]
 
         with pytest.warns(UserWarning) as w:
             validation.validate_names_against_project(
@@ -460,7 +460,7 @@ class TestValidation(BaseTest):
             )
 
         assert (
-            "the same ses id as ses-002_@DATE@. "
+            "the same ses id as ses-002_id-11. "
             "The existing folder is ses-002." in str(w[0].message)
         )
         assert (


### PR DESCRIPTION
This PR changes at lot of the 'showers' functions in the API to getters, which makes more sense from an API-focused perspective. Now the CLI functions print the output in the `command_line_interface.py` script.

Also, all CLI functions are now tested (mostly these showers were not tested previously).

In some cases, showing configs and local-file-tree are still exposed as these perform some `__repr__` like functionality. Otherwise everything is a getter.

Currently, the CLI is a bit weird (e.g. I'm not sure if these should be called 'getters' in the CLI as they can't return anything) and not all underlying arguments are explosed. As descripted in #267, if we proceed with CLI then CLI can be properly designed to break the link between CLI and API. For now though the CLI should be fairly well fixed (in a sub-optimal state) and we can decide what to do with it later.

Slight change to docs to reflect new function name, but for most part these are build automatically from the API / CLI.