### PR TITLE
Add logging tab

### DIFF
--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -328,7 +328,7 @@ CreateFoldersSettingsScreen {
 
 /* Confirmation Screen --------------------------------------------------------------------- */
 
-ConfirmScreen {
+FinishTransferScreen {
     align: center middle;
 }
 

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -28,7 +28,7 @@ class MessageBox(ModalScreen):
 
     border_color : str
         The color to pass to the `border` style on the widget. Note that the
-        keywords 'red' and 'green' are overridden for custom style.
+        keywords 'red' 'grey' 'green' are overridden for custom style.
     """
 
     def __init__(self, message: str, border_color: str) -> None:
@@ -52,6 +52,8 @@ class MessageBox(ModalScreen):
             color = "rgb(140, 12, 0)"
         elif self.border_color == "green":
             color = "rgb(1, 138, 13)"
+        elif self.border_color in ["gray", "grey"]:
+            color = "rgb(184, 184, 184)"
         else:
             color = self.border_color
 
@@ -64,7 +66,7 @@ class MessageBox(ModalScreen):
         self.dismiss(True)
 
 
-class ConfirmScreen(ModalScreen):
+class FinishTransferScreen(ModalScreen):
     """
     A screen for rendering confirmation messages
     taking user input ('OK' or 'Cancel').
@@ -88,7 +90,13 @@ class ConfirmScreen(ModalScreen):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "confirm_ok_button":
-            self.dismiss(True)
+            # Update the display to 'transferring' before TUI freezes
+            # during data transfer.
+            self.query_one("#confirm_button_container").visible = False
+            self.query_one("#confirm_message_label").update("Transferring...")
+            self.query_one("#confirm_message_label").call_after_refresh(
+                lambda: self.dismiss(True)
+            )
         else:
             self.dismiss(False)
 

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -17,7 +17,7 @@ from textual.widgets import (
 )
 
 from datashuttle.tui.configs import ConfigsContent
-from datashuttle.tui.tabs import create_folders, transfer
+from datashuttle.tui.tabs import create_folders, logging, transfer
 
 
 class ProjectManagerScreen(Screen):
@@ -65,6 +65,12 @@ class ProjectManagerScreen(Screen):
             )
             with TabPane("Configs", id="tabscreen_configs_tab"):
                 yield ConfigsContent(self, self.interface)
+            yield logging.LoggingTab(
+                "Logs",
+                self.mainwindow,
+                self.interface.project,
+                id="tabscreen_logging_tab",
+            )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """
@@ -90,10 +96,12 @@ class ProjectManagerScreen(Screen):
             self.tabbed_content_mount_signal = False
             return
 
-        if event.pane.id == "tabscreen_create_tab":
-            self.query_one("#tabscreen_create_tab").reload_directorytree()
-        elif event.pane.id == "tabscreen_transfer_tab":
-            self.query_one("#tabscreen_transfer_tab").reload_directorytree()
+        if event.pane.id in [
+            "tabscreen_create_tab",
+            "tabscreen_transfer_tab",
+            "tabscreen_logging_tab",
+        ]:
+            self.query_one(f"#{event.pane.id}").reload_directorytree()
 
     def on_configs_content_configs_saved(self) -> None:
         """

--- a/datashuttle/tui/tabs/logging.py
+++ b/datashuttle/tui/tabs/logging.py
@@ -1,0 +1,92 @@
+import os
+
+from textual.containers import Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, RichLog, TabPane
+
+from datashuttle.tui.custom_widgets import (
+    CustomDirectoryTree,
+)
+from datashuttle.tui.utils.tui_decorators import require_double_click
+
+
+class RichLogScreen(ModalScreen):
+    def __init__(self, log_file):
+        super(RichLogScreen, self).__init__()
+
+        with open(log_file, "r") as file:
+            self.log_contents = "".join(file.readlines())
+
+    def compose(self):
+        yield RichLog(highlight=True, markup=True)
+        yield Button("Close", id="rich_log_screen_close_button")
+
+    def on_mount(self):
+        text_log = self.query_one(RichLog)
+        text_log.write(self.log_contents)
+
+    def on_button_pressed(self, event):
+        if event.button.id == "rich_log_screen_close_button":
+            self.dismiss()
+
+
+class LoggingTab(TabPane):
+    def __init__(self, title, mainwindow, project, id):
+        super(LoggingTab, self).__init__(title=title, id=id)
+
+        self.mainwindow = mainwindow
+        self.project = project
+
+        # Hold the latest logs on this variable to ensure
+        # display and functionality are always in sync.
+        self.latest_log_path = None
+        self.update_latest_log_path()
+        self.prev_click_time = 0
+
+    def update_latest_log_path(self):
+        logs = self.project.get_logging_path().glob("*.log")
+        self.latest_log_path = max(logs, key=os.path.getctime)
+
+    def compose(self):
+        yield Label("Double click logging file to select")
+        yield CustomDirectoryTree(
+            self.mainwindow,
+            self.project.get_logging_path(),
+            id="logging_tab_custom_directory_tree",
+        )
+        yield Label("or select most recent:")
+        yield Horizontal(
+            Button(
+                "Open Most Recent", id="logging_tab_open_most_recent_button"
+            ),
+            Label(f"{self.latest_log_path.stem}"),
+        )
+
+    def on_button_pressed(self, event):
+        if event.button.id == "logging_tab_open_most_recent_button":
+            self.push_rich_log_screen(self.latest_log_path)
+
+    @require_double_click
+    def on_directory_tree_file_selected(self, node):
+        if not node.path.is_file():
+            self.mainwindow.show_modal_error_dialog(
+                "Log file no longer exists. Refresh the directory tree"
+                "by pressing CTRL and r at the same time."
+            )
+            return
+
+        self.push_rich_log_screen(node.path)
+
+    def push_rich_log_screen(self, log_path):
+        self.mainwindow.push_screen(
+            RichLogScreen(
+                log_path,
+            )
+        )
+
+    def reload_directorytree(self):
+        self.query_one("#logging_tab_custom_directory_tree").reload()
+
+    # TODO: look into this, should handle on the directorytree itself... dam this sucks!
+    def on_custom_directory_tree_directory_tree_special_key_press(self):
+        self.reload_directorytree()

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -27,7 +27,10 @@ from datashuttle.tui.custom_widgets import (
     TopLevelFolderSelect,
     TreeAndInputTab,
 )
-from datashuttle.tui.screens.modal_dialogs import ConfirmScreen
+from datashuttle.tui.screens.modal_dialogs import (
+    FinishTransferScreen,
+    MessageBox,
+)
 from datashuttle.tui.tabs.transfer_status_tree import TransferStatusTree
 
 
@@ -227,7 +230,7 @@ class TransferTab(TreeAndInputTab):
             )
 
             self.mainwindow.push_screen(
-                ConfirmScreen(message), self.transfer_data
+                FinishTransferScreen(message), self.transfer_data
             )
 
     def on_custom_directory_tree_directory_tree_special_key_press(
@@ -261,7 +264,7 @@ class TransferTab(TreeAndInputTab):
 
         Parameters
         ----------
-        transfer_bool: Passed by `ConfirmScreen`. True if user confirmed
+        transfer_bool: Passed by `FinishTransferScreen`. True if user confirmed
             transfer by clicking "Yes".
 
         """
@@ -304,5 +307,15 @@ class TransferTab(TreeAndInputTab):
 
             self.reload_directorytree()
 
-            if not success:
+            if success:
+                self.mainwindow.push_screen(
+                    MessageBox(
+                        "Transfer finished."
+                        "\n\n"
+                        "Check the most recent logs to "
+                        "ensure transfer completed successfully.",
+                        border_color="grey",
+                    )
+                )
+            else:
                 self.mainwindow.show_modal_error_dialog(output)


### PR DESCRIPTION
Adds a 'Logging' tab that allows you to view datashuttle logs. Currently CSS and docs are not fully implemented as will be added in a later PR.