### PR TITLE
Remove unnecessary system calls.

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -28,6 +28,7 @@ from datashuttle.utils.custom_exceptions import (
 from datashuttle.utils.data_transfer import TransferData
 from datashuttle.utils.decorators import (  # noqa
     check_configs_set,
+    check_configs_set_for_transfer,
     requires_ssh_configs,
 )
 
@@ -107,8 +108,6 @@ class DataShuttle:
         if print_startup_message:
             if self.cfg:
                 self.show_top_level_folder()
-
-        rclone.prompt_rclone_download_if_does_not_exist()
 
     def _set_attributes_after_config_load(self) -> None:
         """
@@ -284,6 +283,7 @@ class DataShuttle:
     # -------------------------------------------------------------------------
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def upload(
         self,
         sub_names: Union[str, list],
@@ -358,6 +358,7 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def download(
         self,
         sub_names: Union[str, list],
@@ -394,6 +395,7 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def upload_all(self, dry_run: bool = False):
         """
         Convenience function to upload all data.
@@ -406,6 +408,7 @@ class DataShuttle:
         self.upload("all", "all", "all", dry_run=dry_run, init_log=False)
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def download_all(self, dry_run: bool = False):
         """
         Convenience function to download all data.
@@ -418,6 +421,7 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def upload_entire_project(self):
         """
         Upload the entire project (from 'local' to 'central'),
@@ -427,6 +431,7 @@ class DataShuttle:
         self._transfer_entire_project("upload")
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def download_entire_project(self):
         """
         Download the entire project (from 'central' to 'local'),
@@ -436,6 +441,7 @@ class DataShuttle:
         self._transfer_entire_project("download")
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def upload_specific_folder_or_file(
         self, filepath: str, dry_run: bool = False
     ) -> None:
@@ -487,6 +493,7 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
+    @check_configs_set_for_transfer
     def download_specific_folder_or_file(
         self, filepath: str, dry_run: bool = False
     ) -> None:

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -28,7 +28,6 @@ from datashuttle.utils.custom_exceptions import (
 from datashuttle.utils.data_transfer import TransferData
 from datashuttle.utils.decorators import (  # noqa
     check_configs_set,
-    check_configs_set_for_transfer,
     requires_ssh_configs,
 )
 
@@ -123,6 +122,9 @@ class DataShuttle:
         self._make_project_metadata_if_does_not_exist()
 
         self.cfg.init_datatype_folders()
+
+        if self.cfg["connection_method"] == "local_filesystem":
+            self._setup_rclone_central_local_filesystem_config()
 
     # -------------------------------------------------------------------------
     # Public Folder Makers
@@ -283,7 +285,6 @@ class DataShuttle:
     # -------------------------------------------------------------------------
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def upload(
         self,
         sub_names: Union[str, list],
@@ -358,7 +359,6 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def download(
         self,
         sub_names: Union[str, list],
@@ -395,7 +395,6 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def upload_all(self, dry_run: bool = False):
         """
         Convenience function to upload all data.
@@ -408,7 +407,6 @@ class DataShuttle:
         self.upload("all", "all", "all", dry_run=dry_run, init_log=False)
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def download_all(self, dry_run: bool = False):
         """
         Convenience function to download all data.
@@ -421,7 +419,6 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def upload_entire_project(self):
         """
         Upload the entire project (from 'local' to 'central'),
@@ -431,7 +428,6 @@ class DataShuttle:
         self._transfer_entire_project("upload")
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def download_entire_project(self):
         """
         Download the entire project (from 'central' to 'local'),
@@ -441,7 +437,6 @@ class DataShuttle:
         self._transfer_entire_project("download")
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def upload_specific_folder_or_file(
         self, filepath: str, dry_run: bool = False
     ) -> None:
@@ -493,7 +488,6 @@ class DataShuttle:
         ds_logger.close_log_filehandler()
 
     @check_configs_set
-    @check_configs_set_for_transfer
     def download_specific_folder_or_file(
         self, filepath: str, dry_run: bool = False
     ) -> None:
@@ -706,8 +700,6 @@ class DataShuttle:
             self.cfg.dump_to_file()
 
         self._set_attributes_after_config_load()
-
-        self._setup_rclone_central_local_filesystem_config()
 
         utils.log_and_message(
             "Configuration file has been saved and "

--- a/datashuttle/utils/decorators.py
+++ b/datashuttle/utils/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from datashuttle.utils import rclone, utils
+from datashuttle.utils import utils
 from datashuttle.utils.custom_exceptions import ConfigError
 
 
@@ -26,13 +26,6 @@ def requires_ssh_configs(func):
             return func(*args, **kwargs)
 
     return wrapper
-
-
-def check_configs_set_for_transfer(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        rclone.prompt_rclone_download_if_does_not_exist()
-        return func(*args, **kwargs)
 
 
 def check_configs_set(func):

--- a/datashuttle/utils/decorators.py
+++ b/datashuttle/utils/decorators.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
+from datashuttle.utils import rclone, utils
 from datashuttle.utils.custom_exceptions import ConfigError
-from datashuttle.utils.utils import log_and_raise_error
 
 
 def requires_ssh_configs(func):
@@ -16,7 +16,7 @@ def requires_ssh_configs(func):
             not args[0].cfg["central_host_id"]
             or not args[0].cfg["central_host_username"]
         ):
-            log_and_raise_error(
+            utils.log_and_raise_error(
                 "Cannot setup SSH connection, 'central_host_id' "
                 "or 'central_host_username' is not set in "
                 "the configuration file.",
@@ -26,6 +26,13 @@ def requires_ssh_configs(func):
             return func(*args, **kwargs)
 
     return wrapper
+
+
+def check_configs_set_for_transfer(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        rclone.prompt_rclone_download_if_does_not_exist()
+        return func(*args, **kwargs)
 
 
 def check_configs_set(func):
@@ -38,7 +45,7 @@ def check_configs_set(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if args[0].cfg is None:
-            log_and_raise_error(
+            utils.log_and_raise_error(
                 "Must set configs with make_config_file() "
                 "before using this function.",
                 ConfigError,

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -75,9 +75,8 @@ def setup_central_as_rclone_target(
             pipe_std=True,
         )
 
-    output = call_rclone("config file", pipe_std=True)
-
     if log:
+        output = call_rclone("config file", pipe_std=True)
         utils.log(
             f"Successfully created rclone config. "
             f"{output.stdout.decode('utf-8')}"

--- a/tests/tests_integration/base.py
+++ b/tests/tests_integration/base.py
@@ -25,7 +25,7 @@ class BaseTest:
         yield no_cfg_project
 
     @pytest.fixture(scope="function")
-    def project(self, tmp_path):
+    def project(self, tmp_path, monkeypatch):
         """
         Setup a project with default configs to use
         for testing.
@@ -34,6 +34,14 @@ class BaseTest:
         in test_filesystem_transfer.py fixture
         """
         tmp_path = tmp_path / "test with space"
+
+        def return_nothing(*args, **kwargs):
+            return
+
+        monkeypatch.setattr(
+            "datashuttle.utils.rclone.setup_central_as_rclone_target",
+            return_nothing,
+        )
 
         project = test_utils.setup_project_default_configs(
             TEST_PROJECT_NAME,


### PR DESCRIPTION
It turns out system calls to `rclone` are quite slow, meaning sometimes initialising the project is slow because rclone call to check for rclone install is made every time datashuttle is initialised. Also, for large projects logging the whole file tree on every `make_folders` call is slow.

For testing, whenever a config file is setup this entails calls to `_setup_rclone_central_local_filesystem_config` which is slow. I thought monkeypatching this in tests would lead to huge speed increase and also break the test, but it did neither.

This can become a prototyping PR then:

Move to new PR:

1) move the rclone only show install error message when system call fails to a new PR
2) remove the file tree logging in `make_folders` in the same PR
3) definitely move rclone config setup to `_set_attributes_after_config_load` as is done here as we always want to do this for new configs

Investigate further:
- Why are the tests not failing when monkeypatching local filesystem rclone config setup? 