### PR TITLE
Add name templates and improve validation

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -11,7 +11,7 @@ get_canonical_configs()
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List
 
 if TYPE_CHECKING:
     from datashuttle.configs.config_class import Configs
@@ -264,12 +264,13 @@ def check_config_types(config_dict: Configs) -> None:
                 ConfigError,
             )
 
+
 # -----------------------------------------------------------------------------
 # Persistent settings
 # -----------------------------------------------------------------------------
 
 
-def get_tui_config_defaults():  # TODO: doc!
+def get_tui_config_defaults() -> Dict:  # TODO: doc!
     settings = {
         "tui": {
             "checkboxes_on": {
@@ -277,17 +278,20 @@ def get_tui_config_defaults():  # TODO: doc!
                 "ephys": True,
                 "funcimg": True,
                 "anat": True,
-            },
-            "templates": {"on": False, "sub": None, "ses": None},
+            }
         }
     }
     return settings
+
+
+def get_name_templates_defaults() -> Dict:
+    return {"name_templates": {"on": False, "sub": None, "ses": None}}
 
 
 def get_persistent_settings_defaults():  # TODO: doc!
     settings = {"top_level_folder": "rawdata"}
 
     settings.update(get_tui_config_defaults())
+    settings.update(get_name_templates_defaults())
 
     return settings
-

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -263,3 +263,31 @@ def check_config_types(config_dict: Configs) -> None:
                 f"Config file was not updated.",
                 ConfigError,
             )
+
+# -----------------------------------------------------------------------------
+# Persistent settings
+# -----------------------------------------------------------------------------
+
+
+def get_tui_config_defaults():  # TODO: doc!
+    settings = {
+        "tui": {
+            "checkboxes_on": {
+                "behav": True,
+                "ephys": True,
+                "funcimg": True,
+                "anat": True,
+            },
+            "templates": {"on": False, "sub": None, "ses": None},
+        }
+    }
+    return settings
+
+
+def get_persistent_settings_defaults():  # TODO: doc!
+    settings = {"top_level_folder": "rawdata"}
+
+    settings.update(get_tui_config_defaults())
+
+    return settings
+

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -270,7 +270,11 @@ def check_config_types(config_dict: Configs) -> None:
 # -----------------------------------------------------------------------------
 
 
-def get_tui_config_defaults() -> Dict:  # TODO: doc!
+def get_tui_config_defaults() -> Dict:
+    """
+    Get the default settings for the datatype checkboxes
+    in the TUI. By default, they are all checked.
+    """
     settings = {
         "tui": {
             "checkboxes_on": {
@@ -288,7 +292,16 @@ def get_name_templates_defaults() -> Dict:
     return {"name_templates": {"on": False, "sub": None, "ses": None}}
 
 
-def get_persistent_settings_defaults():  # TODO: doc!
+def get_persistent_settings_defaults() -> Dict:
+    """
+    Persistent settings are settings that are maintained
+    across sessions. Currently, persistent settings for
+    both the API and TUI are stored in the same place.
+
+    Currently, settings for the working top level folder,
+    TUI checkboxes and name templates (i.e. regexp
+    validation for sub and ses names) are stored.
+    """
     settings = {"top_level_folder": "rawdata"}
 
     settings.update(get_tui_config_defaults())

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -12,7 +12,11 @@ from typing import Any, Dict, List, Literal, Optional, Union
 import paramiko
 import yaml
 
-from datashuttle.configs import canonical_folders, load_configs
+from datashuttle.configs import (
+    canonical_configs,
+    canonical_folders,
+    load_configs,
+)
 from datashuttle.configs.config_class import Configs
 from datashuttle.utils import (
     ds_logger,
@@ -1183,7 +1187,7 @@ class DataShuttle:
         Initialise the default persistent settings
         and save to file.
         """
-        settings = {"top_level_folder": "rawdata"}
+        settings = canonical_configs.get_persistent_settings_defaults()
         self._save_persistent_settings(settings)
 
     def _save_persistent_settings(self, settings: Dict) -> None:
@@ -1203,7 +1207,17 @@ class DataShuttle:
 
         with open(self._persistent_settings_path, "r") as settings_file:
             settings = yaml.full_load(settings_file)
+
+        self._update_settings_with_new_canonical_keys(settings)
+
         return settings
+
+    def _update_settings_with_new_canonical_keys(
+        self, settings: Dict
+    ):  # TODO: unit test!
+        """"""
+        if "tui" not in settings:
+            settings.update(canonical_configs.get_tui_config_defaults())
 
     @check_configs_set
     def _display_top_level_folder(self) -> None:

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -243,7 +243,7 @@ class DataShuttle:
         if ses_names is not None:
             ses_names = formatting.check_and_format_names(
                 ses_names, "ses", name_templates
-            )  # not sure about passing this around so much
+            )
         else:
             ses_names = []
 
@@ -942,10 +942,34 @@ class DataShuttle:
     # -------------------------------------------------------------------------
 
     def get_name_templates(self) -> Dict:
+        """
+        Get the regexp templates used for validation. If
+        the "on" key is set to `False`, template validation is not performed.
+
+        Returns
+        -------
+
+        name_templates : Dict
+            e.g. {"name_templates": {"on": False, "sub": None, "ses": None}}
+        """
         settings = self._load_persistent_settings()
         return settings["name_templates"]
 
     def set_name_templates(self, new_name_templates: Dict) -> None:
+        """
+        Update the persistent settings with new name templates.
+
+        Name templates are regexp for that, when name_templates["on"] is
+        set to `True`, "sub" and "ses" names are validated against
+        the regexp contained in the dict.
+
+        Parameters
+        ----------
+        new_name_templates : Dict
+            e.g. {"name_templates": {"on": False, "sub": None, "ses": None}}
+            where "sub" or "ses" can be a regexp that subject and session
+            names respectively are validated against.
+        """
         self._update_persistent_setting("name_templates", new_name_templates)
 
     # -------------------------------------------------------------------------
@@ -1238,9 +1262,7 @@ class DataShuttle:
 
         return settings
 
-    def _update_settings_with_new_canonical_keys(
-        self, settings: Dict
-    ):  # TODO: unit test!
+    def _update_settings_with_new_canonical_keys(self, settings: Dict):
         """"""
         if "name_templates" not in settings:
             settings.update(canonical_configs.get_name_templates_defaults())

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import List, Literal, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from datashuttle.configs.canonical_folders import canonical_reserved_keywords
 from datashuttle.configs.canonical_tags import tags
@@ -16,6 +16,7 @@ from datashuttle.utils import utils, validation
 def check_and_format_names(
     names: Union[list, str],
     prefix: Literal["sub", "ses"],
+    name_templates: Optional[Dict] = None,  # TODO: DOC!
 ) -> List[str]:
     """
     Format a list of subject or session names, e.g.
@@ -51,7 +52,14 @@ def check_and_format_names(
 
     formatted_names = format_names(names_to_check, prefix)
 
-    validation.validate_list_of_names(formatted_names, prefix)
+    validation.validate_list_of_names(
+        formatted_names,
+        prefix,
+        "error",
+        check_duplicates=True,
+        name_templates=name_templates,
+        log=True,
+    )
 
     return formatted_names + reserved_keywords
 

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -16,7 +16,7 @@ from datashuttle.utils import utils, validation
 def check_and_format_names(
     names: Union[list, str],
     prefix: Literal["sub", "ses"],
-    name_templates: Optional[Dict] = None,  # TODO: DOC!
+    name_templates: Optional[Dict] = None,
 ) -> List[str]:
     """
     Format a list of subject or session names, e.g.
@@ -35,10 +35,16 @@ def check_and_format_names(
     Parameters
     ----------
 
-    names: str or list containing sub or ses names
-                  (e.g. to make folders)
+    names : Union[list, str]
+        str or list containing sub or ses names (e.g. to make folders)
 
-    prefix: "sub" or "ses" - this defines the prefix checks.
+    prefix : Literal["sub", "ses"]
+        "sub" or "ses" - this defines the prefix checks.
+
+    name_templates : Dict
+        A dictionary of templates to validate subject and session name against.
+        e.g. {"name_templates": {"on": False, "sub": None, "ses": None}}
+        where the "sub" and "ses" may contain a regexp to validate against.
     """
     if isinstance(names, str):
         names = [names]

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union
+import re
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from datashuttle.configs.config_class import Configs
@@ -21,6 +22,7 @@ def validate_list_of_names(
     prefix: Literal["sub", "ses"],
     error_or_warn: Literal["error", "warn"] = "error",
     check_duplicates: bool = True,
+    name_templates: Optional[Dict] = None,
     log: bool = True,
 ) -> None:
     """
@@ -47,6 +49,10 @@ def validate_list_of_names(
 
     log: bool
         If `True`, output will also be logged to "datashuttle" logger.
+
+    TODO: this is potentially slow because each function loops over
+    the whole list. I'd imagine it would be faster to loop once
+    over and pass each name to the sub-function individually.
     """
     if len(names_list) == 0:
         return
@@ -56,6 +62,7 @@ def validate_list_of_names(
         lambda: names_include_spaces(names_list),
         lambda: dashes_and_underscore_alternate_incorrectly(names_list),
         lambda: value_lengths_are_inconsistent(names_list, prefix),
+        lambda: names_dont_match_templates(names_list, prefix, name_templates),
     ]
     if check_duplicates:
         tests_to_run += [lambda: duplicated_prefix_values(names_list, prefix)]
@@ -64,6 +71,49 @@ def validate_list_of_names(
         failed, message = test()
         if failed:
             raise_error_or_warn(message, error_or_warn, log)
+
+
+def names_dont_match_templates(
+    names_list: List[str],
+    prefix: Literal["sub", "ses"],
+    name_templates: Optional[Dict] = None,
+) -> Tuple[bool, str]:
+    """"""
+    if name_templates is None:
+        return False, "No `names_template` dictionary passed."
+
+    if name_templates["on"] is False:
+        return False, "Names templates is set to off and will not be checked."
+
+    regexp = name_templates[prefix]
+
+    bad_names = []
+    for name in names_list:
+        if not re.fullmatch(regexp, name):
+            bad_names.append(name)
+
+    if bad_names:
+        do_or_does = "does" if len(bad_names) == 1 else "do"
+
+        return (
+            True,
+            f"The {get_names_format(bad_names)} "
+            f"{do_or_does} not match the template: {regexp}",
+        )
+
+    return False, ""
+
+
+def get_names_format(bad_names):
+    assert len(bad_names) != 0, "`bad_names` should not be empty."
+    if len(bad_names) == 1:
+        name_str_format = "name"
+        bad_names_format = bad_names[0]
+    else:
+        name_str_format = "names"
+        bad_names_format = bad_names
+
+    return f"{name_str_format}: {bad_names_format}"
 
 
 def name_beings_with_bad_key(
@@ -83,7 +133,7 @@ def name_beings_with_bad_key(
 
     if bad_names:
         message = (
-            f"The names: {bad_names} "
+            f"The {get_names_format(bad_names)} "
             f"do not begin with the required prefix: {prefix}"
         )
         return True, message
@@ -107,7 +157,7 @@ def names_include_spaces(names_list: List[str]) -> Tuple[bool, str]:
     if bad_names:
         return (
             True,
-            f"The names {bad_names} include spaces, "
+            f"Spaces are in the {get_names_format(bad_names)}, "
             f"which is not permitted.",
         )
     return False, ""
@@ -133,7 +183,7 @@ def dashes_and_underscore_alternate_incorrectly(
             discrim[ele] for ele in name if ele in ["-", "_"]
         ]
 
-        if dashes_underscores[0] != 1:
+        if dashes_underscores[0] != 1 or name[-1] in discrim.keys():
             bad_names.append(name)
 
         elif any([ele == 0 for ele in utils.diff(dashes_underscores)]):
@@ -141,7 +191,7 @@ def dashes_and_underscore_alternate_incorrectly(
 
     if bad_names:
         message = (
-            f"The names {bad_names} are not formatted correctly. Names "
+            f"Problem with {get_names_format(bad_names)}. Names "
             f"must consist of key-value pairs separated by underscores."
             f"e.g. 'sub-001_ses-01_date-20230516"
         )
@@ -243,6 +293,7 @@ def validate_project(
     local_only: bool = False,
     error_or_warn: Literal["error", "warn"] = "error",
     log: bool = True,
+    name_templates: Optional[Dict] = None,
 ) -> None:
     """
     Validate all subject and session folders within a project.
@@ -283,6 +334,7 @@ def validate_project(
         error_or_warn=error_or_warn,
         log=log,
         check_duplicates=False,
+        name_templates=name_templates,
     )
 
     for sub in sub_names:
@@ -317,6 +369,7 @@ def validate_names_against_project(
     local_only: bool = False,
     error_or_warn: Literal["error", "warn"] = "error",
     log: bool = True,
+    name_templates: Optional[Dict] = None,
 ) -> None:
     """
     Given a list of subject and (optionally) session names,
@@ -370,6 +423,7 @@ def validate_names_against_project(
             prefix="sub",
             check_duplicates=False,
             error_or_warn=error_or_warn,
+            name_templates=name_templates,
         )
 
         for new_sub in sub_names:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -50,6 +50,9 @@ def validate_list_of_names(
     log: bool
         If `True`, output will also be logged to "datashuttle" logger.
 
+    name_templates : Dict
+        e.g. {"name_templates": {"on": False, "sub": None, "ses": None}}
+
     TODO: this is potentially slow because each function loops over
     the whole list. I'd imagine it would be faster to loop once
     over and pass each name to the sub-function individually.
@@ -78,7 +81,13 @@ def names_dont_match_templates(
     prefix: Literal["sub", "ses"],
     name_templates: Optional[Dict] = None,
 ) -> Tuple[bool, str]:
-    """"""
+    """
+    Test a list of subject or session names against the respective `name_templates`,
+    a regexp template.
+
+    If checking `name_templates` is on, an invalid result will be given if the
+    name does not re.fullmatch the regexp.
+    """
     if name_templates is None:
         return False, "No `names_template` dictionary passed."
 
@@ -105,6 +114,10 @@ def names_dont_match_templates(
 
 
 def get_names_format(bad_names):
+    """
+    A convenience function to properly format error messages
+    depending on whether there is just 1, or multiple bad names.
+    """
     assert len(bad_names) != 0, "`bad_names` should not be empty."
     if len(bad_names) == 1:
         name_str_format = "name"

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -15,7 +15,7 @@ class TestPersistentSettings(BaseTest):
         """
         settings = project._load_persistent_settings()
 
-        assert len(settings) == 1
+        assert len(settings) == 2
         assert settings["top_level_folder"] == "rawdata"
 
         # Update they persistent setting and check this is reflected

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -1,8 +1,13 @@
+import os
+import shutil
+
 import pytest
 import test_utils
 from base import BaseTest
 
 from datashuttle import DataShuttle
+from datashuttle.utils import validation
+from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 
 class TestPersistentSettings(BaseTest):
@@ -40,6 +45,111 @@ class TestPersistentSettings(BaseTest):
         fresh_project = DataShuttle(project.project_name)
 
         assert fresh_project.cfg.top_level_folder == "rawdata"
+
+    def test_persistent_settings_name_templates(self, project):
+        """
+        Test the 'name_templates' option that is stored in persistent
+        settings and adds a regexp to validate subject and session
+        names against.
+
+        Here we test the mechanisms of getting and setting `name_templates`
+        and then check that all validation are performing as expected when
+        using them.
+        """
+        # Load name_templates and check defaults are as expected
+        name_templates = project.get_name_templates()
+
+        assert len(name_templates) == 3
+        assert name_templates["on"] is False
+        assert name_templates["sub"] is None
+        assert name_templates["ses"] is None
+
+        # Set some new settings and check they become persistent
+        sub_regexp = "sub-\d_id-.?.?_random-.*"
+        ses_regexp = "ses-\d\d_id-.?.?.?_random-.*"
+
+        new_name_templates = {
+            "on": True,
+            "sub": sub_regexp,
+            "ses": ses_regexp,
+        }
+
+        project.set_name_templates(new_name_templates)
+
+        project_reload = DataShuttle(project.project_name)
+
+        reload_name_templates = project_reload.get_name_templates()
+
+        assert len(reload_name_templates) == 3
+        assert reload_name_templates["on"] is True
+        assert reload_name_templates["sub"] == sub_regexp
+        assert reload_name_templates["ses"] == ses_regexp
+
+        # Check the validation works correctly based on settings
+        # when making sub / ses folders
+        good_sub = "sub-2_id-ab_random-helloworld"
+        bad_sub = "sub-3_id-abC_random-helloworld"
+        good_ses = "ses-33_id-xyz_random-helloworld"
+        bad_ses = "ses-33_id-xyz_ranDUM-helloworld"
+
+        # Bad sub name
+        with pytest.raises(NeuroBlueprintError) as e:
+            project.make_folders(bad_sub)
+        assert (
+            str(e.value) == "The name: "
+            "sub-3_id-abC_random-helloworld "
+            "does not match the template: "
+            "sub-\d_id-.?.?_random-.*"
+        )
+
+        # Good sub name (should not raise)
+        project.make_folders(good_sub)
+
+        # Bad ses name
+        with pytest.raises(NeuroBlueprintError) as e:
+            project.make_folders(good_sub, bad_ses)
+
+        assert (
+            str(e.value) == "The name: "
+            "ses-33_id-xyz_ranDUM-helloworld "
+            "does not match the template: "
+            "ses-\\d\\d_id-.?.?.?_random-.*"
+        )
+
+        # Good ses name (should not raise)
+        project.make_folders(good_sub, good_ses)
+
+        # Now just test the other validation functions explicitly
+        # here as well to avoid duplicate of test setup.
+
+        # Test `validate_names_against_project()`
+        with pytest.raises(NeuroBlueprintError) as e:
+            validation.validate_names_against_project(
+                project.cfg,
+                [bad_sub],
+                ses_names=None,
+                local_only=True,
+                error_or_warn="error",
+                name_templates=reload_name_templates,
+            )
+        assert "does not match the template:" in str(e.value)
+
+        bad_sub_path = project.cfg["local_path"] / "rawdata" / bad_sub
+        os.makedirs(bad_sub_path)
+
+        # Test `validate_project()`
+        with pytest.raises(NeuroBlueprintError) as e:
+            project.validate_project("error", local_only=True)
+        shutil.rmtree(bad_sub_path)
+
+        assert "sub-3_id-abC_random-helloworld" in str(e.value)
+
+        # Turn it off the `name_template` option
+        # and check a bad ses name does not raise
+        reload_name_templates["on"] = False
+        project.set_name_templates(reload_name_templates)
+
+        project.make_folders(good_sub, "ses-02")
 
     def test_set_top_level_folder_is_persistent(self, project):
         """

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -20,7 +20,7 @@ class TestPersistentSettings(BaseTest):
         """
         settings = project._load_persistent_settings()
 
-        assert len(settings) == 2
+        assert len(settings) == 3
         assert settings["top_level_folder"] == "rawdata"
 
         # Update they persistent setting and check this is reflected

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -467,10 +467,3 @@ class TestValidation(BaseTest):
             "the same ses id as ses-003_id-random. "
             "The existing folder is ses-003." in str(w[1].message)
         )
-
-    # 3) fix passing around 'verbose' argument.
-    # 3) final refactor
-
-    # 4) Make data transfer keywords more intuitive.
-    # 5) release on conda?
-    # 6) ping on 'allow rclone at any time of day'

--- a/tests/tests_unit/test_validation_unit.py
+++ b/tests/tests_unit/test_validation_unit.py
@@ -65,7 +65,7 @@ class TestValidationUnit:
         with pytest.raises(BaseException) as e:
             validation.validate_list_of_names(names, prefix)
 
-        assert "include spaces, which is not permitted." in str(e.value)
+        assert "Spaces are in the name:" in str(e.value)
 
     @pytest.mark.parametrize("prefix", ["sub", "ses"])
     def test_formatting_dashes_and_underscore_alternate_incorrectly(
@@ -75,9 +75,13 @@ class TestValidationUnit:
         Check `validate_list_of_names()` catches "-" and "_" that
         are not in the correct order.
         """
-        error_message = (
-            lambda names: f"The names {names} " f"are not formatted correctly."
-        )
+        # def error_message(names):
+
+        def error_message(names):
+            name_format = "name" if len(names) == 1 else "names"
+            list_format = names[0] if len(names) == 1 else names
+            return f"Problem with {name_format}: {list_format}."
+
         # Test a large range of bad names. Do not use
         # parametrize so we can use f"{prefix}".
         for test_all_names_and_bad_names in [


### PR DESCRIPTION
This PR makes some changes to the validation logic of datashuttle in order to allow the TUI to operate properly / fix any problems discovered when working on the TUI. Also, it introduces `name_templates`.

`name_templates` are regexp strings that sub / ses folder names can be validated against during validation and making folders. DataShuttle now has a setter that update a entry in the `persistent_settings` dictionary with new `name_templates` and a getter that returns them. These are called within the TUI code.

Otherwise, this PR includes some general cleanups and minor fixes to the validation code:
- stores all `persistent_settings` defaults in `canonical_configs.py`.
- imrpoves the `validation.py` error messages to account for if a single or multiple sub / ses names after invalid.

The behaviour is tested. Currently it is not documented, with issue #292 opened for this purpose. The reason it is not documented at present is there is a still a bit of work to do to decide on the final form on the regexp. We will probably go for a simpler regexp, for sure at the TUI level. At the python API level it would probably make sense to take original regexps inputs. 
