### PR TITLE
Fixup configs and add ssh setup (2)

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -309,6 +309,10 @@ def get_name_templates_defaults() -> Dict:
     return {"name_templates": {"on": False, "sub": None, "ses": None}}
 
 
+def get_validation_defaults() -> Dict:
+    return {"bypass_validation": False}
+
+
 def get_persistent_settings_defaults() -> Dict:
     """
     Persistent settings are settings that are maintained

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -298,7 +298,7 @@ def get_tui_config_defaults() -> Dict:
                 "anat": False,
                 "all": True,
                 "all_datatype": False,
-                "all_ses_level_non_datatype": False,
+                "all_non_datatype": False,
             },
             "top_level_folder_select": {
                 "create_tab": "rawdata",

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -300,6 +300,11 @@ def get_tui_config_defaults() -> Dict:
                 "all_datatype": False,
                 "all_ses_level_non_datatype": False,
             },
+            "top_level_folder_select": {
+                "create_tab": "rawdata",
+                "toplevel_transfer": "rawdata",
+                "custom_transfer": "rawdata",
+            },
         }
     }
     return settings

--- a/datashuttle/configs/canonical_folders.py
+++ b/datashuttle/configs/canonical_folders.py
@@ -62,7 +62,7 @@ def get_non_sub_names() -> List[str]:
         "all_ses",
         "all_non_ses",
         "all_datatype",
-        "all_ses_level_non_datatype",
+        "all_non_datatype",
     ]
 
 
@@ -75,7 +75,7 @@ def get_non_ses_names() -> List[str]:
         "all_sub",
         "all_non_sub",
         "all_datatype",
-        "all_ses_level_non_datatype",
+        "all_non_datatype",
     ]
 
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -1293,7 +1293,11 @@ class DataShuttle:
         return settings
 
     def _update_settings_with_new_canonical_keys(self, settings: Dict):
-        """"""
+        """
+
+        TODO: this is not really sufficient, e.g. a new field in tui
+        will not be discoverd.
+        """
         if "name_templates" not in settings:
             settings.update(canonical_configs.get_name_templates_defaults())
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -235,14 +235,15 @@ class DataShuttle:
         ds_logger.log_names(["sub_names", "ses_names"], [sub_names, ses_names])
 
         name_templates = self.get_name_templates()
+        bypass_validation = self.get_bypass_validation()
 
         sub_names = formatting.check_and_format_names(
-            sub_names, "sub", name_templates
+            sub_names, "sub", name_templates, bypass_validation
         )
 
         if ses_names is not None:
             ses_names = formatting.check_and_format_names(
-                ses_names, "ses", name_templates
+                ses_names, "ses", name_templates, bypass_validation
             )
         else:
             ses_names = []
@@ -252,14 +253,15 @@ class DataShuttle:
             [sub_names, ses_names],
         )
 
-        validation.validate_names_against_project(
-            self.cfg,
-            sub_names,
-            ses_names,
-            local_only=True,
-            error_or_warn="error",
-            name_templates=name_templates,
-        )
+        if not bypass_validation:
+            validation.validate_names_against_project(
+                self.cfg,
+                sub_names,
+                ses_names,
+                local_only=True,
+                error_or_warn="error",
+                name_templates=name_templates,
+            )
 
         utils.log("\nMaking folders...")
         folders.make_folder_trees(
@@ -972,6 +974,17 @@ class DataShuttle:
         """
         self._update_persistent_setting("name_templates", new_name_templates)
 
+    def set_bypass_validation(self, on):
+        self._update_persistent_setting(
+            "bypass_validation", on
+        )  # TODO: test this!  # TODO: test this!  # TODO: test this!  # TODO: test this!
+
+    def get_bypass_validation(
+        self,
+    ):  # TODO: test this!  # TODO: test this!  # TODO: test this!  # TODO: test this!  # TODO: test this!
+        settings = self._load_persistent_settings()
+        return settings["bypass_validation"]
+
     # -------------------------------------------------------------------------
     # Showers
     # -------------------------------------------------------------------------
@@ -1286,6 +1299,9 @@ class DataShuttle:
 
         if "tui" not in settings:
             settings.update(canonical_configs.get_tui_config_defaults())
+
+        if "bypass_validation" not in settings:
+            settings.update(canonical_configs.get_validation_defaults())
 
     @check_configs_set
     def _display_top_level_folder(self) -> None:

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import yaml
 from showinfm import show_in_file_manager
 from textual.app import App
 from textual.binding import Binding
@@ -9,11 +10,13 @@ from textual.widgets import (
     Label,
 )
 
+from datashuttle.configs import canonical_folders
 from datashuttle.tui.screens import (
     modal_dialogs,
     new_project,
     project_manager,
     project_selector,
+    settings,
 )
 
 
@@ -53,6 +56,9 @@ class TuiApp(App):
             id="mainwindow_contents_container",
         )
 
+    def on_mount(self):
+        self.dark = self.load_global_settings()["dark_mode"]
+
     def on_button_pressed(self, event: Button.Pressed):
         """
         When a button is pressed, a new screen is displayed with
@@ -74,6 +80,13 @@ class TuiApp(App):
             self.push_screen(
                 new_project.NewProjectScreen(self),
                 self.load_project_page,
+            )
+
+        elif event.button.id == "mainwindow_settings_button":
+            self.push_screen(
+                settings.SettingsScreen(
+                    self,
+                )
             )
 
     def load_project_page(self, project):
@@ -110,6 +123,33 @@ class TuiApp(App):
                 )
 
             self.show_modal_error_dialog(message)
+
+    def get_global_settings_path(self):
+        path_ = canonical_folders.get_datashuttle_path()
+        return path_ / "global_tui_settings.yaml"
+
+    def load_global_settings(self):
+        # TODO: there is now a lot of code that does this kind of thing
+        # here, persistent settings, configs. See if it can be centralised
+        settings_path = self.get_global_settings_path()
+
+        if not settings_path.is_file():
+            global_settings = {
+                "dark_mode": True,
+                "show_transfer_tree_status": False,
+            }
+            self.save_global_settings(global_settings)
+        else:
+            with open(settings_path, "r") as file:
+                global_settings = yaml.full_load(file)
+
+        return global_settings
+
+    def save_global_settings(self, global_settings):
+        settings_path = self.get_global_settings_path()
+
+        with open(settings_path, "w") as file:
+            yaml.dump(global_settings, file, sort_keys=False)
 
 
 if __name__ == "__main__":

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -83,7 +83,7 @@ class TuiApp(App):
             )
 
     def show_modal_error_dialog(self, message):
-        self.push_screen(modal_dialogs.ErrorScreen(message))
+        self.push_screen(modal_dialogs.MessageBox(message, border_color="red"))
 
     def handle_open_filesystem_browser(self, path_):
         if not path_.exists():

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -124,26 +124,41 @@ class TuiApp(App):
 
             self.show_modal_error_dialog(message)
 
-    def get_global_settings_path(self):
-        path_ = canonical_folders.get_datashuttle_path()
-        return path_ / "global_tui_settings.yaml"
+    # Global Settings ---------------------------------------------------------
+    # TODO: there is now a lot of code that does this kind of thing
+    # here, persistent settings, configs. See if it can be centralised
 
     def load_global_settings(self):
-        # TODO: there is now a lot of code that does this kind of thing
-        # here, persistent settings, configs. See if it can be centralised
+        """
+        Load the 'global settings' for the TUI that determine
+        project-independent settings that are persistent across
+        sessions. These are stored in the canonical
+        .datashuttle folder (see `get_global_settings_path`).
+        """
         settings_path = self.get_global_settings_path()
 
         if not settings_path.is_file():
-            global_settings = {
-                "dark_mode": True,
-                "show_transfer_tree_status": False,
-            }
+            global_settings = self.get_default_global_settings()
             self.save_global_settings(global_settings)
         else:
             with open(settings_path, "r") as file:
                 global_settings = yaml.full_load(file)
 
         return global_settings
+
+    def get_global_settings_path(self):
+        """
+        The cannoincal path for the TUI's global settings.
+
+        """
+        path_ = canonical_folders.get_datashuttle_path()
+        return path_ / "global_tui_settings.yaml"
+
+    def get_default_global_settings(self):
+        return {
+            "dark_mode": True,
+            "show_transfer_tree_status": False,
+        }
 
     def save_global_settings(self, global_settings):
         settings_path = self.get_global_settings_path()

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import yaml
 from showinfm import show_in_file_manager
 from textual.app import App
-from textual.binding import Binding
 from textual.containers import Container
 from textual.widgets import (
     Button,
@@ -38,10 +37,6 @@ class TuiApp(App):
 
     tui_path = Path(__file__).parent
     CSS_PATH = list(Path(tui_path / "css").glob("*.tcss"))
-
-    BINDINGS = [
-        Binding("ctrl+d", "toggle_dark", "Toggle Dark Mode", priority=True)
-    ]
 
     def compose(self):
         yield Container(

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -72,16 +72,14 @@ class ConfigsContent(Container):
 
         config_screen_widgets = [
             Label("Local Path", id="configs_local_path_label"),
-            ClickableInput(
-                self.parent_class.mainwindow,
-                placeholder=r"e.g. C:\path\to\my_projects\my_first_project",
-                id="configs_local_path_input",
-            ),
-            Label("Central Path", id="configs_central_path_label"),
-            ClickableInput(
-                self.parent_class.mainwindow,
-                placeholder="e.g. /central/live/username/my_projects/my_first_project",
-                id="configs_central_path_input",
+            Horizontal(
+                Button("Select", id="configs_local_path_select_button"),
+                ClickableInput(
+                    self.parent_class.mainwindow,
+                    placeholder=r"e.g. C:\path\to\my_projects\my_first_project",
+                    id="configs_local_path_input",
+                ),
+                id="configs_local_path_button_input_container",
             ),
             Label("Connection Method", id="configs_connect_method_label"),
             RadioSet(
@@ -93,6 +91,16 @@ class ConfigsContent(Container):
                 id="configs_connect_method_radioset",
             ),
             *self.config_ssh_widgets,
+            Label("Central Path", id="configs_central_path_label"),
+            Horizontal(
+                Button("Select", id="configs_central_path_select_button"),
+                ClickableInput(
+                    self.parent_class.mainwindow,
+                    placeholder="e.g. /central/live/username/my_projects/my_first_project",
+                    id="configs_central_path_input",
+                ),
+                id="configs_central_path_button_input_container",
+            ),
             Container(
                 Checkbox(
                     "Overwrite Old Files",
@@ -110,7 +118,11 @@ class ConfigsContent(Container):
                 id="configs_transfer_options_container",
             ),
             Horizontal(
-                Button("Configure Project", id="configs_set_configs_button")
+                Button("Save", id="configs_set_configs_button"),
+                Button(
+                    "Setup SSH Connection",
+                    id="configs_setup_ssh_connection_button",
+                ),
             ),
         ]
 
@@ -198,6 +210,29 @@ class ConfigsContent(Container):
                 self.setup_configs_for_a_new_project_and_switch_to_tab_screen()
             else:
                 self.setup_configs_for_an_existing_project()
+
+        elif event.button.id == "configs_setup_ssh_connection_button":
+            self.setup_ssh_connection()
+
+    def setup_ssh_connection(self):
+        cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
+
+        if cfg_kwargs["connection_method"] != "ssh":
+            self.parent_class.mainwindow.show_modal_error_dialog(
+                "Configs must be set to SSH to setup an SSH connection."
+            )
+            return
+
+        if (
+            self.project.cfg["connection_method"] != "ssh"
+            or self.project.cfg["connection_method"]
+            != cfg_kwargs["connection_method"]
+        ):
+            self.parent_class.mainwindow.show_modal_error_dialog(
+                "The values set above must equal the datashuttle settings. "
+                "Either press 'Save' or reload this page."
+            )
+            # or self.project.cfg[""]
 
     def setup_configs_for_a_new_project_and_switch_to_tab_screen(self):
         """

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -133,7 +133,8 @@ class ConfigsContent(Container):
                     "documentation. Once configs are set, you will "
                     "be able\nto use the 'Create' and 'Transfer' tabs.",
                     id="configs_info_label",
-                )
+                ),
+                id="configs_info_label_container",
             ),
             Label("Project Name", id="configs_name_label"),
             ClickableInput(

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -113,14 +113,6 @@ class ConfigsContent(Container):
                     value=False,
                     id="configs_overwrite_files_checkbox",
                 ),
-                Checkbox(
-                    "Verbose", value=False, id="configs_verbosity_checkbox"
-                ),
-                Checkbox(
-                    "Show Transfer Progress",
-                    value=False,
-                    id="configs_transfer_progress_checkbox",
-                ),
                 id="configs_transfer_options_container",
             ),
             Horizontal(
@@ -271,7 +263,7 @@ class ConfigsContent(Container):
         cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
 
         if any(
-            cfg_kwargs[key] != value for key, value in self.project.cfg.items()
+            self.project.cfg[key] != value for key, value in cfg_kwargs.items()
         ):
             self.parent_class.mainwindow.show_modal_error_dialog(
                 "The values set above must equal the datashuttle settings. "
@@ -395,17 +387,6 @@ class ConfigsContent(Container):
         checkbox = self.query_one("#configs_overwrite_files_checkbox")
         checkbox.value = self.project.cfg["overwrite_old_files"]
 
-        # Transfer Verbosity
-        checkbox = self.query_one("#configs_verbosity_checkbox")
-        bool = (
-            True if self.project.cfg["transfer_verbosity"] == "vv" else False
-        )
-        checkbox.value = bool
-
-        # Show Transfer Progress
-        checkbox = self.query_one("#configs_transfer_progress_checkbox")
-        checkbox.value = self.project.cfg["show_transfer_progress"]
-
     def get_datashuttle_inputs_from_widgets(self):
         """
         Get the configs to pass to `make_config_file()` from
@@ -439,17 +420,6 @@ class ConfigsContent(Container):
 
         cfg_kwargs["overwrite_old_files"] = self.query_one(
             "#configs_overwrite_files_checkbox"
-        ).value
-
-        verbosity_kwarg = (
-            "vv"
-            if self.query_one("#configs_verbosity_checkbox").value
-            else "v"
-        )
-        cfg_kwargs["transfer_verbosity"] = verbosity_kwarg
-
-        cfg_kwargs["show_transfer_progress"] = self.query_one(
-            "#configs_transfer_progress_checkbox"
         ).value
 
         return cfg_kwargs

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 from textual.containers import Container, Horizontal
 from textual.message import Message
@@ -268,10 +269,8 @@ class ConfigsContent(Container):
     def setup_ssh_connection(self):
         cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
 
-        if (
-            self.project.cfg["connection_method"] != "ssh"
-            or self.project.cfg["connection_method"]
-            != cfg_kwargs["connection_method"]
+        if any(
+            cfg_kwargs[key] != value for key, value in self.project.cfg.items()
         ):
             self.parent_class.mainwindow.show_modal_error_dialog(
                 "The values set above must equal the datashuttle settings. "
@@ -397,7 +396,9 @@ class ConfigsContent(Container):
 
         # Transfer Verbosity
         checkbox = self.query_one("#configs_verbosity_checkbox")
-        bool = True if self.project.cfg["transfer_verbosity"] == "v" else False
+        bool = (
+            True if self.project.cfg["transfer_verbosity"] == "vv" else False
+        )
         checkbox.value = bool
 
         # Show Transfer Progress
@@ -413,13 +414,13 @@ class ConfigsContent(Container):
         """
         cfg_kwargs = {}
 
-        cfg_kwargs["local_path"] = self.query_one(
-            "#configs_local_path_input"
-        ).value
+        cfg_kwargs["local_path"] = Path(
+            self.query_one("#configs_local_path_input").value
+        )
 
-        cfg_kwargs["central_path"] = self.query_one(
-            "#configs_central_path_input"
-        ).value
+        cfg_kwargs["central_path"] = Path(
+            self.query_one("#configs_central_path_input").value
+        )
 
         cfg_kwargs["connection_method"] = (
             "ssh"

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -237,20 +237,21 @@ class ConfigsContent(Container):
         elif event.button.id == "configs_setup_ssh_connection_button":
             self.setup_ssh_connection()
 
-        elif (
-            event.button.id == "configs_local_path_select_button"
-        ):  # TODO: duplication
+        elif event.button.id in [
+            "configs_local_path_select_button",
+            "configs_central_path_select_button",
+        ]:
+            input_to_fill = (
+                "local"
+                if event.button.id == "configs_local_path_select_button"
+                else "central"
+            )
+
             self.parent_class.mainwindow.push_screen(
                 modal_dialogs.SelectDirectoryTreeScreen(
                     self.parent_class.mainwindow
                 ),
-                lambda path_: self.handle_input_fill(path_, "local"),
-            )
-        elif event.button.id == "configs_central_path_select_button":
-            self.parent_class.mainwindow.push_screen(
-                modal_dialogs.SelectDirectoryTreeScreen(
-                    self.parent_class.mainwindow
-                )
+                lambda path_: self.handle_input_fill(path_, input_to_fill),
             )
 
     def handle_input_fill(self, path_, local_or_central):
@@ -261,7 +262,7 @@ class ConfigsContent(Container):
             self.query_one(
                 "#configs_local_path_input"
             ).value = path_.as_posix()
-        elif local_or_central == "local":
+        elif local_or_central == "central":
             self.query_one(
                 "#configs_central_path_input"
             ).value = path_.as_posix()

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -277,7 +277,7 @@ class ConfigsContent(Container):
                 "The values set above must equal the datashuttle settings. "
                 "Either press 'Save' or reload this page."
             )
-
+            return
         self.parent_class.mainwindow.push_screen(
             setup_ssh.SetupSshScreen(self.project)
         )

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -13,7 +13,7 @@ from textual.widgets import (
 
 from datashuttle import DataShuttle
 from datashuttle.tui.custom_widgets import ClickableInput
-from datashuttle.tui.screens import modal_dialogs
+from datashuttle.tui.screens import modal_dialogs, setup_ssh
 from datashuttle.tui.utils import tui_utils
 
 
@@ -268,12 +268,6 @@ class ConfigsContent(Container):
     def setup_ssh_connection(self):
         cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
 
-        if cfg_kwargs["connection_method"] != "ssh":
-            self.parent_class.mainwindow.show_modal_error_dialog(
-                "Configs must be set to SSH to setup an SSH connection."
-            )
-            return
-
         if (
             self.project.cfg["connection_method"] != "ssh"
             or self.project.cfg["connection_method"]
@@ -283,6 +277,10 @@ class ConfigsContent(Container):
                 "The values set above must equal the datashuttle settings. "
                 "Either press 'Save' or reload this page."
             )
+
+        self.parent_class.mainwindow.push_screen(
+            setup_ssh.SetupSshScreen(self.project)
+        )
 
     def setup_configs_for_a_new_project_and_switch_to_tab_screen(self):
         """

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -154,12 +154,15 @@ ShowConfigsDialog:light > #display_configs_top_container {
 }
 
 #configs_set_configs_button {
-    content-align: center middle;
-    align-horizontal: center;
-    margin: 2 0 2 0;
+    align-horizontal: left;
+    margin: 2 5 0 0;
     padding: 0 4 0 4;
     width: 30%;
     color: $success;  /* unsure about this */
+}
+
+#configs_setup_ssh_connection_button {
+    margin: 2 0 0 0;
 }
 
 #configs_container > DatatypeCheckboxes {
@@ -190,13 +193,26 @@ ShowConfigsDialog:light > #display_configs_top_container {
     height: auto;
 }
 
+#configs_local_path_input {
+    width: 70%;
+}
+#configs_central_path_input {
+    width: 70%;
+}
+#configs_local_path_select_button{
+    width: auto;
+}
+#configs_central_path_select_button {
+    width: auto;
+}
+
+
 /* This Horizontal wrapper container is necessary to make the
 config label and button align center */
 
 #configs_container > Horizontal {
     width: 60%;
     height: auto;
-    align: center middle;
 }
 
 

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -134,6 +134,10 @@ MessageBox:light > #messagebox_top_container {
     height: 5;
 }
 
+#configs_info_label_container {
+    align: center top;
+}
+
 #configs_info_label {
     align: center middle;
     text-align: center;

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -38,80 +38,36 @@
 
 /* Error Screen --------------------------------------------------------------------- */
 
-ErrorScreen {
+MessageBox {
     align: center middle;
 }
 
-#errorscreen_top_container {
+#messagebox_top_container {
     height: 15;
     width: 65;
-    border: thick rgb(140, 12, 0);
-    background: $primary-background;
  }
 
-#errorscreen_message_container {
+#messagebox_message_container {
     align: center middle;
     overflow: hidden auto;
     margin: 0 1;
 }
 
-#errorscreen_message_label {
+#messagebox_message_label {
     text-align: center;
     padding: 0 2;
 }
 
-#errorscreen_ok_button {
+#messagebox_ok_button {
     align: center bottom;
     height: 3;
 }
 
 /* Light Mode Error Screen */
 
-ErrorScreen:light > #errorscreen_top_container {
+MessageBox:light > #messagebox_top_container {
     border: thick rgb(209, 41, 25);
     background: $boost;
-    align: center middle;
- }
-
-/* ShowConfigsDialog --------------------------------------------------------------------- */
-
-ShowConfigsDialog {
-    align: center middle;
-}
-
-#display_configs_top_container {
-    height: 20;
-    width: 115;
-    background: $primary-background;
-    border: thick rgb(1, 138, 13);
-}
-
-#display_configs_message_container {
-    align: center middle;
-    overflow: hidden auto;
-    margin: 0 1;
-}
-
-#display_configs_message_label {
-    text-align: center;
-    width: auto;
-    overflow: auto;
-    padding: 1 0 2 0;
-}
-
-#display_configs_ok_button {
-    align: center bottom;
-    height: 3;
-}
-
-#modal_table {
-    width: auto;
-}
-
-/* Light Mode Config Dialog */
-
-ShowConfigsDialog:light > #display_configs_top_container {
-    background: $background-darken-1;
     align: center middle;
  }
 
@@ -133,7 +89,7 @@ ShowConfigsDialog:light > #display_configs_top_container {
     text-style: bold;
     content-align: center middle;
     border: hkey $secondary-darken-1;
-    width: 60%;
+    width: 85%;
     height: 5;
 }
 
@@ -149,7 +105,7 @@ ShowConfigsDialog:light > #display_configs_top_container {
 }
 
 #configs_container > Input {
-    width: 60%;
+    width: 85%;
     align-horizontal: center;
 }
 
@@ -157,7 +113,7 @@ ShowConfigsDialog:light > #display_configs_top_container {
     align-horizontal: left;
     margin: 2 5 0 0;
     padding: 0 4 0 4;
-    width: 30%;
+    width: 20%;
     color: $success;  /* unsure about this */
 }
 
@@ -211,7 +167,7 @@ ShowConfigsDialog:light > #display_configs_top_container {
 config label and button align center */
 
 #configs_container > Horizontal {
-    width: 60%;
+    width: 85%;
     height: auto;
 }
 
@@ -335,7 +291,7 @@ ConfirmScreen {
 
 /* Light Mode Error Screen */
 
-ErrorScreen:light > #confirm_top_container {
+MessageBox:light > #confirm_top_container {
     border: tall $accent;
     background: $boost;
  }

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -223,25 +223,36 @@ TemplateSettingsScreen {
     align: center middle;
 }
 
-#template_top_container {
-    height: 25;
-    width: 80;
+#labelTESTEST {
+    padding: 1 0 1 2;
+}
+#tabscreen_toplevel_select {
+    padding: 0 0 0 1;
+}
+#template_top_container2 {
+    height: 80%;
+    width: 80%;
     background: $primary-background;
     border: tall $panel-lighten-3;
  }
-
- #template_inner_horizontal_container{
+#template_top_container {
+    height: 50%;
+    background: $primary-background;
+    border: tall $panel-lighten-3;
+    overflow: hidden auto;
+ }
+#template_inner_horizontal_container{
     height: 3;
 }
 
  #template_inner_container {
-    height: auto;
-    overflow: auto hidden;
+    height: 15;
+    overflow: auto;
  }
 
 #template_message_label {
     width: auto;
-    margin: 1 0 0 2;
+    margin: 0 0 0 2;
 }
 
 #template_settings_radioset {
@@ -250,17 +261,12 @@ TemplateSettingsScreen {
     background: transparent;
     align: center middle;
     width: 50%;
-    margin: 1 0 0 0;
+    margin: 0 0 0 0;
 }
 
 #template_settings_input {
     align: center middle;
     width: 50%;
-}
-
-#template_sessions_close_button{
-    dock: right;
-    layer: top;
 }
 
 #template_other_widgets_container{

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -38,6 +38,26 @@
 
 /* Error Screen --------------------------------------------------------------------- */
 
+SetupSshScreen {
+    align: center middle;
+}
+
+#setup_ssh_screen_top_container {
+    height: 75%;
+    width: auto;
+    align: center middle;
+    border: solid $panel-lighten-1;
+}
+#setup_ssh_screen_label {
+    align: center middle;
+}
+#horizontal_XXX {
+    align: center middle;
+}
+#setup_ssh_screen_label_container {
+    align: center middle;
+}
+
 MessageBox {
     align: center middle;
 }

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -38,11 +38,32 @@
 
 /* Error Screen --------------------------------------------------------------------- */
 
+#settings_screen_top_container {
+    height: 85%;
+    width: 85%;
+    align: center middle;
+    border: thick $panel-lighten-1;
+    overflow: hidden auto;
+    margin: 0 1;
+}
+
+#settings_screen_close_button {
+    dock: bottom;
+}
+#settings_color_scheme_radioset {  /* TODO: duplicate with other css */
+    layout: horizontal;
+    width: auto;
+    border: none;
+    background: transparent;
+}
 SetupSshScreen {
     align: center middle;
 }
+SettingsScreen {
+    align: center middle;
+}
 
-#setup_ssh_screen_top_container {
+#setup_ssh_screen_container {
     height: 75%;
     width: auto;
     align: center middle;

--- a/datashuttle/tui/css/tui_style.tcss
+++ b/datashuttle/tui/css/tui_style.tcss
@@ -38,37 +38,65 @@ Header {
 
 /* Directory Tree ------------------------------------------------------------------- */
 
-DirectoryTree {
-    dock: left;
+CustomDirectoryTree {
     width: 45%;
     padding: 1 2;
     margin: 0 4 0 0;
     border: tall wide $panel-lighten-1;
 }
-DirectoryTree:focus .tree--cursor {
+CustomDirectoryTree:focus .tree--cursor {
     background: $panel-lighten-2;
 }
-DirectoryTree .tree--guides {
+CustomDirectoryTree .tree--guides {
     color: #949494;
     text-style: none;
 }
-DirectoryTree .tree--guides-selected {
+CustomDirectoryTree .tree--guides-selected {
     color: #949494;
     text-style: none;
 }
-DirectoryTree:focus .tree--guides-hover {
+CustomDirectoryTree:focus .tree--guides-hover {
     color: #949494;
     text-style: none;
 }
 /* Light mode Directory Tree */
 
-DirectoryTree:light {
+CustomDirectoryTree:light {
     border: tall wide $panel-darken-3;
     background: $boost;
 }
 
-DirectoryTree:light:focus .tree--cursor {
+CustomDirectoryTree:light:focus .tree--cursor {
     background: $panel-lighten-2;
+}
+
+/* Could not figure out how to selectively override dock by CustomDirectoryTree that do not
+want to dock left */
+
+#tabscreen_directorytree {
+    dock: left;
+}
+#transfer_directorytree {
+    dock: left;
+}
+
+/* SelectDirectoryTreeScreen -------------------------------------------------------- */
+
+SelectDirectoryTreeScreen {
+    align: center middle;
+}
+
+#select_directory_tree_container {
+    height: 85%;
+    width: 70%;
+    background: $primary-background;
+    border: thick rgb(5, 5, 5);
+    align: center middle;
+}
+
+#select_directory_tree_directory_tree {
+    height: 80%;
+    width: 80%
 }
 
 /* Checkboxes ----------------------------------------------------------------------- */

--- a/datashuttle/tui/custom_widgets.py
+++ b/datashuttle/tui/custom_widgets.py
@@ -69,7 +69,7 @@ class DatatypeCheckboxes(Static):
     def compose(self):
         for datatype in self.datatype_config.keys():
             yield Checkbox(
-                datatype.title(),
+                datatype.title().replace("_", " "),
                 id=f"tabscreen_{datatype}_checkbox",
                 value=self.datatype_config[datatype],
             )

--- a/datashuttle/tui/custom_widgets.py
+++ b/datashuttle/tui/custom_widgets.py
@@ -14,7 +14,16 @@ from rich.text import Text
 from textual._segment_tools import line_pad
 from textual.message import Message
 from textual.strip import Strip
-from textual.widgets import Checkbox, DirectoryTree, Input, Static, TabPane
+from textual.widgets import (
+    Checkbox,
+    DirectoryTree,
+    Input,
+    Select,
+    Static,
+    TabPane,
+)
+
+from datashuttle.configs import canonical_folders
 
 # --------------------------------------------------------------------------------------
 # DatatypeCheckboxes
@@ -439,3 +448,64 @@ class TreeAndInputTab(TabPane):
         datatype = self.query_one("DatatypeCheckboxes").selected_datatypes()
 
         return sub_names, ses_names, datatype
+
+
+class TopLevelFolderSelect(Select):
+    def __init__(self, project, existing_only, id):
+        self.project = project
+
+        top_level_folders = [
+            (folder, folder)
+            for folder in canonical_folders.get_top_level_folders()
+        ]
+
+        if existing_only:
+            top_level_folders = [
+                folders_tuple
+                for folders_tuple in top_level_folders
+                if (self.project.get_local_path() / folders_tuple[0]).exists()
+            ]
+
+        if id == "tabscreen_toplevel_select":
+            self.settings_key = "create_tab"
+        elif id == "transfer_toplevel_select":
+            self.settings_key = "toplevel_transfer"
+        elif id == "transfer_custom_select":
+            self.settings_key = "custom_transfer"
+        else:
+            raise ValueError(
+                "TopLevelSelect id not recognised. Must be matched to"
+                "a persistent settings field"
+            )
+
+        value = self.get_top_level_folder_from_file()
+
+        super(TopLevelFolderSelect, self).__init__(
+            top_level_folders, value=value, id=id, allow_blank=True
+        )
+
+    def get_displayed_top_level_folder(self):
+        assert self.value in canonical_folders.get_top_level_folders()
+        return self.value
+
+    def get_top_level_folder_from_file(self):
+        persistent_settings = self.project._load_persistent_settings()
+        top_level_folder = persistent_settings["tui"][
+            "top_level_folder_select"
+        ][self.settings_key]
+        return top_level_folder
+
+    def get_top_level_folder(self):
+        top_level_folder = self.get_top_level_folder_from_file()
+        assert (
+            top_level_folder == self.get_displayed_top_level_folder()
+        ), "config and widget should never be out of sync."  # TODO: should be tested in a dedicated unit test.
+        return top_level_folder
+
+    def on_select_changed(self, event):
+        top_level_folder = event.value
+        persistent_settings = self.project._load_persistent_settings()
+        persistent_settings["tui"]["top_level_folder_select"][
+            self.settings_key
+        ] = top_level_folder
+        self.project._save_persistent_settings(persistent_settings)

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -1,85 +1,57 @@
-from rich.text import Text
+from pathlib import Path
+
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.screen import ModalScreen
-from textual.widgets import Button, DataTable, Label, Static
+from textual.widgets import Button, Label, Static
+
+from datashuttle.tui.custom_widgets import CustomDirectoryTree
+from datashuttle.tui.utils.tui_decorators import require_double_click
 
 
-class ErrorScreen(ModalScreen):
+class MessageBox(ModalScreen):
     """
-    A screen for rendering error messages. The border of the
-    central widget is red. The screen does not return any value.
+    A screen for rendering error messages.
+
+    message : str
+        The message to display in the message box
+
+    border_color : str
+        The color to pass to the `border` style on the widget. Note that the
+        keywords 'red' and 'green' are overridden for custom style.
     """
 
-    def __init__(self, message):
-        super(ErrorScreen, self).__init__()
+    def __init__(self, message, border_color):
+        super(MessageBox, self).__init__()
 
         self.message = message
+        self.border_color = border_color
 
     def compose(self) -> ComposeResult:
         yield Container(
             Container(
-                Static(self.message, id="errorscreen_message_label"),
-                id="errorscreen_message_container",
+                Static(self.message, id="messagebox_message_label"),
+                id="messagebox_message_container",
             ),
-            Container(Button("OK"), id="errorscreen_ok_button"),
-            id="errorscreen_top_container",
-        )
-
-    def on_button_pressed(self) -> None:
-        self.dismiss()
-
-
-class ShowConfigsDialog(ModalScreen):
-    """
-    This window is used to display the configs of a newly (re-)configured
-    project. The message above the displayed configs can be configured
-    depending on whether a new project was created or an existing project
-    was updated.
-
-    This screen returns None, such that it is displayed until the
-    user presses OK via a callback function. See
-    `ConfigsContent.setup_configs_for_a_new_project_and_switch_to_tab_screen()`
-    for more information.
-    """
-
-    def __init__(self, project_configs_dict, message_before_dict=""):
-        super(ShowConfigsDialog, self).__init__()
-
-        self.project_configs_dict = project_configs_dict
-        self.message_before_dict = message_before_dict
-
-    def compose(self):
-        yield Container(
-            Container(
-                Static(
-                    self.message_before_dict,
-                    id="display_configs_message_label",
-                ),
-                DataTable(id="modal_table", show_header=False),
-                id="display_configs_message_container",
-            ),
-            Container(Button("OK"), id="display_configs_ok_button"),
-            id="display_configs_top_container",
+            Container(Button("OK"), id="messagebox_ok_button"),
+            id="messagebox_top_container",
         )
 
     def on_mount(self):
-        """
-        The first row is empty because the header is not displayed.
-        """
-        ROWS = [("", "")] + [
-            (key, value) for key, value in self.project_configs_dict.items()
-        ]
+        if self.border_color == "red":
+            color = "rgb(140, 12, 0)"
+        elif self.border_color == "green":
+            color = "rgb(1, 138, 13)"
+        else:
+            color = self.border_color
 
-        table = self.query_one(DataTable)
-        table.add_columns(*ROWS[0])
-
-        for row in ROWS[1:]:
-            styled_row = [Text(str(cell), justify="left") for cell in row]
-            table.add_row(*styled_row)
+        self.query_one("#messagebox_top_container").styles.border = (
+            "thick",
+            color,
+        )
 
     def on_button_pressed(self) -> None:
-        self.dismiss(None)
+        self.dismiss(True)
 
 
 class ConfirmScreen(ModalScreen):
@@ -107,4 +79,39 @@ class ConfirmScreen(ModalScreen):
         if event.button.id == "confirm_ok_button":
             self.dismiss(True)
         else:
+            self.dismiss(False)
+
+
+class SelectDirectoryTreeScreen(ModalScreen):
+    def __init__(self, mainwindow, path_=None):
+        super(SelectDirectoryTreeScreen, self).__init__()
+        self.mainwindow = mainwindow
+
+        if path_ is None:
+            path_ = Path().home()
+        self.path_ = path_
+
+        self.prev_click_time = 0
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Label("Double click a folder to select:", id="test_label"),
+            CustomDirectoryTree(
+                self.mainwindow,
+                self.path_,
+                id="select_directory_tree_directory_tree",
+            ),
+            Button("Cancel", id="cancel_button"),
+            id="select_directory_tree_container",
+        )
+
+    @require_double_click
+    def on_directory_tree_directory_selected(self, node):
+        if node.path.is_file():
+            return
+        else:
+            self.dismiss(node.path)
+
+    def on_button_pressed(self, event):
+        if event.button.id == "cancel_button":
             self.dismiss(False)

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -45,6 +45,9 @@ class ProjectManagerScreen(Screen):
         self.project = project
         self.title = f"Project: {self.project.project_name}"
 
+        # see `on_tabbed_content_tab_activated()`
+        self.tabbed_content_mount_signal = True
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Button("Main Menu", id="all_main_menu_buttons")
@@ -75,7 +78,16 @@ class ProjectManagerScreen(Screen):
         """
         Refresh the directorytree for create or transfer tabs whenever
         the tabbedcontent is switched to one of these tabs.
+
+        This is also triggered on mount, leading to it being reloaded
+        twice, leading to a strange flicker. Ideally no trigger
+        would be sent on mount. Therefore the ugly `tabbed_content_mount_signal`
+        variable is introduced to track this.
         """
+        if self.tabbed_content_mount_signal:
+            self.tabbed_content_mount_signal = False
+            return
+
         if event.pane.id == "tabscreen_create_tab":
             self.query_one("#tabscreen_create_tab").reload_directorytree()
         elif event.pane.id == "tabscreen_transfer_tab":
@@ -89,7 +101,6 @@ class ProjectManagerScreen(Screen):
 
         TODO
         ----
-
         Currently this defaults to the local path always but in future when it
         shows the central path it will have to be updated.
         """

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -1,0 +1,54 @@
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import (
+    Button,
+    Checkbox,
+    RadioButton,
+    RadioSet,
+)
+
+
+class SettingsScreen(ModalScreen):
+    def __init__(self, mainwindow):
+        super(SettingsScreen, self).__init__()
+
+        self.mainwindow = mainwindow
+        self.global_settings = self.mainwindow.load_global_settings()
+
+    def compose(self):
+        dark_mode = self.global_settings["dark_mode"]
+        yield Container(
+            RadioSet(
+                RadioButton(
+                    "Dark Mode",
+                    value=dark_mode,
+                ),
+                RadioButton(
+                    "Light Mode",
+                    value=not dark_mode,
+                ),
+                id="settings_color_scheme_radioset",
+            ),
+            Checkbox(
+                "Show transfer status on directory tree",
+                value=self.global_settings["show_transfer_tree_status"],
+            ),
+            Button("Close", id="settings_screen_close_button"),
+            id="settings_screen_top_container",
+        )
+
+    def on_radio_set_changed(self, event):
+        label = str(event.pressed.label)
+        assert label in ["Light Mode", "Dark Mode"]
+        dark_mode = label == "Dark Mode"
+        self.mainwindow.dark = dark_mode
+        self.global_settings["dark_mode"] = dark_mode
+        self.mainwindow.save_global_settings(self.global_settings)
+
+    def on_checkbox_changed(self, event):
+        self.global_settings["show_transfer_tree_status"] = event.value
+        self.mainwindow.save_global_settings(self.global_settings)
+
+    def on_button_pressed(self, event):
+        if event.button.id == "settings_screen_close_button":
+            self.dismiss()

--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -1,0 +1,125 @@
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import (
+    Button,
+    Input,
+    Static,
+)
+
+
+class SetupSshScreen(ModalScreen):
+    def __init__(self, project):
+        super(SetupSshScreen, self).__init__()
+
+        self.project = project
+        self.stage = 0
+        self.failed_password_attempts = 1
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Horizontal(
+                Static(
+                    "Ready to setup setup SSH. " "Press OK to proceed.",
+                    id="messagebox_message_label",
+                ),
+                id="messagebox_message_container",
+            ),
+            Input("Test", password=True, id="input"),
+            Horizontal(
+                Button("OK", id="setup_ssh_ok_button"),
+                Button("Cancel", id="setup_ssh_cancel_button"),
+                id="horizontal_XXX",
+            ),
+            id="setup_ssh_screen_top_container",
+        )
+
+    def on_mount(self):
+        self.query_one("#input").visible = False
+
+    def on_button_pressed(self, event):
+        # TODO: retest ssh setup! also why are these skipped?
+
+        if event.button.id == "setup_ssh_cancel_button":
+            self.dismiss()
+
+        if event.button.id == "setup_ssh_ok_button":
+            from datashuttle.utils import ssh
+
+            central_host_id = self.project.cfg["central_host_id"]
+
+            if self.stage == 0:
+                try:
+                    self.key = ssh.get_remote_server_key(central_host_id)
+                    # TODO: this message is direct copy from datashuttle!
+                    # except 'y' goes to 'OK'
+                    message = (
+                        f"The host key is not cached for this server: "
+                        f"{central_host_id}.\nYou have no guarantee "
+                        f"that the server is the computer you think it is.\n"
+                        f"The server's {self.key.get_name()} key fingerprint is:\n\n "
+                        f"{self.key.get_base64()}\n\nIf you trust this host, to connect"
+                        f" and cache the host key, press OK: "
+                    )
+                except BaseException as e:
+                    self.query_one("#setup_ssh_ok_button").disabled = True
+                    message = (
+                        "Could not connect to server. \nCheck the connection "
+                        f"and the central host ID : \n\n{central_host_id} \n\n Traceback: {e}"
+                    )
+
+                self.query_one("#messagebox_message_label").update(message)
+                self.stage = 1
+
+            elif self.stage == 1:
+                try:
+                    ssh.save_hostkey_locally(
+                        self.key,
+                        central_host_id,
+                        self.project.cfg.hostkeys_path,
+                    )
+                    message = (
+                        "Hostkey accepted. \n\nNext, input your password to the server "
+                        "below to setup an SSH key pair. You will not need to enter "
+                        "your password again. Press OK to confirm"
+                    )
+                    self.query_one("#input").visible = True
+                except BaseException as e:
+                    self.query_one("#setup_ssh_ok_button").disabled = True
+                    message = (
+                        f"Could not store host key. Check permissions "
+                        f"to: \n\n {self.project.cfg.hostkeys_path}.\n\n Traceback: {e}"
+                    )
+
+                self.query_one("#messagebox_message_label").update(message)
+                self.stage += 1
+
+            elif self.stage == 2:
+                try:
+                    ssh.generate_and_write_ssh_key(
+                        self.project.cfg.ssh_key_path
+                    )
+                    #  key = paramiko.RSAKey.from_private_key_file(
+                    #      cfg.ssh_key_path.as_posix())
+                    password = self.query_one("#input").value
+
+                    ssh.add_public_key_to_central_authorized_keys(
+                        self.project.cfg, password, self.key
+                    )
+                    self.project._setup_rclone_central_ssh_config(log=True)
+
+                    message = (
+                        f"Connection successful! SSH key "
+                        f"saved to {self.project.cfg.ssh_key_path}"
+                    )
+                    self.query_one("#setup_ssh_ok_button").label = "Finish"
+                    self.query_one("#setup_ssh_cancel_button").disabled = True
+                except BaseException as e:
+                    message = (
+                        f"Password setup failed. Check password is correct and try again."
+                        f"\n\n{self.failed_password_attempts} failed password attempts."
+                        f"\n\n Traceback: {e}"
+                    )
+                    self.failed_password_attempts += 1
+
+                self.query_one("#messagebox_message_label").update(message)

--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -31,7 +31,7 @@ class SetupSshScreen(ModalScreen):
                 Button("Cancel", id="setup_ssh_cancel_button"),
                 id="horizontal_XXX",
             ),
-            id="setup_ssh_screen_top_container",
+            id="setup_ssh_screen_container",
         )
 
     def on_mount(self):
@@ -114,6 +114,7 @@ class SetupSshScreen(ModalScreen):
                     )
                     self.query_one("#setup_ssh_ok_button").label = "Finish"
                     self.query_one("#setup_ssh_cancel_button").disabled = True
+                    self.stage += 1
                 except BaseException as e:
                     message = (
                         f"Password setup failed. Check password is correct and try again."
@@ -123,3 +124,6 @@ class SetupSshScreen(ModalScreen):
                     self.failed_password_attempts += 1
 
                 self.query_one("#messagebox_message_label").update(message)
+
+            elif self.stage == 3:
+                self.dismiss()

--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -7,8 +7,25 @@ from textual.widgets import (
     Static,
 )
 
+from datashuttle.utils import ssh
+
 
 class SetupSshScreen(ModalScreen):
+    """
+    This dialog windows handles the TUI equivalent of API's
+    setup_connection_to_central_server(). This asks to
+    confirm the central hostkey, and takes password to setup
+    SSH key pair.
+
+    This is the one instance in which it is not possible for
+    the TUI to nearly wrap the API, because the logic flow is
+    broken up requiring user input (accept hostkey and input password).
+
+    Therefore, these functions mirror as closely as possible
+    the API versions found in /utils/ssh.py As much as possible
+    core functionality is centralised in ssh.py functions.
+    """
+
     def __init__(self, project):
         super(SetupSshScreen, self).__init__()
 
@@ -25,7 +42,7 @@ class SetupSshScreen(ModalScreen):
                 ),
                 id="messagebox_message_container",
             ),
-            Input("Test", password=True, id="input"),
+            Input(password=True, id="setup_ssh_password_input"),
             Horizontal(
                 Button("OK", id="setup_ssh_ok_button"),
                 Button("Cancel", id="setup_ssh_cancel_button"),
@@ -35,95 +52,116 @@ class SetupSshScreen(ModalScreen):
         )
 
     def on_mount(self):
-        self.query_one("#input").visible = False
+        self.query_one("#setup_ssh_password_input").visible = False
 
     def on_button_pressed(self, event):
-        # TODO: retest ssh setup! also why are these skipped?
-
+        """
+        When each stage is successfully progressed, `self.stage` is iterated
+        by 1. For saving and excepting hostkey, if there is a problem
+        (error or user declines) the 'OK' button is frozen so it is
+        not possible to proceed. For accepting password input, multiple
+        attempts are allowed.
+        """
         if event.button.id == "setup_ssh_cancel_button":
             self.dismiss()
 
         if event.button.id == "setup_ssh_ok_button":
-            from datashuttle.utils import ssh
-
-            central_host_id = self.project.cfg["central_host_id"]
-
             if self.stage == 0:
-                try:
-                    self.key = ssh.get_remote_server_key(central_host_id)
-                    # TODO: this message is direct copy from datashuttle!
-                    # except 'y' goes to 'OK'
-                    message = (
-                        f"The host key is not cached for this server: "
-                        f"{central_host_id}.\nYou have no guarantee "
-                        f"that the server is the computer you think it is.\n"
-                        f"The server's {self.key.get_name()} key fingerprint is:\n\n "
-                        f"{self.key.get_base64()}\n\nIf you trust this host, to connect"
-                        f" and cache the host key, press OK: "
-                    )
-                except BaseException as e:
-                    self.query_one("#setup_ssh_ok_button").disabled = True
-                    message = (
-                        "Could not connect to server. \nCheck the connection "
-                        f"and the central host ID : \n\n{central_host_id} \n\n Traceback: {e}"
-                    )
-
-                self.query_one("#messagebox_message_label").update(message)
-                self.stage = 1
+                self.ask_user_to_accept_hostkeys()
 
             elif self.stage == 1:
-                try:
-                    ssh.save_hostkey_locally(
-                        self.key,
-                        central_host_id,
-                        self.project.cfg.hostkeys_path,
-                    )
-                    message = (
-                        "Hostkey accepted. \n\nNext, input your password to the server "
-                        "below to setup an SSH key pair. You will not need to enter "
-                        "your password again. Press OK to confirm"
-                    )
-                    self.query_one("#input").visible = True
-                except BaseException as e:
-                    self.query_one("#setup_ssh_ok_button").disabled = True
-                    message = (
-                        f"Could not store host key. Check permissions "
-                        f"to: \n\n {self.project.cfg.hostkeys_path}.\n\n Traceback: {e}"
-                    )
-
-                self.query_one("#messagebox_message_label").update(message)
-                self.stage += 1
+                self.save_hostkeys_and_prompt_password_input()
 
             elif self.stage == 2:
-                try:
-                    ssh.generate_and_write_ssh_key(
-                        self.project.cfg.ssh_key_path
-                    )
-                    #  key = paramiko.RSAKey.from_private_key_file(
-                    #      cfg.ssh_key_path.as_posix())
-                    password = self.query_one("#input").value
-
-                    ssh.add_public_key_to_central_authorized_keys(
-                        self.project.cfg, password, self.key
-                    )
-                    self.project._setup_rclone_central_ssh_config(log=True)
-
-                    message = (
-                        f"Connection successful! SSH key "
-                        f"saved to {self.project.cfg.ssh_key_path}"
-                    )
-                    self.query_one("#setup_ssh_ok_button").label = "Finish"
-                    self.query_one("#setup_ssh_cancel_button").disabled = True
-                    self.stage += 1
-                except BaseException as e:
-                    message = (
-                        f"Password setup failed. Check password is correct and try again."
-                        f"\n\n{self.failed_password_attempts} failed password attempts."
-                        f"\n\n Traceback: {e}"
-                    )
-                    self.failed_password_attempts += 1
-
-                self.query_one("#messagebox_message_label").update(message)
+                self.use_password_to_setup_ssh_key_pairs()
 
             elif self.stage == 3:
                 self.dismiss()
+
+    def ask_user_to_accept_hostkeys(self):
+        """
+        The central server is identified by a hostkey.
+        Get this hostkey and present it to user, clicking 'OK' is
+        they are happy. If there is an error, block process (because it
+        most likely is necessary to edit the central host id) and
+        show the traceback.
+        """
+        try:
+            self.key = ssh.get_remote_server_key(
+                self.project.cfg["central_host_id"]
+            )
+            message = (
+                f"The host key is not cached for this server: "
+                f"{self.project.cfg['central_host_id']}.\nYou have no guarantee "
+                f"that the server is the computer you think it is.\n"
+                f"The server's {self.key.get_name()} key fingerprint is:\n\n "
+                f"{self.key.get_base64()}\n\nIf you trust this host, to connect"
+                f" and cache the host key, press OK: "
+            )
+        except BaseException as e:
+            self.query_one("#setup_ssh_ok_button").disabled = True
+            message = (
+                "Could not connect to server. \nCheck the connection "
+                f"and the central host ID : \n\n{self.project.cfg['central_host_id']} \n\n Traceback: {e}"
+            )
+        self.query_one("#messagebox_message_label").update(message)
+        self.stage += 1
+
+    def save_hostkeys_and_prompt_password_input(self):
+        """
+        Once the hostkey is accepted, get the user password
+        for the central server. When 'OK' is pressed we go
+        straight to 'use_password_to_setup_ssh_key_pairs'.
+        """
+        try:
+            ssh.save_hostkey_locally(
+                self.key,
+                self.project.cfg["central_host_id"],
+                self.project.cfg.hostkeys_path,
+            )
+            message = (
+                "Hostkey accepted. \n\nNext, input your password to the server "
+                "below to setup an SSH key pair. You will not need to enter "
+                "your password again. Press OK to confirm"
+            )
+            self.query_one("#setup_ssh_password_input").visible = True
+        except BaseException as e:
+            self.query_one("#setup_ssh_ok_button").disabled = True
+            message = (
+                f"Could not store host key. Check permissions "
+                f"to: \n\n {self.project.cfg.hostkeys_path}.\n\n Traceback: {e}"
+            )
+
+        self.query_one("#messagebox_message_label").update(message)
+        self.stage += 1
+
+    def use_password_to_setup_ssh_key_pairs(self):
+        """
+        Get the user password for the central server. If correct,
+        SSH key pair is setup and 'OK' button changed to 'Finish'.
+        Otherwise, continue allowing failed password attempts.
+        """
+        try:
+            password = self.query_one("#setup_ssh_password_input").value
+
+            ssh.add_public_key_to_central_authorized_keys(
+                self.project.cfg, password, log=False
+            )
+            self.project._setup_rclone_central_ssh_config(log=False)
+
+            message = (
+                f"Connection successful! SSH key "
+                f"saved to {self.project.cfg.ssh_key_path}"
+            )
+            self.query_one("#setup_ssh_ok_button").label = "Finish"
+            self.query_one("#setup_ssh_cancel_button").disabled = True
+            self.stage += 1
+        except BaseException as e:
+            message = (
+                f"Password setup failed. Check password is correct and try again."
+                f"\n\n{self.failed_password_attempts} failed password attempts."
+                f"\n\n Traceback: {e}"
+            )
+            self.failed_password_attempts += 1
+
+        self.query_one("#messagebox_message_label").update(message)

--- a/datashuttle/tui/screens/template_settings.py
+++ b/datashuttle/tui/screens/template_settings.py
@@ -11,6 +11,8 @@ from textual.widgets import (
     RadioSet,
 )
 
+from datashuttle.tui.custom_widgets import TopLevelFolderSelect
+
 
 # TODO: need to do some renaming to distinguish template settings vs. general create settings
 class TemplateSettingsScreen(ModalScreen):
@@ -58,49 +60,57 @@ class TemplateSettingsScreen(ModalScreen):
         bypass_validation = self.project.get_bypass_validation()
 
         yield Container(
+            Horizontal(
+                Label("Top level folder:", id="labelTESTEST"),
+                TopLevelFolderSelect(
+                    self.project,
+                    existing_only=True,
+                    id="tabscreen_toplevel_select",
+                ),
+            ),
             Checkbox(
                 "Bypass validation",
                 value=bypass_validation,
                 id="create_settings_bypass_validation_checkbox",
             ),
-            Horizontal(
-                Checkbox(
-                    "Template Validation",
-                    id="template_settings_validation_on_checkbox",
-                    value=self.templates["on"],
-                ),
-                Horizontal(),
-                Button("Close", id="template_sessions_close_button"),
-                id="template_inner_horizontal_container",
-            ),
             Container(
-                Label(explanation, id="template_message_label"),
-                Container(
-                    RadioSet(
-                        RadioButton(
-                            "Subject",
-                            id="template_settings_subject_radiobutton",
-                            value=sub_on,
-                        ),
-                        RadioButton(
-                            "Session",
-                            id="template_settings_session_radiobutton",
-                            value=ses_on,
-                        ),
-                        id="template_settings_radioset",
+                Horizontal(
+                    Checkbox(
+                        "Template Validation",
+                        id="template_settings_validation_on_checkbox",
+                        value=self.templates["on"],
                     ),
-                    Input(id="template_settings_input"),
-                    id="template_other_widgets_container",
+                    id="template_inner_horizontal_container",
                 ),
-                id="template_inner_container",
+                Container(
+                    Label(explanation, id="template_message_label"),
+                    Container(
+                        RadioSet(
+                            RadioButton(
+                                "Subject",
+                                id="template_settings_subject_radiobutton",
+                                value=sub_on,
+                            ),
+                            RadioButton(
+                                "Session",
+                                id="template_settings_session_radiobutton",
+                                value=ses_on,
+                            ),
+                            id="template_settings_radioset",
+                        ),
+                        Input(id="template_settings_input"),
+                        id="template_other_widgets_container",
+                    ),
+                    id="template_inner_container",
+                ),
+                id="template_top_container",
             ),
-            id="template_top_container",
+            Container(),
+            Button("Close", id="template_sessions_close_button"),
+            id="template_top_container2",
         )
 
     def on_mount(self):
-        container = self.query_one("#template_top_container")
-        container.border_title = "Template Settings"
-
         self.fill_input_from_template()
         self.set_disabled_mode_widgets()
 

--- a/datashuttle/tui/screens/template_settings.py
+++ b/datashuttle/tui/screens/template_settings.py
@@ -12,6 +12,7 @@ from textual.widgets import (
 )
 
 
+# TODO: need to do some renaming to distinguish template settings vs. general create settings
 class TemplateSettingsScreen(ModalScreen):
     """
     This screen handles setting datashuttle's `name_template`'s.
@@ -54,7 +55,14 @@ class TemplateSettingsScreen(ModalScreen):
         Visit the [@click=screen.link_docs()]Documentation[/] for more information.
         """
 
+        bypass_validation = self.project.get_bypass_validation()
+
         yield Container(
+            Checkbox(
+                "Bypass validation",
+                value=bypass_validation,
+                id="create_settings_bypass_validation_checkbox",
+            ),
             Horizontal(
                 Checkbox(
                     "Template Validation",
@@ -107,16 +115,26 @@ class TemplateSettingsScreen(ModalScreen):
     def on_button_pressed(self, event: Button.Pressed):
         if event.button.id == "template_sessions_close_button":
             self.dismiss(self.templates)
+        elif event.button.id == "create_settings_bypass_validation_button":
+            self.project.set_bypass_validation(on=False)
 
-    def on_checkbox_changed(self, message):
+    def on_checkbox_changed(self, event):
         """
         Turn `name_templates` on or off and update the TUI accordingly.
         """
-        is_on = message.value
+        is_on = event.value
 
-        self.templates["on"] = is_on
-        self.project.set_name_templates(self.templates)
-        self.set_disabled_mode_widgets()
+        if event.checkbox.id == "template_settings_validation_on_checkbox":
+            self.templates["on"] = is_on
+            self.project.set_name_templates(self.templates)
+            self.set_disabled_mode_widgets()
+
+        elif event.checkbox.id == "create_settings_bypass_validation_checkbox":
+            self.project.set_bypass_validation(on=is_on)
+            self.query_one("#template_inner_container").disabled = is_on
+            self.query_one(
+                "#template_settings_validation_on_checkbox"
+            ).disabled = is_on
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         """

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -181,12 +181,25 @@ class CreateFoldersTab(TreeAndInputTab):
         if ses_names == [""]:
             ses_names = None
 
+        # This can't use the top level folder argument on the select
+        # because it is on another screen, which is not good...
+        # In general this handling of top level folder is not ideal...
+        tmp_top_level_folder = self.project.get_top_level_folder()
+        persistent_settings = self.project._load_persistent_settings()
+        top_level_folder = persistent_settings["tui"][
+            "top_level_folder_select"
+        ]["create_tab"]
+
         try:
+            self.project.set_top_level_folder(top_level_folder)
             self.project.make_folders(
                 sub_names=sub_names, ses_names=ses_names, datatype=datatype
             )
             self.reload_directorytree()
+
+            self.project.set_top_level_folder(tmp_top_level_folder)
         except BaseException as e:
+            self.project.set_top_level_folder(tmp_top_level_folder)
             self.mainwindow.show_modal_error_dialog(str(e))
             return
 

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -65,7 +65,8 @@ class CreateFoldersTab(TreeAndInputTab):
         yield Horizontal(
             Button("Make Folders", id="tabscreen_make_folder_button"),
             Button(
-                "Template Settings", id="tabscreen_template_settings_button"
+                "Settings",
+                id="tabscreen_template_settings_button",  # TODO: rename tabscreen here
             ),
         )
 

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -45,6 +45,9 @@ class TransferTab(TreeAndInputTab):
         self.mainwindow = mainwindow
         self.project = project
         self.prev_click_time = 0.0
+        self.show_legend = self.mainwindow.load_global_settings()[
+            "show_transfer_tree_status"
+        ]
 
     def compose(self):
         self.transfer_all_widgets = [
@@ -120,7 +123,8 @@ class TransferTab(TreeAndInputTab):
             Button("Transfer", id="transfer_transfer_button"),
             Horizontal(),  # push button to left
         )
-        yield Label("⭕ Legend", id="transfer_legend")
+        if self.show_legend:
+            yield Label("⭕ Legend", id="transfer_legend")
 
     def on_mount(self):
         self.query_one(
@@ -128,13 +132,14 @@ class TransferTab(TreeAndInputTab):
         ).border_title = "Parameters"
         self.switch_transfer_widgets_display()
 
-        self.query_one("#transfer_legend").tooltip = Text.assemble(
-            "Unchanged\n",
-            ("Changed\n", "gold3"),
-            ("Local Only\n", "green3"),
-            # ("Central Only\n", "italic dodger_blue3"),
-            ("Error\n", "bright_red"),
-        )
+        if self.show_legend:
+            self.query_one("#transfer_legend").tooltip = Text.assemble(
+                "Unchanged\n",
+                ("Changed\n", "gold3"),
+                ("Local Only\n", "green3"),
+                # ("Central Only\n", "italic dodger_blue3"),
+                ("Error\n", "bright_red"),
+            )
 
     def switch_transfer_widgets_display(self):
         """

--- a/datashuttle/tui/tabs/transfer_status_tree.py
+++ b/datashuttle/tui/tabs/transfer_status_tree.py
@@ -26,7 +26,8 @@ class TransferStatusTree(CustomDirectoryTree):
         )
 
         self.project = project
-        self.update_transfer_diffs()
+
+    #        self.update_transfer_diffs()
 
     def on_mount(self):
         self.update_local_transfer_paths()
@@ -68,7 +69,7 @@ class TransferStatusTree(CustomDirectoryTree):
         and project transfer status.
         """
         self.update_local_transfer_paths()
-        self.update_transfer_diffs()
+        #   self.update_transfer_diffs()
         self.reload()
 
     def format_transfer_label(self, node_label, node_path):
@@ -138,7 +139,7 @@ class TransferStatusTree(CustomDirectoryTree):
                 ),
             )
 
-        self.format_transfer_label(node_label, node_path)
+        #     self.format_transfer_label(node_label, node_path)
 
         text = Text.assemble(prefix, node_label)
         return text

--- a/datashuttle/tui/tabs/transfer_status_tree.py
+++ b/datashuttle/tui/tabs/transfer_status_tree.py
@@ -26,11 +26,10 @@ class TransferStatusTree(CustomDirectoryTree):
         )
 
         self.project = project
-
-    #        self.update_transfer_diffs()
+        self.transfer_diffs = None
 
     def on_mount(self):
-        self.update_local_transfer_paths()
+        self.update_transfer_tree(init=True)
 
     def update_local_transfer_paths(self):
         """
@@ -63,38 +62,16 @@ class TransferStatusTree(CustomDirectoryTree):
             self.project.cfg, all_top_level_folder=True
         )
 
-    def update_transfer_tree(self):
+    def update_transfer_tree(self, init=False):
         """
         Updates tree styling to reflect the current TUI state
         and project transfer status.
         """
         self.update_local_transfer_paths()
-        #   self.update_transfer_diffs()
-        self.reload()
-
-    def format_transfer_label(self, node_label, node_path):
-        """
-        Takes nodes being formatted using `render_label` and applies custom
-        formatting according to the node's transfer status.
-        """
-
-        node_relative_path = node_path.as_posix().replace(
-            f"{self.project.cfg['local_path'] .as_posix()}/", ""
-        )
-
-        # Checks whether the current node's file path is staged for transfer
-        if node_path in self.transfer_paths:
-            # Sets sub- and ses-level folders to orange if files within have changed
-            # fmt: off
-            if node_relative_path in self.transfer_diffs["same"]:
-                pass
-            elif node_relative_path in self.transfer_diffs["different"] or any([node_relative_path in file for file in self.transfer_diffs["different"]]):
-                node_label.stylize_before("gold3")
-            elif node_relative_path in self.transfer_diffs["local_only"] or any([node_relative_path in file for file in self.transfer_diffs["local_only"]]):
-                node_label.stylize_before("green3")
-            elif node_label.plain in self.transfer_diffs["error"] or any([node_relative_path in file for file in self.transfer_diffs["error"]]):
-                node_label.stylize_before("bright_red")
-            # fmt: on
+        if self.mainwindow.load_global_settings()["show_transfer_tree_status"]:
+            self.update_transfer_diffs()
+        if not init:
+            self.reload()
 
     # Overridden Methods
     # ----------------------------------------------------------------------------------
@@ -139,7 +116,32 @@ class TransferStatusTree(CustomDirectoryTree):
                 ),
             )
 
-        #     self.format_transfer_label(node_label, node_path)
+        if self.transfer_diffs:
+            self.format_transfer_label(node_label, node_path)
 
         text = Text.assemble(prefix, node_label)
         return text
+
+    def format_transfer_label(self, node_label, node_path):
+        """
+        Takes nodes being formatted using `render_label` and applies custom
+        formatting according to the node's transfer status.
+        """
+
+        node_relative_path = node_path.as_posix().replace(
+            f"{self.project.cfg['local_path'] .as_posix()}/", ""
+        )
+
+        # Checks whether the current node's file path is staged for transfer
+        if node_path in self.transfer_paths:
+            # Sets sub- and ses-level folders to orange if files within have changed
+            # fmt: off
+            if node_relative_path in self.transfer_diffs["same"]:
+                pass
+            elif node_relative_path in self.transfer_diffs["different"] or any([node_relative_path in file for file in self.transfer_diffs["different"]]):
+                node_label.stylize_before("gold3")
+            elif node_relative_path in self.transfer_diffs["local_only"] or any([node_relative_path in file for file in self.transfer_diffs["local_only"]]):
+                node_label.stylize_before("green3")
+            elif node_label.plain in self.transfer_diffs["error"] or any([node_relative_path in file for file in self.transfer_diffs["error"]]):
+                node_label.stylize_before("bright_red")
+            # fmt: on

--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -290,9 +290,7 @@ class TransferData:
         Given a particular subject and session, get a list of all
         canonical datatype folders.
         """
-        datatype = list(
-            filter(lambda x: x != "all_ses_level_non_datatype", datatype)
-        )
+        datatype = list(filter(lambda x: x != "all_non_datatype", datatype))
 
         datatype_items = folders.items_from_datatype_input(
             self.cfg, self.local_or_central, datatype, sub, ses
@@ -443,8 +441,5 @@ class TransferData:
         are to be transferred
         """
         return any(
-            [
-                name in ["all_ses_level_non_datatype", "all"]
-                for name in datatype_checked
-            ]
+            [name in ["all_non_datatype", "all"] for name in datatype_checked]
         )

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -17,7 +17,7 @@ def check_and_format_names(
     names: Union[list, str],
     prefix: Literal["sub", "ses"],
     name_templates: Optional[Dict] = None,
-    bypass_validation: bool = True,
+    bypass_validation: bool = False,
 ) -> List[str]:
     """
     Format a list of subject or session names, e.g.

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -17,6 +17,7 @@ def check_and_format_names(
     names: Union[list, str],
     prefix: Literal["sub", "ses"],
     name_templates: Optional[Dict] = None,
+    bypass_validation: bool = True,
 ) -> List[str]:
     """
     Format a list of subject or session names, e.g.
@@ -45,27 +46,32 @@ def check_and_format_names(
         A dictionary of templates to validate subject and session name against.
         e.g. {"name_templates": {"on": False, "sub": None, "ses": None}}
         where the "sub" and "ses" may contain a regexp to validate against.
+
+    bypass_validation : Dict
+        If `True`, NeuroBlueprint validation will be performed
+        on the passed names.
     """
     if isinstance(names, str):
         names = [names]
 
-    names_to_check, reserved_keywords = [], []
+    names_to_format, reserved_keywords = [], []
     for name in names:
         if name in canonical_reserved_keywords() or tags("*") in name:
             reserved_keywords.append(name)
         else:
-            names_to_check.append(name)
+            names_to_format.append(name)
 
-    formatted_names = format_names(names_to_check, prefix)
+    formatted_names = format_names(names_to_format, prefix)
 
-    validation.validate_list_of_names(
-        formatted_names,
-        prefix,
-        "error",
-        check_duplicates=True,
-        name_templates=name_templates,
-        log=True,
-    )
+    if not bypass_validation:
+        validation.validate_list_of_names(
+            formatted_names,
+            prefix,
+            "error",
+            check_duplicates=True,
+            name_templates=name_templates,
+            log=True,
+        )
 
     return formatted_names + reserved_keywords
 

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -185,7 +186,8 @@ def get_existing_project_paths() -> List[Path]:
     Return full path and names of datashuttle projects on
     this local machine. A project is determined by a project
     folder in the home / .datashuttle folder that contains a
-    config.yaml file.
+    config.yaml file. Returns in order of most recently modified
+    first.
     """
     datashuttle_path = canonical_folders.get_datashuttle_path()
 
@@ -208,6 +210,8 @@ def get_existing_project_paths() -> List[Path]:
             )
         elif len(config_file) == 1:
             existing_project_paths.append(datashuttle_path / folder_name)
+
+    existing_project_paths.sort(key=os.path.getmtime, reverse=True)
 
     return existing_project_paths
 

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -875,7 +875,7 @@ Datashuttle provides a number of keyword arguments to allow separate
 handling of files that are not found in *datatype* folders.
 
 These are:
-`all_sub` and `all_non_sub` (for `-sub`), `all_ses` and `all_non_ses` (for `-ses`) and `-all_ses_level_non_datatype` (for `-dt`).
+`all_sub` and `all_non_sub` (for `-sub`), `all_ses` and `all_non_ses` (for `-ses`) and `all_non_datatype` (for `-dt`).
 
 
 #### For use with the `-sub` / `--sub-names` flag
@@ -910,7 +910,7 @@ as well as all files and folders within selected *session* folders.
 `behav`, `ephys`, `funcimg`, `anat`) within a *session* folder will be
 transferred. Non-*datatype* folders at the *session* level will not be transferred
 
-`all_ses_level_non_datatype` : Non-*datatype* folders within *session* folders only will be transferred
+`all_non_datatype` : Non-*datatype* folders within *session* folders only will be transferred
 
 Below, a number of examples are given to exemplify how these arguments effect data transfer.
 Given our example *local* project folder above:
@@ -923,7 +923,7 @@ Given our example *local* project folder above:
 
 :::{tab-item} Python API
 ```{code-block} console
-project.upload("all", "all", "all_ses_level_non_datatype")
+project.upload("all", "all", "all_non_datatype")
 ```
 :::
 
@@ -935,7 +935,7 @@ my_first_project \
 upload \
 -sub all \
 -ses all \
--dt all_ses_level_non_datatype
+-dt all_non_datatype
 ```
 :::
 
@@ -946,7 +946,7 @@ my_first_project ^
 upload ^
 -sub all ^
 -ses all ^
--dt all_ses_level_non_datatype
+-dt all_non_datatype
 ```
 :::
 

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -15,12 +15,12 @@ class TestPersistentSettings(BaseTest):
     def test_persistent_settings(self, project, unused_repeat):
         """
         Test persistent settings functions by editing the
-        persistent settings, checking they are changed and
-        the program settings are changed accordingly.
+        persistent settings top-level-folder entry, checking they are
+        changed and the program settings are changed accordingly.
         """
         settings = project._load_persistent_settings()
 
-        assert len(settings) == 3
+        assert len(settings) == 4
         assert settings["top_level_folder"] == "rawdata"
 
         # Update they persistent setting and check this is reflected

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -147,13 +147,13 @@ class TestFileTransfer:
         "datatype",
         [
             ["all"],
-            ["all_ses_level_non_datatype"],
+            ["all_non_datatype"],
             ["all_datatype"],
             ["behav"],
             ["ephys"],
             ["anat"],
             ["funcimg"],
-            ["anat", "behav", "all_ses_level_non_datatype"],
+            ["anat", "behav", "all_non_datatype"],
         ],
     )
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])
@@ -267,7 +267,7 @@ class TestFileTransfer:
                 entries += (
                     [f"all_non_{field}"]
                     if field != "datatype"
-                    else ["all_ses_level_non_datatype"]
+                    else ["all_non_datatype"]
                 )
             list_of_names = entries
         return list_of_names
@@ -296,7 +296,7 @@ class TestFileTransfer:
                         ]
                     else:
                         for dtype in datatype:
-                            if dtype == "all_ses_level_non_datatype":
+                            if dtype == "all_non_datatype":
                                 extra_arguments += [
                                     f"(parent_sub == '{sub}' & parent_ses == '{ses}' & is_ses_level_non_datatype == True)"
                                 ]


### PR DESCRIPTION
This PR introduces a number of new features and tidy ups, ideally these would have been split into separate PR.

1) Add a filetree select to the 'Configs' screen, which opens a popup with a DirectoryTree to select the local / central path
2) Add a 'Setup SSH Connection' that walks through the process of setting up an SSH connection, when everything has been input into configs
3) Connecting with SSH meant that the filetree coloring became very slow, because making the SSH connection to perform the checks was slow and in some cases would crash if the SSH was not setup correctly. As such I added an option to turn it off to the front-page settings; this is a temporary workaround and if it's possible to improve the speed of SSH we can keep it always on, or alternatively only every had it on for 'local' version. Ideally this would be the case now but for ease of implementation I started with a global option, and will tell testers to turn it on of not using SSH as it's such a nice feature.
4) Removed transfer verbosity  show transfer progress config options from TUI as realsied only relevant for API
5) Set dark / light mode in the global 'settings' on the front page (CTRL+D no longer changes, will reserve this key pairing for later use e.g. deleting files from the directory tree
6) Add an option to bypass validation and create folders even when invalid, in case use get's stuck somehow
7) Add top level folder select for create folders. I couldnt make it look nice on the main page so added it to tempalte settings (which are now a more general 'settings'
8) Changed the `all_ses_level_non_datatype` option for transfers to `all_non_datatype` and updated the checkboxes to render title + replace "_" with " " e.g. "all_non_datatype" becomes "All Non Datatype".



Original Post:
TODO: accidentally made this on the fork!