### PR TITLE
Apply meeting feedback

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -505,8 +505,8 @@ def construct_parser():
         help="(str)",
     )
     make_config_file_parser.add_argument(
-        "--overwrite-old-files",
-        "--overwrite_old_files",
+        "--overwrite-existing-files",
+        "--overwrite_existing_files",
         required=False,
         action="store_true",
         help=help("flag_default_false"),

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -1037,8 +1037,9 @@ def main() -> None:
     """
     args = parser.parse_args()
 
-    if args.project_name in ["tui", "gui", "start"]:
+    if args.project_name in ["tui", "gui", "launch"]:
         tui_main()
+        return
 
     if "func" in args and str(args.func.__name__) == "make_config_file":
         warn = "ignore"

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -1037,7 +1037,7 @@ def main() -> None:
     """
     args = parser.parse_args()
 
-    if args.project_name in ["tui", "gui"]:
+    if args.project_name in ["tui", "gui", "start"]:
         tui_main()
 
     if "func" in args and str(args.func.__name__) == "make_config_file":

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -122,31 +122,7 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
         )
 
     for path_type in ["local_path", "central_path"]:
-        path_name = config_dict[path_type].as_posix()
-        if path_name[0] == "~":
-            utils.log_and_raise_error(
-                f"{path_type} must contain the full folder path "
-                "with no ~ syntax.",
-                ConfigError,
-            )
-
-        # pathlib strips "./" so not checked.
-        for bad_start in [".", "../"]:
-            if path_name.startswith(bad_start):
-                utils.log_and_raise_error(
-                    f"{path_type} must contain the full folder path "
-                    "with no dot syntax.",
-                    ConfigError,
-                )
-
-        project_name = config_dict.project_name
-        if config_dict[path_type].stem != project_name:
-            utils.log_and_raise_error(
-                f"The last folder in the passed {path_type} "
-                f"should be {project_name}.\n"
-                f"The passed path was {config_dict[path_type]}",
-                ConfigError,
-            )
+        raise_on_bad_path_syntax(config_dict[path_type].as_posix(), path_type)
 
     check_folder_above_project_name_exists(config_dict)
 
@@ -181,6 +157,31 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
             f"Config file not updated.",
             RuntimeError,
         )
+
+
+def raise_on_bad_path_syntax(
+    path_name: str,
+    path_type: str,
+) -> None:
+    """
+    Error if some common, unsupported patterns are observed
+    (e.g. ~, .) for path.
+    """
+    if path_name[0] == "~":
+        utils.log_and_raise_error(
+            f"{path_type} must contain the full folder path "
+            "with no ~ syntax.",
+            ConfigError,
+        )
+
+    # pathlib strips "./" so not checked.
+    for bad_start in [".", "../"]:
+        if path_name.startswith(bad_start):
+            utils.log_and_raise_error(
+                f"{path_type} must contain the full folder path "
+                "with no dot syntax.",
+                ConfigError,
+            )
 
 
 def check_folder_above_project_name_exists(config_dict: Configs) -> None:

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -41,7 +41,7 @@ def get_canonical_configs() -> dict:
         "connection_method": Literal["ssh", "local_filesystem"],
         "central_host_id": Optional[str],
         "central_host_username": Optional[str],
-        "overwrite_old_files": bool,
+        "overwrite_existing_files": bool,
         "transfer_verbosity": Literal["v", "vv"],
         "show_transfer_progress": bool,
     }
@@ -63,7 +63,7 @@ def get_flags() -> List[str]:
     testing and type checking config inputs.
     """
     return [
-        "overwrite_old_files",
+        "overwrite_existing_files",
         "show_transfer_progress",
     ]
 

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -142,8 +142,6 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
         project_name = config_dict.project_name
         if config_dict[path_type].stem != project_name:
             utils.log_and_raise_error(
-                f"The {path_type} does not end in the "
-                f"project name: {project_name}. \n"
                 f"The last folder in the passed {path_type} "
                 f"should be {project_name}.\n"
                 f"The passed path was {config_dict[path_type]}",

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -56,7 +56,20 @@ class Configs(UserDict):
 
     def setup_after_load(self) -> None:
         self.convert_str_and_pathlib_paths(self, "str_to_path")
+        self.ensure_local_and_central_path_end_in_project_name()
         self.check_dict_values_raise_on_fail()
+
+    def ensure_local_and_central_path_end_in_project_name(self):
+        """"""
+        for path_type in ["local_path", "central_path"]:
+
+            # important to check for "." path name as these
+            # disappear when paths are concatenated.
+            canonical_configs.raise_on_bad_path_syntax(
+                self[path_type].as_posix(), path_type
+            )
+            if self[path_type].name != self.project_name:
+                self[path_type] = self[path_type] / self.project_name
 
     def check_dict_values_raise_on_fail(self) -> None:
         """

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -241,7 +241,7 @@ class Configs(UserDict):
 
     def make_rclone_transfer_options(self, dry_run: bool) -> Dict:
         return {
-            "overwrite_old_files": self["overwrite_old_files"],
+            "overwrite_existing_files": self["overwrite_existing_files"],
             "transfer_verbosity": self["transfer_verbosity"],
             "show_transfer_progress": self["show_transfer_progress"],
             "dry_run": dry_run,

--- a/datashuttle/configs/load_configs.py
+++ b/datashuttle/configs/load_configs.py
@@ -101,9 +101,8 @@ def supplied_configs_confirm_overwrite(
 
     new_cfg = Configs(project_name, path_to_config, None)
     new_cfg.load_from_file()
-
     new_cfg = handle_cli_or_supplied_config_bools(new_cfg)
-    new_cfg.check_dict_values_raise_on_fail()
+    new_cfg.setup_after_load()
 
     return new_cfg
 

--- a/datashuttle/configs/load_configs.py
+++ b/datashuttle/configs/load_configs.py
@@ -15,7 +15,9 @@ ConfigValueTypes = Union[Path, str, bool, None]
 
 
 def attempt_load_configs(
-    project_name: str, config_path: Path
+    project_name: str,
+    config_path: Path,
+    verbose: bool = True,
 ) -> Optional[Configs]:
     """
     Try to load an existing config file, that was previously
@@ -32,14 +34,17 @@ def attempt_load_configs(
     project_name : name of project
 
     config_path : path to datashuttle config .yaml file
+
+    verbose : warnings and error messages will be printed.
     """
     exists = config_path.is_file()
 
     if not exists:
-        warnings.warn(
-            "Configuration file has not been initialized. "
-            "Use make_config_file() to setup before continuing."
-        )
+        if verbose:
+            warnings.warn(
+                "Configuration file has not been initialized. "
+                "Use make_config_file() to setup before continuing."
+            )
         return None
 
     new_cfg: Optional[Configs]

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -335,8 +335,8 @@ class DataShuttle:
             see create_folders()
 
         init_log :
-            (Optional). Whether to start the logger. This should
-            always be True, unless logger has already been started
+            (Optional). Whether handle logging. This should
+            always be True, unless logger is handled elsewhere
             (e.g. in a calling function).
 
         Notes
@@ -374,7 +374,9 @@ class DataShuttle:
             dry_run,
             log=True,
         )
-        ds_logger.close_log_filehandler()
+
+        if init_log:
+            ds_logger.close_log_filehandler()
 
     @check_configs_set
     def download(
@@ -411,30 +413,42 @@ class DataShuttle:
             dry_run,
             log=True,
         )
-        ds_logger.close_log_filehandler()
+
+        if init_log:
+            ds_logger.close_log_filehandler()
 
     @check_configs_set
-    def upload_all(self, dry_run: bool = False) -> None:
+    def upload_all(self, dry_run: bool = False, init_log: bool = True) -> None:
         """
         Convenience function to upload all data.
 
         Alias for:
             project.upload("all", "all", "all")
         """
-        self._start_log("upload-all", local_vars=locals())
+        if init_log:
+            self._start_log("upload-all", local_vars=locals())
 
         self.upload("all", "all", "all", dry_run=dry_run, init_log=False)
 
+        if init_log:
+            ds_logger.close_log_filehandler()
+
     @check_configs_set
-    def download_all(self, dry_run: bool = False) -> None:
+    def download_all(
+        self, dry_run: bool = False, init_log: bool = True
+    ) -> None:
         """
         Convenience function to download all data.
 
         Alias for : project.download("all", "all", "all")
         """
-        self._start_log("download-all", local_vars=locals())
+        if init_log:
+            self._start_log("download-all", local_vars=locals())
 
         self.download("all", "all", "all", dry_run=dry_run, init_log=False)
+
+        if init_log:
+            ds_logger.close_log_filehandler()
 
     @check_configs_set
     def upload_entire_project(self) -> None:
@@ -443,7 +457,9 @@ class DataShuttle:
         i.e. including every top level folder (e.g. 'rawdata',
         'derivatives', 'code', 'analysis').
         """
+        self._start_log("transfer-entire-project", local_vars=locals())
         self._transfer_entire_project("upload")
+        ds_logger.close_log_filehandler()
 
     @check_configs_set
     def download_entire_project(self) -> None:
@@ -452,7 +468,9 @@ class DataShuttle:
         i.e. including every top level folder (e.g. 'rawdata',
         'derivatives', 'code', 'analysis').
         """
+        self._start_log("transfer-entire-project", local_vars=locals())
         self._transfer_entire_project("download")
+        ds_logger.close_log_filehandler()
 
     @check_configs_set
     def upload_specific_folder_or_file(
@@ -1108,8 +1126,9 @@ class DataShuttle:
         tmp_current_top_level_folder = copy.copy(self.cfg.top_level_folder)
 
         for folder_name in canonical_folders.get_top_level_folders():
+            utils.log_and_message(f"Transferring `{folder_name}`")
             self.cfg.top_level_folder = folder_name
-            transfer_all_func()
+            transfer_all_func(init_log=False)
 
         self.cfg.top_level_folder = tmp_current_top_level_folder
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -85,11 +85,8 @@ class DataShuttle:
     """
 
     def __init__(self, project_name: str, print_startup_message: bool = True):
-        if " " in project_name:
-            utils.log_and_raise_error(
-                "'project_name' must not include spaces.", ValueError
-            )
 
+        self._error_on_base_project_name(project_name)
         self.project_name = project_name
         (
             self._datashuttle_path,
@@ -1192,6 +1189,13 @@ class DataShuttle:
         log_files = glob.glob(str(self._temp_log_path / "*.log"))
         for file in log_files:
             os.remove(file)
+
+    def _error_on_base_project_name(self, project_name):
+        if validation.name_has_special_character(project_name):
+            utils.log_and_raise_error(
+                "The project name must contain alphanumeric characters only.",
+                ValueError,
+            )
 
     def _log_successful_config_change(self, message: bool = False) -> None:
         """

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -103,7 +103,7 @@ class DataShuttle:
         self.cfg: Any = None
 
         self.cfg = load_configs.attempt_load_configs(
-            self.project_name, self._config_path
+            self.project_name, self._config_path, verbose=print_startup_message
         )
 
         if self.cfg:

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -758,20 +758,13 @@ class DataShuttle:
 
         new_cfg = copy.deepcopy(self.cfg)
         new_cfg.update(**kwargs)
+        new_cfg.setup_after_load()  # Will raise on error
 
-        check_change = new_cfg.safe_check_current_dict_is_valid()
-
-        if check_change["passed"]:
-            self.cfg = new_cfg
-            self._set_attributes_after_config_load()
-            self.cfg.dump_to_file()
-            self._log_successful_config_change(message=True)
-            ds_logger.close_log_filehandler()
-        else:
-            utils.log_and_raise_error(
-                f"{check_change['error']}\nConfigs were not updated.",
-                ConfigError,
-            )
+        self.cfg = new_cfg
+        self._set_attributes_after_config_load()
+        self.cfg.dump_to_file()
+        self._log_successful_config_change(message=True)
+        ds_logger.close_log_filehandler()
 
     def supply_config_file(
         self, input_path_to_config: str, warn: bool = True

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -342,7 +342,7 @@ class DataShuttle:
         Notes
         -----
 
-        The configs "overwrite_old_files", "transfer_verbosity"
+        The configs "overwrite_existing_files", "transfer_verbosity"
         and "show_transfer_progress" pertain to data-transfer settings.
         See make_config_file() for more information.
 
@@ -645,7 +645,7 @@ class DataShuttle:
         connection_method: str,
         central_host_id: Optional[str] = None,
         central_host_username: Optional[str] = None,
-        overwrite_old_files: bool = False,
+        overwrite_existing_files: bool = False,
         transfer_verbosity: str = "v",
         show_transfer_progress: bool = False,
     ) -> None:
@@ -691,7 +691,7 @@ class DataShuttle:
             username for which to log in to central host.
             e.g. "jziminski"
 
-        overwrite_old_files :
+        overwrite_existing_files :
             If True, when copying data (upload or download) files
             will be overwritten if the timestamp of the copied
             version is later than the target folder version
@@ -731,7 +731,7 @@ class DataShuttle:
                 "connection_method": connection_method,
                 "central_host_id": central_host_id,
                 "central_host_username": central_host_username,
-                "overwrite_old_files": overwrite_old_files,
+                "overwrite_existing_files": overwrite_existing_files,
                 "transfer_verbosity": transfer_verbosity,
                 "show_transfer_progress": show_transfer_progress,
             },

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -184,6 +184,7 @@ class TuiApp(App):
     def get_default_global_settings(self) -> Dict:
         return {
             "dark_mode": True,
+            "show_transfer_tree_status": False,
         }
 
     def save_global_settings(self, global_settings: Dict) -> None:

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
@@ -85,7 +86,9 @@ class TuiApp(App):
     def load_project_page(self, interface: Interface) -> None:
         if interface:
             self.push_screen(
-                project_manager.ProjectManagerScreen(self, interface)
+                project_manager.ProjectManagerScreen(
+                    self, interface, id="project_manager_screen"
+                )
             )
 
     def show_modal_error_dialog(self, message: str) -> None:
@@ -120,6 +123,36 @@ class TuiApp(App):
                 )
 
             self.show_modal_error_dialog(message)
+
+    def prompt_rename_file_or_folder(self, path_):
+        """ """
+        self.push_screen(
+            modal_dialogs.RenameFileOrFolderScreen(self, path_),
+            lambda new_name: self.rename_file_or_folder(path_, new_name),
+        )
+
+    def rename_file_or_folder(self, path_, new_name):
+        """ """
+        if new_name is False:
+            return
+        try:
+            if path_.is_dir():
+                os.rename(
+                    path_.as_posix(), (path_.parent / new_name).as_posix()
+                )
+            else:
+                os.rename(
+                    path_.as_posix(),
+                    path_.parent / f"{new_name}{path_.suffix}",
+                )
+            self.query_one("#project_manager_screen").update_active_tab_tree()
+        except BaseException as e:
+            self.show_modal_error_dialog(
+                f"Could not rename the file or folder."
+                f"Check the new name is valid, and correct "
+                f"permissions are set. \n\n"
+                f"Full error log {str(e)}"
+            )
 
     # Global Settings ---------------------------------------------------------
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -184,7 +184,6 @@ class TuiApp(App):
     def get_default_global_settings(self) -> Dict:
         return {
             "dark_mode": True,
-            "show_transfer_tree_status": False,
         }
 
     def save_global_settings(self, global_settings: Dict) -> None:

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -205,8 +205,8 @@ class ConfigsContent(Container):
         for widget in self.config_ssh_widgets:
             widget.display = display_bool
 
-        self.query_one("#configs_central_path_select_button").disabled = (
-            display_bool
+        self.query_one("#configs_central_path_select_button").display = (
+            not display_bool
         )
 
         if self.interface is not None:

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -16,7 +16,6 @@ from textual.containers import Container, Horizontal
 from textual.message import Message
 from textual.widgets import (
     Button,
-    Checkbox,
     Label,
     RadioButton,
     RadioSet,
@@ -125,14 +124,6 @@ class ConfigsContent(Container):
                 Button("Select", id="configs_central_path_select_button"),
                 id="configs_central_path_button_input_container",
             ),
-            Container(
-                Checkbox(
-                    "Overwrite Old Files",
-                    value=False,
-                    id="configs_overwrite_files_checkbox",
-                ),
-                id="configs_transfer_options_container",
-            ),
             Horizontal(
                 Button("Save", id="configs_save_configs_button"),
                 Button(
@@ -182,8 +173,6 @@ class ConfigsContent(Container):
         should be off by default anyway if `value` is not set, but we set here
         anyway as it is critical this is not on by default.
         """
-        container = self.query_one("#configs_transfer_options_container")
-        container.border_title = "Transfer Options"
         if self.interface:
             self.fill_widgets_with_project_configs()
         else:
@@ -191,8 +180,6 @@ class ConfigsContent(Container):
                 True
             )
             self.switch_ssh_widgets_display(display_bool=False)
-
-            self.query_one("#configs_overwrite_files_checkbox").value = False
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         """
@@ -465,10 +452,6 @@ class ConfigsContent(Container):
         )
         input.value = value
 
-        # Overwrite Files Checkbox
-        checkbox = self.query_one("#configs_overwrite_files_checkbox")
-        checkbox.value = self.interface.get_configs()["overwrite_old_files"]
-
     def get_datashuttle_inputs_from_widgets(self) -> Dict:
         """
         Get the configs to pass to `make_config_file()` from
@@ -504,9 +487,5 @@ class ConfigsContent(Container):
         cfg_kwargs["central_host_username"] = (
             None if central_host_username == "" else central_host_username
         )
-
-        cfg_kwargs["overwrite_old_files"] = self.query_one(
-            "#configs_overwrite_files_checkbox"
-        ).value
 
         return cfg_kwargs

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -144,7 +144,7 @@ class ConfigsContent(Container):
         ]
 
         init_only_config_screen_widgets = [
-            Label("Configure A New Project", id="configs_banner_label"),
+            Label("Make A New Project", id="configs_banner_label"),
             Horizontal(
                 Static(
                     "Set your configurations for a new project. For more "

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -192,17 +192,6 @@ MessageBox:light > #messagebox_top_container {
     border: none;
 }
 
-#configs_transfer_options_container {
-    margin: 2 0 0 0;
-    padding: 1 1;
-    border: solid $panel-lighten-1;
-    border-title-color: $text;
-    width: 30%;
-    height: auto;
-}
-#configs_transfer_options_container:light {
-    border: solid $panel-darken-3;
-}
 #configs_local_path_input {
     width: 70%;
 }

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -379,3 +379,40 @@ MessageBox:light > #confirm_top_container {
     border: tall $accent;
     background: $boost;
  }
+
+/* Rename File or Folders Screen ------------------------------------------------------------ */
+
+RenameFileOrFolderScreen {
+    align: center middle;
+    content-align: center middle;
+}
+
+#rename_screen_container {
+    align: center middle;
+    content-align: center middle;
+    height: 12;
+    width: 65;
+    border: tall $panel-lighten-1;
+    background: $primary-background;
+ }
+ RenameFileOrFolderScreen:light > #rename_screen_container {
+    border: tall $panel-darken-3;
+    background: $boost;
+ }
+#rename_screen_label {
+    align: center middle;
+    margin: 0 0 1 2;
+    text-align: center;
+ }
+#rename_screen_input {
+    align: center middle;
+ }
+#rename_screen_horizontal {
+    align: center middle;
+}
+#rename_screen_okay_button {
+    align: center middle;
+ }
+#rename_screen_cancel_button {
+    align: center middle;
+ }

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -49,9 +49,6 @@
 #generic_screen_container:light {
     border: thick $panel-darken-3;
 }
-#generic_screen_close_button {
-    dock: bottom;
-}
 #settings_color_scheme_radioset {  /* TODO: duplicate with other css */
     layout: horizontal;
     width: auto;

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -163,16 +163,18 @@ MessageBox:light > #messagebox_top_container {
 
 #configs_save_configs_button {
     align-horizontal: left;
-    margin: 2 5 0 0;
+    margin: 2 1 0 0;
     padding: 0 4 0 4;
-    width: 20%;
+    width: 26;
     color: $success;  /* unsure about this */
 }
 
 #configs_setup_ssh_connection_button {
-    margin: 2 0 0 0;
+    margin: 2 1 0 0;
 }
-
+#configs_go_to_project_screen_button {
+    margin: 2 1 0 0;
+}
 #configs_container > DatatypeCheckboxes {
     layout: grid;
     grid-size: 2 2;

--- a/datashuttle/tui/css/tui_style.tcss
+++ b/datashuttle/tui/css/tui_style.tcss
@@ -79,6 +79,9 @@ want to dock left */
 #transfer_directorytree {
     dock: left;
 }
+#transfer_legend:light {
+    background: $boost;
+}
 
 /* SelectDirectoryTreeScreen -------------------------------------------------------- */
 

--- a/datashuttle/tui/css/tui_style.tcss
+++ b/datashuttle/tui/css/tui_style.tcss
@@ -76,6 +76,9 @@ want to dock left */
 #create_folders_directorytree {
     dock: left;
 }
+#create_folders_directorytree .tree-tooltip {
+    width: 45;
+}
 #transfer_directorytree {
     dock: left;
 }

--- a/datashuttle/tui/css/tui_style.tcss
+++ b/datashuttle/tui/css/tui_style.tcss
@@ -88,9 +88,22 @@ want to dock left */
 SelectDirectoryTreeScreen {
     align: center middle;
 }
+#select_directory_tree_container {
+    width: 90%;
+    height: 90%;
+    overflow: hidden auto;
+    content-align: center middle;
+}
 #select_directory_tree_directory_tree {
-    height: 80%;
-    width: 80%
+    height: 75%;
+    width: 100%;
+    align: center middle;
+    margin: 0 1 0 1;
+}
+
+#select_directory_tree_screen_label {
+    text-align: center;
+    padding: 0 0 0 1;
 }
 
 /* Checkboxes ----------------------------------------------------------------------- */

--- a/datashuttle/tui/css/tui_tab.tcss
+++ b/datashuttle/tui/css/tui_tab.tcss
@@ -62,7 +62,7 @@ TabScreen > TabbedContent {
 }
 
 #transfer_radioset > RadioButton {
-    margin: -1 3 -1 0;
+    margin: 0 3 0 0;
 }
 
 #transfer_params_container {

--- a/datashuttle/tui/css/tui_tab.tcss
+++ b/datashuttle/tui/css/tui_tab.tcss
@@ -62,14 +62,14 @@ TabScreen > TabbedContent {
 }
 
 #transfer_radioset > RadioButton {
-    margin: 0 3 0 0;
+    margin: -1 3 -1 0;
 }
 
 #transfer_params_container {
     border: solid $panel-lighten-1;
-    margin: 0 1 2 1;
-    padding: 0 0 0 2;
-    height: 60%;
+    margin: 0 0 0 0;
+    padding: 0 0 0 1;
+    height: 50%;
     overflow: hidden auto;
     align: left top;
 }
@@ -97,7 +97,7 @@ TabScreen > TabbedContent {
     width: auto;
     height: auto;
     align-vertical: middle;
-    margin: 0 0 0 2;
+    margin: 1 0 0 2;
 }
 
 #transfer_switch_container > Label{
@@ -135,7 +135,17 @@ Tooltip:light {
 }
 
 #transfer_transfer_button {
-    margin: 0 0 0 4;
+    width: 25;
+}
+#configs_overwrite_files_checkbox {
+    margin: 1 0 1 10;
+}
+#transfer_tab_transfer_settings_container{
+    height: auto;
+}
+#test4 {
+    height: auto;
+    padding: 0 0 10 0;
 }
 
 /* Logging Tab ------------------------------------------------------------- */

--- a/datashuttle/tui/custom_widgets.py
+++ b/datashuttle/tui/custom_widgets.py
@@ -232,7 +232,7 @@ class CustomDirectoryTree(DirectoryTree):
                 self.DirectoryTreeSpecialKeyPress(event.key, node_path=None)
             )
 
-        elif event.key in ["ctrl+a", "ctrl+f"]:
+        elif event.key in ["ctrl+a", "ctrl+f", "ctrl+n"]:
             path_ = self.get_node_at_line(self.hover_line).data.path
             self.post_message(
                 self.DirectoryTreeSpecialKeyPress(event.key, node_path=path_)

--- a/datashuttle/tui/custom_widgets.py
+++ b/datashuttle/tui/custom_widgets.py
@@ -202,16 +202,10 @@ class CustomDirectoryTree(DirectoryTree):
 
     def filter_paths(self, paths: Iterable[Path]) -> Iterable[Path]:
         """
-        Filter out the top level .datashuttle folder than contains logs from
-        the directorytree display.
-
-        `paths` below are only the folders within the root folder. So this will
-        filter out .datashuttle only at the root and not all instances of
-        .datashuttle lower down the tree.
+        Filter out all hidden folders and files from DirectoryTree
+        display.
         """
-        return [
-            path for path in paths if not path.name.startswith(".datashuttle")
-        ]
+        return [path for path in paths if not path.name.startswith(".")]
 
     def on_key(self, event: events.Key) -> None:
         """

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -49,7 +49,7 @@ class Interface:
             Must already exist.
         """
         try:
-            project = DataShuttle(project_name)
+            project = DataShuttle(project_name, print_startup_message=False)
             self.project = project
             return True, None
 

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -374,15 +374,24 @@ class Interface:
         cfg_to_load.convert_str_and_pathlib_paths(cfg_to_load, "path_to_str")
         return cfg_to_load
 
-    def get_next_sub_number(self) -> str:
-        return self.project.get_next_sub_number(
-            return_with_prefix=True, local_only=True
-        )
+    def get_next_sub_number(self) -> Output:
+        try:
+            next_sub = self.project.get_next_sub_number(
+                return_with_prefix=True, local_only=True
+            )
+            return True, next_sub
+        except BaseException as e:
+            return False, str(e)
 
-    def get_next_ses_number(self, sub: str) -> str:
-        return self.project.get_next_ses_number(
-            sub, return_with_prefix=True, local_only=True
-        )
+    def get_next_ses_number(self, sub: str) -> Output:
+
+        try:
+            next_ses = self.project.get_next_ses_number(
+                sub, return_with_prefix=True, local_only=True
+            )
+            return True, next_ses
+        except BaseException as e:
+            return False, str(e)
 
     def get_ssh_hostkey(self) -> Output:
         try:

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -395,7 +395,7 @@ class Interface:
 
     def update_overwrite_existing_files(self, value: bool) -> Output:
         try:
-            self.project.update_config_file(overwrite_old_files=value)
+            self.project.update_config_file(overwrite_existing_files=value)
             return True, None
         except BaseException as e:
             return False, str(e)

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -393,6 +393,13 @@ class Interface:
         except BaseException as e:
             return False, str(e)
 
+    def update_overwrite_existing_files(self, value: bool) -> Output:
+        try:
+            self.project.update_config_file(overwrite_old_files=value)
+            return True, None
+        except BaseException as e:
+            return False, str(e)
+
     def get_ssh_hostkey(self) -> Output:
         try:
             key = ssh.get_remote_server_key(

--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -24,6 +24,7 @@ from textual.widgets import (
 
 from datashuttle.configs import links
 from datashuttle.tui.custom_widgets import TopLevelFolderSelect
+from datashuttle.tui.tooltips import get_tooltip
 
 
 class CreateFoldersSettingsScreen(ModalScreen):
@@ -140,6 +141,13 @@ class CreateFoldersSettingsScreen(ModalScreen):
         )
 
     def on_mount(self) -> None:
+        for id in [
+            "#create_folders_settings_toplevel_select",
+            "#create_folders_settings_bypass_validation_checkbox",
+            "#template_settings_validation_on_checkbox",
+        ]:
+            self.query_one(id).tooltip = get_tooltip(id)
+
         self.init_input_values_holding_variable()
         self.fill_input_from_template()
         self.switch_template_container_disabled()

--- a/datashuttle/tui/screens/get_help.py
+++ b/datashuttle/tui/screens/get_help.py
@@ -49,10 +49,10 @@ class GetHelpScreen(ModalScreen):
 
         yield Container(
             Static(self.text, id="get_help_label"),
-            Button("Close", id="generic_screen_close_button"),
+            Button("Main Menu", id="all_main_menu_buttons"),
             id="generic_screen_container",
         )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "generic_screen_close_button":
+        if event.button.id == "all_main_menu_buttons":
             self.dismiss()

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from textual.containers import Container, Horizontal
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static
+from textual.widgets import Button, Input, Label, Static
 
 from datashuttle.tui.custom_widgets import CustomDirectoryTree
 from datashuttle.tui.utils.tui_decorators import require_double_click
@@ -150,4 +150,34 @@ class SelectDirectoryTreeScreen(ModalScreen):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel_button":
+            self.dismiss(False)
+
+
+class RenameFileOrFolderScreen(ModalScreen):
+    """ """
+
+    def __init__(self, mainwindow: App, path_: Path) -> None:
+        super(RenameFileOrFolderScreen, self).__init__()
+
+        self.mainwindow = mainwindow
+        self.path_ = path_
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Label("Input the new name:", id="rename_screen_label"),
+            Input(value=self.path_.stem, id="rename_screen_input"),
+            Horizontal(
+                Button("Ok", id="rename_screen_okay_button"),
+                Button("Cancel", id="rename_screen_cancel_button"),
+                id="rename_screen_horizontal",
+            ),
+            id="rename_screen_container",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """"""
+        if event.button.id == "rename_screen_okay_button":
+            self.dismiss(self.query_one("#rename_screen_input").value)
+
+        elif event.button.id == "rename_screen_cancel_button":
             self.dismiss(False)

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -130,8 +130,14 @@ class SelectDirectoryTreeScreen(ModalScreen):
         self.prev_click_time = 0
 
     def compose(self) -> ComposeResult:
+
+        label_message = (
+            "Select (double click) a folder with the same name as the project.\n"
+            "If the project folder does not exist, select the parent folder and it will be created."
+        )
+
         yield Container(
-            Label("Double click a folder to select:", id="test_label"),
+            Static(label_message, id="select_directory_tree_screen_label"),
             CustomDirectoryTree(
                 self.mainwindow,
                 self.path_,

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -38,8 +38,8 @@ class ProjectManagerScreen(Screen):
     See ConfigsContent for more information.
     """
 
-    def __init__(self, mainwindow: App, interface: Interface) -> None:
-        super(ProjectManagerScreen, self).__init__()
+    def __init__(self, mainwindow: App, interface: Interface, id) -> None:
+        super(ProjectManagerScreen, self).__init__(id=id)
 
         self.mainwindow = mainwindow
         self.interface = interface
@@ -109,6 +109,10 @@ class ProjectManagerScreen(Screen):
                 self.query_one(
                     "#tabscreen_logging_tab"
                 ).update_most_recent_label()
+
+    def update_active_tab_tree(self):
+        active_tab_id = self.query_one("#tabscreen_tabbed_content").active
+        self.query_one(f"#{active_tab_id}").reload_directorytree()
 
     def on_configs_content_configs_saved(self) -> None:
         """

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -110,11 +110,6 @@ class ProjectManagerScreen(Screen):
                     "#tabscreen_logging_tab"
                 ).update_most_recent_label()
 
-            if event.pane.id == "tabscreen_transfer_tab":
-                self.query_one(
-                    "#tabscreen_transfer_tab"
-                ).update_legend_display()
-
     def update_active_tab_tree(self):
         active_tab_id = self.query_one("#tabscreen_tabbed_content").active
         self.query_one(f"#{active_tab_id}").reload_directorytree()

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -110,6 +110,11 @@ class ProjectManagerScreen(Screen):
                     "#tabscreen_logging_tab"
                 ).update_most_recent_label()
 
+            if event.pane.id == "tabscreen_transfer_tab":
+                self.query_one(
+                    "#tabscreen_transfer_tab"
+                ).update_legend_display()
+
     def update_active_tab_tree(self):
         active_tab_id = self.query_one("#tabscreen_tabbed_content").active
         self.query_one(f"#{active_tab_id}").reload_directorytree()

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -16,6 +16,8 @@ from textual.widgets import (
     RadioSet,
 )
 
+from datashuttle.tui.tooltips import get_tooltip
+
 
 class SettingsScreen(ModalScreen):
     """
@@ -55,6 +57,11 @@ class SettingsScreen(ModalScreen):
             Button("Main Menu", id="all_main_menu_buttons"),
             id="generic_screen_container",
         )
+
+    def on_mount(self) -> None:
+        """"""
+        id = "#show_transfer_tree_status_checkbox"
+        self.query_one(id).tooltip = get_tooltip(id)
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         label = str(event.pressed.label)

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -11,6 +11,7 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import (
     Button,
+    Checkbox,
     RadioButton,
     RadioSet,
 )
@@ -46,6 +47,11 @@ class SettingsScreen(ModalScreen):
                 ),
                 id="settings_color_scheme_radioset",
             ),
+            Checkbox(
+                "Show transfer status on directory tree",
+                value=self.global_settings["show_transfer_tree_status"],
+                id="show_transfer_tree_status_checkbox",
+            ),
             Button("Close", id="generic_screen_close_button"),
             id="generic_screen_container",
         )
@@ -57,6 +63,10 @@ class SettingsScreen(ModalScreen):
 
         self.mainwindow.dark = dark_mode
         self.global_settings["dark_mode"] = dark_mode
+        self.mainwindow.save_global_settings(self.global_settings)
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        self.global_settings["show_transfer_tree_status"] = event.value
         self.mainwindow.save_global_settings(self.global_settings)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -52,7 +52,7 @@ class SettingsScreen(ModalScreen):
                 value=self.global_settings["show_transfer_tree_status"],
                 id="show_transfer_tree_status_checkbox",
             ),
-            Button("Close", id="generic_screen_close_button"),
+            Button("Main Menu", id="all_main_menu_buttons"),
             id="generic_screen_container",
         )
 
@@ -70,5 +70,5 @@ class SettingsScreen(ModalScreen):
         self.mainwindow.save_global_settings(self.global_settings)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "generic_screen_close_button":
+        if event.button.id == "all_main_menu_buttons":
             self.dismiss()

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -11,7 +11,6 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import (
     Button,
-    Checkbox,
     RadioButton,
     RadioSet,
 )
@@ -47,11 +46,6 @@ class SettingsScreen(ModalScreen):
                 ),
                 id="settings_color_scheme_radioset",
             ),
-            Checkbox(
-                "Show transfer status on directory tree",
-                value=self.global_settings["show_transfer_tree_status"],
-                id="show_transfer_tree_status_checkbox",
-            ),
             Button("Close", id="generic_screen_close_button"),
             id="generic_screen_container",
         )
@@ -63,10 +57,6 @@ class SettingsScreen(ModalScreen):
 
         self.mainwindow.dark = dark_mode
         self.global_settings["dark_mode"] = dark_mode
-        self.mainwindow.save_global_settings(self.global_settings)
-
-    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
-        self.global_settings["show_transfer_tree_status"] = event.value
         self.mainwindow.save_global_settings(self.global_settings)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -25,6 +25,7 @@ from datashuttle.tui.custom_widgets import (
 from datashuttle.tui.screens.create_folder_settings import (
     CreateFoldersSettingsScreen,
 )
+from datashuttle.tui.tooltips import get_tooltip
 from datashuttle.tui.utils.tui_decorators import require_double_click
 from datashuttle.tui.utils.tui_validators import NeuroBlueprintValidator
 
@@ -59,7 +60,7 @@ class CreateFoldersTab(TreeAndInputTab):
             validate_on=["changed", "submitted"],
             validators=[NeuroBlueprintValidator("sub", self)],
         )
-        yield Label("Session(s)", id="tabscreen_session_label")
+        yield Label("Session(s)", id="create_folders_session_label")
         yield ClickableInput(
             self.mainwindow,
             id="create_folders_session_input",
@@ -81,6 +82,23 @@ class CreateFoldersTab(TreeAndInputTab):
             ),
             id="create_folders_buttons_horizontal",
         )
+
+    def on_mount(self) -> None:
+        """"""
+        if not self.interface:
+            self.query_one("#configs_name_input").tooltip = get_tooltip(
+                "#configs_name_input"
+            )
+
+        for id in [
+            "#create_folders_directorytree",
+            "#create_folders_subject_label",
+            "#create_folders_session_label",
+            "#create_folders_subject_input",
+            "#create_folders_session_input",
+            "#create_folders_datatype_label",
+        ]:
+            self.query_one(id).tooltip = get_tooltip(id)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -140,6 +140,9 @@ class CreateFoldersTab(TreeAndInputTab):
                 event,
             )
 
+        elif event.key == "ctrl+n":
+            self.mainwindow.prompt_rename_file_or_folder(event.node_path)
+
     def fill_input_with_template(self, prefix: Prefix, input_id: str) -> None:
         """
         Given the `name_template`, fill the sub or ses

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -251,7 +251,12 @@ class CreateFoldersTab(TreeAndInputTab):
             The textual input name to update.
         """
         if prefix == "sub":
-            next_val = self.interface.get_next_sub_number()
+            success, output = self.interface.get_next_sub_number()
+            if not success:
+                self.mainwindow.show_modal_error_dialog(output)
+                return
+            else:
+                next_val = output
         else:
             sub_names = self.query_one(
                 "#create_folders_subject_input"
@@ -274,7 +279,12 @@ class CreateFoldersTab(TreeAndInputTab):
             else:
                 sub = sub_names[0]
 
-            next_val = self.interface.get_next_ses_number(sub)
+            success, output = self.interface.get_next_ses_number(sub)
+            if not success:
+                self.mainwindow.show_modal_error_dialog(output)
+                return
+            else:
+                next_val = output
 
         if self.templates_on(prefix):
             split_name = self.interface.get_name_templates()[prefix].split("_")

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -243,6 +243,12 @@ class CreateFoldersTab(TreeAndInputTab):
             self.mainwindow.show_modal_error_dialog(output)
 
     def reload_directorytree(self) -> None:
+        """
+        This reloads the directorytree and also updates validation.
+        Not now a good method name but done for consistency with other
+        tab refresh methods.
+        """
+        self.revalidate_inputs(["sub", "ses"])
         self.query_one("#create_folders_directorytree").reload()
 
     # Filling Inputs

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -15,6 +15,7 @@ from rich.text import Text
 from textual.containers import Container, Horizontal
 from textual.widgets import (
     Button,
+    Checkbox,
     Label,
     RadioButton,
     RadioSet,
@@ -135,16 +136,16 @@ class TransferTab(TreeAndInputTab):
             ),
         ]
 
+        yield TransferStatusTree(
+            self.mainwindow,
+            self.interface,
+            id="transfer_directorytree",
+        )
         yield RadioSet(
             RadioButton("All", id="transfer_all_radiobutton", value=True),
             RadioButton("Top Level", id="transfer_toplevel_radiobutton"),
             RadioButton("Custom", id="transfer_custom_radiobutton"),
             id="transfer_radioset",
-        )
-        yield TransferStatusTree(
-            self.mainwindow,
-            self.interface,
-            id="transfer_directorytree",
         )
         yield Container(
             *self.transfer_all_widgets,
@@ -159,16 +160,21 @@ class TransferTab(TreeAndInputTab):
                 Label("Download", id="transfer_switch_download_label"),
                 id="transfer_switch_container",
             ),
-            Button("Transfer", id="transfer_transfer_button"),
-            Horizontal(),  # push button to left
+            Checkbox(
+                "Overwrite Old Files",
+                value=self.interface.project.cfg["overwrite_old_files"],
+                id="configs_overwrite_files_checkbox",
+            ),
+            id="transfer_tab_transfer_settings_container",
         )
+        yield Horizontal(
+            Button("Transfer", id="transfer_transfer_button"), id="test4"
+        )
+        yield Horizontal()
         if self.show_legend:
             yield Label("⭕ Legend", id="transfer_legend")
 
     def on_mount(self) -> None:
-        self.query_one("#transfer_params_container").border_title = (
-            "Parameters"
-        )
         self.switch_transfer_widgets_display()
 
         if self.show_legend:
@@ -236,6 +242,16 @@ class TransferTab(TreeAndInputTab):
             self.mainwindow.push_screen(
                 FinishTransferScreen(message), self.transfer_data
             )
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        """"""
+        if event.checkbox.id == "configs_overwrite_files_checkbox":
+
+            success, message = self.interface.update_overwrite_existing_files(
+                event.checkbox.value
+            )
+            if not success:
+                self.mainwindow.show_modal_error_dialog(message)
 
     def on_custom_directory_tree_directory_tree_special_key_press(
         self, event: CustomDirectoryTree.DirectoryTreeSpecialKeyPress

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -33,6 +33,7 @@ from datashuttle.tui.screens.modal_dialogs import (
     MessageBox,
 )
 from datashuttle.tui.tabs.transfer_status_tree import TransferStatusTree
+from datashuttle.tui.tooltips import get_tooltip
 
 
 class TransferTab(TreeAndInputTab):
@@ -175,6 +176,19 @@ class TransferTab(TreeAndInputTab):
             yield Label("⭕ Legend", id="transfer_legend")
 
     def on_mount(self) -> None:
+
+        for id in [
+            "#transfer_directorytree",
+            "#transfer_switch_container",
+            "#configs_overwrite_files_checkbox",
+            "#transfer_subject_input",
+            "#transfer_session_input",
+            "#transfer_all_checkbox",
+            "#transfer_all_datatype_checkbox",
+            "#transfer_all_non_datatype_checkbox",
+        ]:
+            self.query_one(id).tooltip = get_tooltip(id)
+
         self.switch_transfer_widgets_display()
 
         if self.show_legend:

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -248,6 +248,10 @@ class TransferTab(TreeAndInputTab):
                 "#transfer_subject_input", "#transfer_session_input", event
             )
 
+        elif event.key == "ctrl+n":
+            self.mainwindow.prompt_rename_file_or_folder(event.node_path)
+            self.reload_directorytree()
+
     def reload_directorytree(self) -> None:
         self.query_one("#transfer_directorytree").update_transfer_tree()
 

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -161,8 +161,8 @@ class TransferTab(TreeAndInputTab):
                 id="transfer_switch_container",
             ),
             Checkbox(
-                "Overwrite Old Files",
-                value=self.interface.project.cfg["overwrite_old_files"],
+                "Overwrite Existing Files",
+                value=self.interface.project.cfg["overwrite_existing_files"],
                 id="configs_overwrite_files_checkbox",
             ),
             id="transfer_tab_transfer_settings_container",

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -58,7 +58,14 @@ class TransferTab(TreeAndInputTab):
     ----------
 
     show_legend : bool
-        When `False`, the legend for showing transfer status is hidden.
+        Convenience attribute linked to a global setting exists that
+        turns off / on styling of directorytree nodes based on transfer status. `
+
+        `self.mainwindow.load_global_settings()[
+            "show_transfer_tree_status"
+        ]`
+
+        When on, the legend must be hidden.
     """
 
     def __init__(
@@ -72,6 +79,9 @@ class TransferTab(TreeAndInputTab):
         self.mainwindow = mainwindow
         self.interface = interface
         self.prev_click_time = 0.0
+        self.show_legend = self.mainwindow.load_global_settings()[
+            "show_transfer_tree_status"
+        ]
 
     # Setup
     # ----------------------------------------------------------------------------------
@@ -152,7 +162,8 @@ class TransferTab(TreeAndInputTab):
             Button("Transfer", id="transfer_transfer_button"),
             Horizontal(),  # push button to left
         )
-        yield Label("⭕ Legend", id="transfer_legend")
+        if self.show_legend:
+            yield Label("⭕ Legend", id="transfer_legend")
 
     def on_mount(self) -> None:
         self.query_one("#transfer_params_container").border_title = (
@@ -160,21 +171,14 @@ class TransferTab(TreeAndInputTab):
         )
         self.switch_transfer_widgets_display()
 
-        self.query_one("#transfer_legend").tooltip = Text.assemble(
-            "Unchanged\n",
-            ("Changed\n", "gold3"),
-            ("Local Only\n", "green3"),
-            # ("Central Only\n", "italic dodger_blue3"),
-            ("Error\n", "bright_red"),
-        )
-        self.update_legend_display()
-
-    def update_legend_display(self):
-        display = (
-            self.interface.project.cfg["connection_method"]
-            == "local_filesystem"
-        )
-        self.query_one("#transfer_legend").visible = display
+        if self.show_legend:
+            self.query_one("#transfer_legend").tooltip = Text.assemble(
+                "Unchanged\n",
+                ("Changed\n", "gold3"),
+                ("Local Only\n", "green3"),
+                # ("Central Only\n", "italic dodger_blue3"),
+                ("Error\n", "bright_red"),
+            )
 
     # Manage Widgets
     # ----------------------------------------------------------------------------------

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -58,14 +58,7 @@ class TransferTab(TreeAndInputTab):
     ----------
 
     show_legend : bool
-        Convenience attribute linked to a global setting exists that
-        turns off / on styling of directorytree nodes based on transfer status. `
-
-        `self.mainwindow.load_global_settings()[
-            "show_transfer_tree_status"
-        ]`
-
-        When on, the legend must be hidden.
+        When `False`, the legend for showing transfer status is hidden.
     """
 
     def __init__(
@@ -79,9 +72,6 @@ class TransferTab(TreeAndInputTab):
         self.mainwindow = mainwindow
         self.interface = interface
         self.prev_click_time = 0.0
-        self.show_legend = self.mainwindow.load_global_settings()[
-            "show_transfer_tree_status"
-        ]
 
     # Setup
     # ----------------------------------------------------------------------------------
@@ -162,8 +152,7 @@ class TransferTab(TreeAndInputTab):
             Button("Transfer", id="transfer_transfer_button"),
             Horizontal(),  # push button to left
         )
-        if self.show_legend:
-            yield Label("⭕ Legend", id="transfer_legend")
+        yield Label("⭕ Legend", id="transfer_legend")
 
     def on_mount(self) -> None:
         self.query_one("#transfer_params_container").border_title = (
@@ -171,14 +160,21 @@ class TransferTab(TreeAndInputTab):
         )
         self.switch_transfer_widgets_display()
 
-        if self.show_legend:
-            self.query_one("#transfer_legend").tooltip = Text.assemble(
-                "Unchanged\n",
-                ("Changed\n", "gold3"),
-                ("Local Only\n", "green3"),
-                # ("Central Only\n", "italic dodger_blue3"),
-                ("Error\n", "bright_red"),
-            )
+        self.query_one("#transfer_legend").tooltip = Text.assemble(
+            "Unchanged\n",
+            ("Changed\n", "gold3"),
+            ("Local Only\n", "green3"),
+            # ("Central Only\n", "italic dodger_blue3"),
+            ("Error\n", "bright_red"),
+        )
+        self.update_legend_display()
+
+    def update_legend_display(self):
+        display = (
+            self.interface.project.cfg["connection_method"]
+            == "local_filesystem"
+        )
+        self.query_one("#transfer_legend").visible = display
 
     # Manage Widgets
     # ----------------------------------------------------------------------------------

--- a/datashuttle/tui/tabs/transfer_status_tree.py
+++ b/datashuttle/tui/tabs/transfer_status_tree.py
@@ -65,8 +65,13 @@ class TransferStatusTree(CustomDirectoryTree):
 
         self.update_local_transfer_paths()
 
-        if self.mainwindow.load_global_settings()["show_transfer_tree_status"]:
+        if (
+            self.interface.project.cfg["connection_method"]
+            == "local_filesystem"
+        ):
             self.update_transfer_diffs()
+        else:
+            self.transfer_diffs = {}
 
         if not init:
             self.reload()

--- a/datashuttle/tui/tabs/transfer_status_tree.py
+++ b/datashuttle/tui/tabs/transfer_status_tree.py
@@ -65,13 +65,8 @@ class TransferStatusTree(CustomDirectoryTree):
 
         self.update_local_transfer_paths()
 
-        if (
-            self.interface.project.cfg["connection_method"]
-            == "local_filesystem"
-        ):
+        if self.mainwindow.load_global_settings()["show_transfer_tree_status"]:
             self.update_transfer_diffs()
-        else:
-            self.transfer_diffs = {}
 
         if not init:
             self.reload()

--- a/datashuttle/tui/tooltips.py
+++ b/datashuttle/tui/tooltips.py
@@ -1,0 +1,200 @@
+# TODO: add a bit more text to 'get help' page + a keyboard shortcuts pop-up.
+
+
+def get_tooltip(id: str) -> str:
+    """
+    Master function to get tooltips for all widgets,
+    based on their widget (textual) id.
+    """
+    # Configs
+    # -------------------------------------------------------------------------
+
+    # project_name input
+    if id == "#configs_name_input":
+        tooltip = "The name of the project. Cannot contain special characters (e.g. !@?) or spaces."
+
+    # local path input
+    elif id == "#configs_local_path_input":
+        tooltip = (
+            "Path to the project folder on the local machine, where acquired data will be saved.\n\n"
+            "The project folder name must be the same as the project name. Input a path directly to "
+            "the project folder, or it's parent folder (and it will be created automatically)."
+        )
+
+    # connection method label
+    elif id == "#configs_connect_method_label":
+        tooltip = "Method to connect to the central data storage machine."
+
+    # local filesystem radiobutton
+    elif id == "#configs_local_filesystem_radiobutton":
+        tooltip = (
+            "Use local filesystem when the central data storage "
+            "is a mounted drive on your current machine."
+        )
+
+    # SSH radiobutton
+    elif id == "#configs_ssh_radiobutton":
+        tooltip = "Use SSH when planning to connect with the central data storage via SSH protocol."
+
+    # central host input
+    elif id == "#configs_central_host_id_input":
+        tooltip = "The hostname or IP address of the server."
+
+    # central host username input
+    elif id == "#configs_central_host_username_input":
+        tooltip = "The account username through which to access the server."
+
+    # central path input
+    elif id == "config_central_path_input_mode-ssh":
+        tooltip = (
+            "The path to the project folder on the central machine (or it's parent folder).\n\n"
+            "With 'SSH', this path is relative to the server e.g. /nhome/users/myusername"
+        )
+
+    elif id == "config_central_path_input_mode-local_filesystem":
+        tooltip = (
+            "The path to the project folder on the central machine (or it's parent folder).\n\n"
+            "With 'local filesystem', this path is relative to the current machine and directs "
+            "to a project folder, possibly on a mounted drive.\n\n"
+        )
+
+    # Settings
+    # -------------------------------------------------------------------------
+
+    # Show transfer status on directory tree checkbox
+    elif id == "#show_transfer_tree_status_checkbox":
+        tooltip = (
+            "Display the status of files on the project manager page's "
+            "`Transfer` directory tree (e.g. file colour indicates changes "
+            "between central and local projects).\n\n"
+            "Note that this may cause performance issues, in particular when "
+            "using an SSH connection."
+        )
+
+    # Tabscreen - Create tab
+    # -------------------------------------------------------------------------
+
+    # directorytree
+    elif id == "#create_folders_directorytree":
+        tooltip = (
+            "The local project folder. Provides a number of convenient shortcuts "
+            "when hovering the mouse over a folder:\n\n"
+            "-CTRL+O : open the folder in the system filebrowser.\n"
+            "-CTRL+N : rename a file or folder.\n"
+            "-CTRL+Q : copy the full filepath to clipboard.\n"
+            "-CTRL+R : refresh the folder tree.\n"
+            "-CTRL+F : fill the 'sub-' or 'ses-' input with the foldername.\n"
+            "-CTRL+A : similar to CTRL+F, but append."
+        )
+
+    # subect / session label (explain input)
+    elif id == "#create_folders_subject_input":
+        tooltip = "Input subject here. Will show live validation."
+
+    # subect / session label (explain input)
+    elif id == "#create_folders_session_input":
+        tooltip = "Input session here. Will show live validation."
+
+    # initial tooltip on the subject / session inputs
+    elif id == "#create_folders_subject_label":
+        tooltip = (
+            "The subject to create. Double-click the input to suggest the next subject.\n\n"
+            "Hold CTRL when clicking to suggest onlu the prefix (with template, if on in 'Settings')."
+        )
+
+    # initial tooltip on the subject / session inputs
+    elif id == "#create_folders_session_label":
+        tooltip = (
+            "The session to create. Auto-fill with the same shortcuts as subject input.\n\n"
+            "The suggested session will be for the subject input above."
+        )
+
+    # datatype label
+    elif id == "#create_folders_datatype_label":
+        tooltip = "The datatypes to create in the session folder."
+
+    # Tabscreen - Settings page
+    # -------------------------------------------------------------------------
+
+    # top level folder select
+    elif id == "#create_folders_settings_toplevel_select":
+        tooltip = "The top-level-folder to create folders in."
+
+    # bypass validation checkbox
+    elif id == "#create_folders_settings_bypass_validation_checkbox":
+        tooltip = (
+            "Allow folder creation even when there is a validation error."
+        )
+
+    # template validation checkbox
+    elif id == "#template_settings_validation_on_checkbox":
+        tooltip = "Turn on the 'name templates' feature."
+
+    # Tabscreen - Tranfser tab
+    # -------------------------------------------------------------------------
+
+    # directorytree
+    elif id == "#transfer_directorytree":
+        tooltip = (
+            "Shows the local project tree. Transfer status highlighting "
+            "can be turned on at the Main Menu 'Settings' page.\n\n"
+            "Keyboard shortcuts, when hovering the mouse over a folder:\n\n"
+            "-CTRL+O : open the folder in the system filebrowser.\n"
+            "-CTRL+N : rename a file or folder.\n"
+            "-CTRL+Q : copy the full filepath to clipboard.\n"
+            "-CTRL+R : refresh the folder tree.\n"
+            "-CTRL+F : fill the 'sub-' or 'ses-' input with the foldername.\n"
+            "-CTRL+A : similar to CTRL+F, but append."
+        )
+
+    # Upload / Download
+    elif id == "#transfer_switch_container":
+        tooltip = (
+            "Upload (local to central) or \n" "Download (central to local)."
+        )
+
+    # Overwrite Existing Files
+    elif id == "#configs_overwrite_files_checkbox":
+        tooltip = (
+            "If on, more recent file versions will overwrite existing, "
+            "older versions of the file.\n\n"
+            "If off, a file on the target local (e.g. central during upload) "
+            "will never be overwritten by a file on the source location "
+            "(e.g. local during upload), even if the file is newer."
+        )
+
+    # custom subject input
+    elif id == "#transfer_subject_input":
+        tooltip = (
+            "Name of names of subjects to transfer. If multiple subjects"
+            "are input, separate with a comma e.g. sub-001, sub-002.\n\n"
+            "The range tag @TO@ can be use to transfer a range of subjects e.g. sub-001@TO@sub-005\n\n"
+            "Wildcard tag @*@ can be use to match any part of a filename e.g. sub-001_date-@*@.\n\n"
+            "Use 'all' to transfer all subject and non-subect folders in the top-level-folder.\n\n"
+            "Use 'all_sub' to transfer all subject folders only (i.e. starting with 'sub-' prefix).\n\n"
+            "Use 'all_non_sub' to transfer all other folders only (i.e. that do not start with the 'sub-' prefix)."
+        )
+
+    # custom session input
+    elif id == "#transfer_session_input":
+        tooltip = (
+            "Name of names of sessions to transfer. If multiple sessions"
+            "are input, separate with a comma e.g. ses-001, ses-002.\n\n"
+            "The range tag @TO@ can be use to transfer a range of subjects e.g. ses-001@TO@ses-005\n\n"
+            "Wildcard tag @*@ can be use to match any part of a filename e.g. ses-001_date-@*@.\n\n"
+            "Use 'all' to transfer all session and non-session folders within subjects.\n\n"
+            "Use 'all_ses' to transfer all session folders only (i.e. starting with 'ses-' prefix).\n\n"
+            "Use 'all_non_ses' to transfer all other folders only (i.e. that do not start with the 'ses-' prefix)."
+        )
+
+    # 'all', 'all datatype', 'all non datatype'
+    elif id == "#transfer_all_checkbox":
+        tooltip = "Select to transfer all datatype and non-datatype folders within sessions."
+
+    elif id == "#transfer_all_datatype_checkbox":
+        tooltip = "Select to transfer all datatype folders, but not non-datatype folders, from within sessions."
+
+    elif id == "#transfer_all_non_datatype_checkbox":
+        tooltip = "Select to transfer only non-datatype folders from within sessions."
+
+    return tooltip

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -311,7 +311,7 @@ def handle_rclone_arguments(
 
     extra_arguments_list += ["-" + rclone_options["transfer_verbosity"]]
 
-    if not rclone_options["overwrite_old_files"]:
+    if not rclone_options["overwrite_existing_files"]:
         extra_arguments_list += [rclone_args("ignore_existing")]
 
     if rclone_options["show_transfer_progress"]:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -170,7 +170,7 @@ def names_include_special_characters(
     """
     bad_names = []
     for name in names_list:
-        if not re.match("^[A-Za-z0-9_-]*$", name):
+        if name_has_special_character(name):
             bad_names.append(name)
 
     if bad_names:
@@ -180,6 +180,10 @@ def names_include_special_characters(
             f"which are not alphanumeric, dash or underscore.",
         )
     return False, ""
+
+
+def name_has_special_character(name: str) -> bool:
+    return not re.match("^[A-Za-z0-9_-]*$", name)
 
 
 def dashes_and_underscore_alternate_incorrectly(

--- a/docs/source/pages/documentation.md
+++ b/docs/source/pages/documentation.md
@@ -251,7 +251,7 @@ more information.
 If connection method is `ssh`, the **central_host_id** and **central_host_username**
 must be set. See the [SSH section](#ssh) for details.
 
-The optional arguments **overwrite_old_files**, **transfer_verbosity** and
+The optional arguments **overwrite_existing_files**, **transfer_verbosity** and
 **show_transfer_progress** determine how data transfer is performed
 (see the [Data Transfer](#data-transfer) section for details).
 
@@ -817,7 +817,7 @@ A number of [Rclone](https://rclone.org/) options are exposed in Datashuttle to 
 
 ### Overwriting existing files
 
-`overwrite_old_files` determines whether folders and files are overwritten
+`overwrite_existing_files` determines whether folders and files are overwritten
 during transfer. By default, Datashuttle does not overwrite any existing
 folder during data transfer.
 
@@ -825,7 +825,7 @@ For example, if the file `sub-001_ses-001_measure-trajectories.csv` exists on
 the *central* repository, it will never be over-written during upload
 from *local* to *central*, even if the version on *local* is newer.
 
-To change this behaviour, the configuration `overwrite_old_files` can be set to `True`.
+To change this behaviour, the configuration `overwrite_existing_files` can be set to `True`.
 In this case, files in which the  timestamp of the target directory (e.g. *central*
 in our example) will be overwritten if their timestamp is
 older than the corresponding file in the source directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pyperclip",
     "textual",
     "show-in-file-manager",
+    "gitpython",
 ]
 
 classifiers = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,7 +229,7 @@ def get_test_config_arguments_dict(
             {
                 "central_host_id": None,
                 "central_host_username": None,
-                "overwrite_old_files": False,
+                "overwrite_existing_files": False,
                 "transfer_verbosity": "v",
                 "show_transfer_progress": False,
             }
@@ -242,7 +242,7 @@ def get_test_config_arguments_dict(
                 "connection_method": "ssh",
                 "central_host_id": "test_central_host_id",
                 "central_host_username": "test_central_host_username",
-                "overwrite_old_files": True,
+                "overwrite_existing_files": True,
                 "transfer_verbosity": "vv",
                 "show_transfer_progress": True,
             }

--- a/tests/tests_integration/test_command_line_interface.py
+++ b/tests/tests_integration/test_command_line_interface.py
@@ -465,17 +465,6 @@ class TestCommandLineInterface(BaseTest):
     # Test Errors Propagate from API
     # -------------------------------------------------------------------------
 
-    def test_warning_on_startup_cli(self, clean_project_name):
-        """
-        Check that warning from API are propagated to CLI
-        """
-        _, stderr = test_utils.run_cli("", clean_project_name)
-
-        assert (
-            "Configuration file has not been initialized. "
-            "Use make_config_file() to setup before continuing." in stderr
-        )
-
     def test_use_ssh_but_pass_no_ssh_options(self, clean_project_name):
         """
         Check that error from API are propagated to CLI

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 import test_utils
@@ -432,28 +431,6 @@ class TestConfigs(BaseTest):
         project.supply_config_file(new_configs_path, warn=False)
 
         test_utils.check_configs(project, new_configs)
-
-    @pytest.mark.parametrize("path_type", ["local_path", "central_path"])
-    def test_config_wrong_project_name(
-        self, no_cfg_project, path_type, tmp_path
-    ):
-        """ """
-        bad_name_configs = test_utils.get_test_config_arguments_dict(
-            tmp_path, no_cfg_project.project_name
-        )
-
-        bad_name = "wrong_project_name"
-        bad_name_configs[path_type] = (
-            Path(bad_name_configs[path_type]) / bad_name
-        )
-
-        with pytest.raises(ConfigError) as e:
-            no_cfg_project.make_config_file(**bad_name_configs)
-
-        assert (
-            f"The {path_type} does not end in the project name: {no_cfg_project.project_name}."
-            in str(e.value)
-        )
 
     def test_existing_projects(self, monkeypatch, tmp_path):
         """

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -371,13 +371,13 @@ class TestFileTransfer(BaseTest):
             make_base_path(project.cfg["central_path"]) / test_file_path
         ).is_file()
 
-    @pytest.mark.parametrize("overwrite_old_files", [True, False])
+    @pytest.mark.parametrize("overwrite_existing_files", [True, False])
     @pytest.mark.parametrize("show_transfer_progress", [True, False])
     @pytest.mark.parametrize("dry_run", [True, False])
     def test_rclone_options(
         self,
         project,
-        overwrite_old_files,
+        overwrite_existing_files,
         show_transfer_progress,
         dry_run,
         capsys,
@@ -392,7 +392,9 @@ class TestFileTransfer(BaseTest):
             project, ["sub-001"], ["ses-002"], ["behav"]
         )
 
-        project.update_config_file(overwrite_old_files=overwrite_old_files)
+        project.update_config_file(
+            overwrite_existing_files=overwrite_existing_files
+        )
         project.update_config_file(transfer_verbosity="vv")
         project.update_config_file(
             show_transfer_progress=show_transfer_progress
@@ -403,7 +405,7 @@ class TestFileTransfer(BaseTest):
 
         log = capsys.readouterr().out
 
-        if overwrite_old_files:
+        if overwrite_existing_files:
             assert "--ignore-existing" not in log
         else:
             assert "--ignore-existing" in log
@@ -440,13 +442,13 @@ class TestFileTransfer(BaseTest):
         else:
             raise BaseException("wrong parameter passed as transfer_verbosity")
 
-    @pytest.mark.parametrize("overwrite_old_files", [True, False])
+    @pytest.mark.parametrize("overwrite_existing_files", [True, False])
     def test_rclone_overwrite_modified_file(
-        self, project, overwrite_old_files
+        self, project, overwrite_existing_files
     ):
         """
         Test how rclone deals with existing files. In datashuttle
-        if project.cfg["overwrite_old_files"] is on,
+        if project.cfg["overwrite_existing_files"] is on,
         files will be replaced with newer versions. Alternatively,
         if this is off, files will never be overwritten even if
         the version in source is newer than target.
@@ -467,8 +469,8 @@ class TestFileTransfer(BaseTest):
 
         time_written = os.path.getatime(local_test_file_path)
 
-        if overwrite_old_files:
-            project.update_config_file(overwrite_old_files=True)
+        if overwrite_existing_files:
+            project.update_config_file(overwrite_existing_files=True)
 
         project.upload_all()
 
@@ -483,7 +485,7 @@ class TestFileTransfer(BaseTest):
 
         central_contents = test_utils.read_file(central_test_file_path)
 
-        if overwrite_old_files:
+        if overwrite_existing_files:
             assert central_contents == ["first edit second edit"]
         else:
             assert central_contents == ["first edit"]

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -255,10 +255,7 @@ class TestLogging:
         )
 
         if use_all_alias:
-            assert (
-                "VariablesState:\nlocals: {'dry_run': False}\ncfg: {'local_path':"
-                in log
-            )
+            assert "VariablesState:\nlocals: {'dry_run': False" in log
         else:
             assert (
                 "VariablesState:\nlocals: {'sub_names': 'all', 'ses_names': 'all', 'datatype': 'all', 'dry_run': False, 'init_log': True}\ncfg: {'local_path': "

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -186,52 +186,10 @@ class TestPersistentSettings(BaseTest):
         settings = project._load_persistent_settings()
         tui_settings = settings["tui"]
 
-        assert tui_settings == {
-            "create_checkboxes_on": {
-                "behav": True,
-                "ephys": True,
-                "funcimg": True,
-                "anat": True,
-            },
-            "transfer_checkboxes_on": {
-                "behav": False,
-                "ephys": False,
-                "funcimg": False,
-                "anat": False,
-                "all": True,
-                "all_datatype": False,
-                "all_non_datatype": False,
-            },
-            "top_level_folder_select": {
-                "create_tab": "rawdata",
-                "toplevel_transfer": "rawdata",
-                "custom_transfer": "rawdata",
-            },
-        }
+        assert tui_settings == self.get_settings_default()
 
         # change all defaults
-        new_tui_settings = {
-            "create_checkboxes_on": {
-                "behav": False,
-                "ephys": False,
-                "funcimg": False,
-                "anat": False,
-            },
-            "transfer_checkboxes_on": {
-                "behav": True,
-                "ephys": True,
-                "funcimg": True,
-                "anat": True,
-                "all": False,
-                "all_datatype": True,
-                "all_non_datatype": True,
-            },
-            "top_level_folder_select": {
-                "create_tab": "derivatives",
-                "toplevel_transfer": "derivatives ",
-                "custom_transfer": "derivatives",
-            },
-        }
+        new_tui_settings = self.get_settings_changed()
 
         project._update_persistent_setting("tui", new_tui_settings)
 
@@ -271,3 +229,51 @@ class TestPersistentSettings(BaseTest):
             "The name: name: sub-@@@, contains characters which are not alphanumeric"
             in str(e)
         )
+
+    def get_settings_default(self):
+        return {
+            "create_checkboxes_on": {
+                "behav": True,
+                "ephys": True,
+                "funcimg": True,
+                "anat": True,
+            },
+            "transfer_checkboxes_on": {
+                "behav": False,
+                "ephys": False,
+                "funcimg": False,
+                "anat": False,
+                "all": True,
+                "all_datatype": False,
+                "all_non_datatype": False,
+            },
+            "top_level_folder_select": {
+                "create_tab": "rawdata",
+                "toplevel_transfer": "rawdata",
+                "custom_transfer": "rawdata",
+            },
+        }
+
+    def get_settings_changed(self):
+        return {
+            "create_checkboxes_on": {
+                "behav": False,
+                "ephys": False,
+                "funcimg": False,
+                "anat": False,
+            },
+            "transfer_checkboxes_on": {
+                "behav": True,
+                "ephys": True,
+                "funcimg": True,
+                "anat": True,
+                "all": False,
+                "all_datatype": True,
+                "all_non_datatype": True,
+            },
+            "top_level_folder_select": {
+                "create_tab": "derivatives",
+                "toplevel_transfer": "derivatives ",
+                "custom_transfer": "derivatives",
+            },
+        }

--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -358,7 +358,7 @@ class TestTuiConfigs(TuiBase):
             )
 
             assert (
-                "The central_path does not end in the project name: a"
+                "The central_path: b that the project folder will reside in does not yet exist"
                 in pilot.app.screen.query_one(
                     "#messagebox_message_label"
                 ).renderable._text[0]

--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -5,7 +5,6 @@ import pytest
 import test_utils
 from tui_base import TuiBase
 
-from datashuttle import DataShuttle
 from datashuttle.tui.app import TuiApp
 from datashuttle.tui.screens.modal_dialogs import (
     SelectDirectoryTreeScreen,
@@ -52,7 +51,6 @@ class TestTuiConfigs(TuiBase):
                     "connection_method": "local_filesystem",
                     "central_host_id": None,
                     "central_host_username": None,
-                    "overwrite_existing_files": False,
                 }
             )
         elif kwargs_set == 2:
@@ -61,7 +59,6 @@ class TestTuiConfigs(TuiBase):
                     "connection_method": "ssh",
                     "central_host_id": "@test.host.id",
                     "central_host_username": "test_username",
-                    "overwrite_existing_files": True,
                 }
             )
 
@@ -112,27 +109,36 @@ class TestTuiConfigs(TuiBase):
                 assert (
                     pilot.app.screen.query_one(
                         "#configs_setup_ssh_connection_button"
-                    ).disabled
-                    is False
+                    ).visible
+                    is True
                 )
-                project = DataShuttle(project_name)
             else:
                 assert (
                     pilot.app.screen.query_one(
                         "#messagebox_message_label"
                     ).renderable._text[0]
                     == "A DataShuttle project has now been created.\n\n "
-                    "Click 'OK' to proceed to the project page, where you "
-                    "will be able to create and transfer project folders."
+                    "Next proceed to the project page, where you will "
+                    "be able to create and transfer project folders."
                 )
                 await self.close_messagebox(pilot)
-                assert isinstance(pilot.app.screen, ProjectManagerScreen)
-                project = pilot.app.screen.interface.project
 
-                assert (
-                    pilot.app.screen.interface.project.project_name
-                    == project_name
-                )
+            assert (
+                pilot.app.screen.query_one(
+                    "#configs_go_to_project_screen_button"
+                ).visible
+                is True
+            )
+            await self.scroll_to_click_pause(
+                pilot, "#configs_go_to_project_screen_button"
+            )
+            assert isinstance(pilot.app.screen, ProjectManagerScreen)
+
+            project = pilot.app.screen.interface.project
+
+            assert (
+                pilot.app.screen.interface.project.project_name == project_name
+            )
 
             # After saving, check all configs are correct on the DataShuttle
             # instance as well as the stored configs.
@@ -206,7 +212,6 @@ class TestTuiConfigs(TuiBase):
                 "connection_method": "ssh",
                 "central_host_id": "random_host",
                 "central_host_username": "random_username",
-                "overwrite_existing_files": True,
             }
 
             for key in new_kwargs.keys():
@@ -328,14 +333,14 @@ class TestTuiConfigs(TuiBase):
 
                 await pilot.pause()
 
-            # Check the central path only is disabled in SSH mode.
-            assert local_path_button.disabled is False
-            assert central_path_button.disabled is False
+            # Check the central path only is not displayed in SSH mode.
+            assert local_path_button.display is True
+            assert central_path_button.display is True
 
             await self.scroll_to_click_pause(pilot, "#configs_ssh_radiobutton")
 
-            assert local_path_button.disabled is False
-            assert central_path_button.disabled is True
+            assert local_path_button.display is True
+            assert central_path_button.display is False
 
             await pilot.pause()
 
@@ -489,7 +494,6 @@ class TestTuiConfigs(TuiBase):
             "local_path": "",
             "central_path": "",
             "connection_method": "local_filesystem",
-            "overwrite_existing_files": False,
         }
         await self.check_configs_widgets_match_configs(
             configs_content, default_kwargs

--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -52,7 +52,7 @@ class TestTuiConfigs(TuiBase):
                     "connection_method": "local_filesystem",
                     "central_host_id": None,
                     "central_host_username": None,
-                    "overwrite_old_files": False,
+                    "overwrite_existing_files": False,
                 }
             )
         elif kwargs_set == 2:
@@ -61,7 +61,7 @@ class TestTuiConfigs(TuiBase):
                     "connection_method": "ssh",
                     "central_host_id": "@test.host.id",
                     "central_host_username": "test_username",
-                    "overwrite_old_files": True,
+                    "overwrite_existing_files": True,
                 }
             )
 
@@ -206,7 +206,7 @@ class TestTuiConfigs(TuiBase):
                 "connection_method": "ssh",
                 "central_host_id": "random_host",
                 "central_host_username": "random_username",
-                "overwrite_old_files": True,
+                "overwrite_existing_files": True,
             }
 
             for key in new_kwargs.keys():
@@ -489,7 +489,7 @@ class TestTuiConfigs(TuiBase):
             "local_path": "",
             "central_path": "",
             "connection_method": "local_filesystem",
-            "overwrite_old_files": False,
+            "overwrite_existing_files": False,
         }
         await self.check_configs_widgets_match_configs(
             configs_content, default_kwargs

--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -425,15 +425,6 @@ class TestTuiConfigs(TuiBase):
             == kwargs["central_path"]
         )
 
-        # Overwrite Old Files -------------------------------------------------
-
-        assert (
-            configs_content.query_one(
-                "#configs_overwrite_files_checkbox"
-            ).value
-            is kwargs["overwrite_old_files"]
-        )
-
     async def set_configs_content_widgets(
         self, pilot, configs_content, kwargs
     ):
@@ -475,19 +466,6 @@ class TestTuiConfigs(TuiBase):
         await self.fill_input(
             pilot, "#configs_central_path_input", kwargs["central_path"]
         )
-
-        # Overwrite Files -----------------------------------------------------
-
-        if kwargs["overwrite_old_files"]:
-
-            assert not configs_content.query_one(
-                "#configs_overwrite_files_checkbox"
-            ).value
-
-            await self.scroll_to_click_pause(
-                pilot,
-                "#configs_overwrite_files_checkbox",
-            )
 
     async def check_new_project_configs(
         self, pilot, project_name, configs_content, kwargs

--- a/tests/tests_tui/test_tui_get_help.py
+++ b/tests/tests_tui/test_tui_get_help.py
@@ -27,9 +27,7 @@ class TestTuiSettings(TuiBase):
                 ).renderable._text[0]
             )
 
-            await self.scroll_to_click_pause(
-                pilot, "#generic_screen_close_button"
-            )
+            await self.scroll_to_click_pause(pilot, "#all_main_menu_buttons")
 
             assert pilot.app.screen.id == "_default"
 

--- a/tests/tests_tui/test_tui_logging.py
+++ b/tests/tests_tui/test_tui_logging.py
@@ -30,7 +30,7 @@ class TestTuiLogging(TuiBase):
             for file in project.get_logging_path().glob("*.log"):
                 file.unlink()
 
-            project.update_config_file(overwrite_old_files=True)
+            project.update_config_file(overwrite_existing_files=True)
 
             await pilot.pause(5)
 

--- a/tests/tests_tui/test_tui_settings.py
+++ b/tests/tests_tui/test_tui_settings.py
@@ -88,6 +88,10 @@ class TestTuiSettings(TuiBase):
             )
 
             await self.scroll_to_click_pause(
+                pilot, "#show_transfer_tree_status_checkbox"
+            )
+
+            await self.scroll_to_click_pause(
                 pilot, "#generic_screen_close_button"
             )
 

--- a/tests/tests_tui/test_tui_settings.py
+++ b/tests/tests_tui/test_tui_settings.py
@@ -88,10 +88,6 @@ class TestTuiSettings(TuiBase):
             )
 
             await self.scroll_to_click_pause(
-                pilot, "#show_transfer_tree_status_checkbox"
-            )
-
-            await self.scroll_to_click_pause(
                 pilot, "#generic_screen_close_button"
             )
 

--- a/tests/tests_tui/test_tui_settings.py
+++ b/tests/tests_tui/test_tui_settings.py
@@ -91,9 +91,7 @@ class TestTuiSettings(TuiBase):
                 pilot, "#show_transfer_tree_status_checkbox"
             )
 
-            await self.scroll_to_click_pause(
-                pilot, "#generic_screen_close_button"
-            )
+            await self.scroll_to_click_pause(pilot, "#all_main_menu_buttons")
 
             # Go back to the project manager screen and now
             # check everything is switched on.

--- a/tests/tests_tui/test_tui_transfer.py
+++ b/tests/tests_tui/test_tui_transfer.py
@@ -134,9 +134,12 @@ class TestTuiTransfer(TuiBase):
             )
 
             # only transfer behav and funcimg
+            # TODO: this is broken, not updating, not sure why.
+            # Seems a general problem with clicks not registered on transfer tab
             await self.scroll_to_click_pause(
                 pilot, "#transfer_all_checkbox"
             )  # turn this off
+
             await self.scroll_to_click_pause(
                 pilot, "#transfer_behav_checkbox"
             )  # and these on...

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -50,7 +50,7 @@ class TestTuiWidgets(TuiBase):
                 configs_content.query_one(
                     "#configs_banner_label"
                 ).renderable._text[0]
-                == "Configure A New Project"
+                == "Make A New Project"
             )
             assert (
                 configs_content.query_one(

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -1,3 +1,4 @@
+import platform
 from typing import Union
 
 import pytest
@@ -87,12 +88,21 @@ class TestTuiWidgets(TuiBase):
                 configs_content.query_one("#configs_local_path_input").value
                 == ""
             )
-            assert (
-                configs_content.query_one(
-                    "#configs_local_path_input"
-                ).placeholder
-                == "e.g. C:\\path\\to\\local\\my_projects\\my_first_project"
-            )
+
+            if platform.system() == "Windows":
+                assert (
+                    configs_content.query_one(
+                        "#configs_local_path_input"
+                    ).placeholder
+                    == "e.g. C:\\path\\to\\local\\my_projects\\my_first_project"
+                )
+            else:
+                assert (
+                    configs_content.query_one(
+                        "#configs_local_path_input"
+                    ).placeholder
+                    == "e.g. /path/to/local/my_projects/my_first_project"
+                )
 
             # Connection Method ---------------------------------------------------
 
@@ -121,12 +131,21 @@ class TestTuiWidgets(TuiBase):
                 configs_content.query_one("#configs_central_path_input").value
                 == ""
             )
-            assert (
-                configs_content.query_one(
-                    "#configs_central_path_input"
-                ).placeholder
-                == "e.g. C:\\path\\to\\central\\my_projects\\my_first_project"
-            )
+            if platform.system() == "Windows":
+
+                assert (
+                    configs_content.query_one(
+                        "#configs_central_path_input"
+                    ).placeholder
+                    == "e.g. C:\\path\\to\\central\\my_projects\\my_first_project"
+                )
+            else:
+                assert (
+                    configs_content.query_one(
+                        "#configs_central_path_input"
+                    ).placeholder
+                    == "e.g. /path/to/central/my_projects/my_first_project"
+                )
 
             # Check Non SSH widgets hidden / disabled ----------------------------------
             await self.check_new_project_ssh_widgets(
@@ -196,19 +215,20 @@ class TestTuiWidgets(TuiBase):
 
             await pilot.pause()
 
-    async def check_new_project_ssh_widgets(self, configs_content, ssh_on):
+    async def check_new_project_ssh_widgets(
+        self, configs_content, ssh_on, save_pressed=False
+    ):
         """"""
-        assert (
-            configs_content.query_one(
-                "#configs_setup_ssh_connection_button"
-            ).disabled
-            is True  # Only enabled after project creation.
-        )
+        assert configs_content.query_one(
+            "#configs_setup_ssh_connection_button"
+        ).visible is (
+            ssh_on and save_pressed
+        )  # Only enabled after project creation.
         assert (
             configs_content.query_one(
                 "#configs_central_path_select_button"
-            ).disabled
-            is ssh_on
+            ).display
+            is not ssh_on
         )
 
         for id in [
@@ -831,6 +851,7 @@ class TestTuiWidgets(TuiBase):
             await self.scroll_to_click_pause(
                 pilot, "#transfer_toplevel_radiobutton"
             )
+
             await self.check_top_folder_select(
                 pilot,
                 "#transfer_toplevel_select",
@@ -864,7 +885,6 @@ class TestTuiWidgets(TuiBase):
                 "rawdata",
                 move_to_position=4,
             )
-
             await pilot.pause()
 
     async def check_top_folder_select(
@@ -1050,14 +1070,6 @@ class TestTuiWidgets(TuiBase):
                     "#transfer_custom_radiobutton"
                 ).label._text[0]
                 == "Custom"
-            )
-
-            # parameters container
-            assert (
-                pilot.app.screen.query_one(
-                    "#transfer_params_container"
-                ).border_title
-                == "Parameters"
             )
 
             # All data label

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -291,7 +291,7 @@ class TestTuiWidgets(TuiBase):
 
             assert (
                 pilot.app.screen.query_one(
-                    "#tabscreen_session_label"
+                    "#create_folders_session_label"
                 ).renderable._text[0]
                 == "Session(s)"
             )

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -194,30 +194,6 @@ class TestTuiWidgets(TuiBase):
                 == "e.g. username"
             )
 
-            # Transfer Options Container -----------------------------------------------
-
-            assert (
-                configs_content.query_one(
-                    "#configs_transfer_options_container"
-                ).border_title
-                == "Transfer Options"
-            )
-
-            # Overwrite Old Files Checkbox ---------------------------------------------
-
-            assert (
-                configs_content.query_one(
-                    "#configs_overwrite_files_checkbox"
-                ).label._text[0]
-                == "Overwrite Old Files"
-            )
-            assert (
-                configs_content.query_one(
-                    "#configs_overwrite_files_checkbox"
-                ).value
-                is False
-            )
-
             await pilot.pause()
 
     async def check_new_project_ssh_widgets(self, configs_content, ssh_on):


### PR DESCRIPTION
This PR addresses feedback given TUI in a recent Neuroinformatics Unit team meeting (#322).

Each commit is a new addition / fix but most I don't think worth review.  I've split these into the most interesting at the top, which may be worth a look due to interesting feature or underlying code. 

## More substantial changes or code might be of interest

[b0fd420](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/b0fd420c6a40df695f85936963e288b06cff4079) Pressing `CTRL+N` on the `DirectoryTree` now brings up a window allowing renaming of the folders. These renames are not validated against `NeuroBlueprint`.

[6ed5a11](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/6ed5a114a39e703a7c1180458c8978f14eb51211)  Now no 'special characters' (non-alphanumeric) are allowed in the `project_name`.

[f056f2c](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/f056f2c2cc79ecf8240dc7387238968540cfc069)  Add tooltips to all widgets.

[9dee917](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/9dee9176161039143821ad630c942df6422398a9)  The example placeholder for `local_path` and `central_path` input boxes in the `Configs` tab are now based on the used platform (e.g. windows example if on windows, otherwise unix-style paths). 

[ece2a13](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/ece2a13d3e440a957a7ad698a2be2348fd604277)  No longer require the `project_name` to be at the end of the `local_path` or `central_path` input when creating configs. If not present, it will be added automatically. Under the hood `local_path` and `central_path` must end in the `project_name` (but adding this is just automated during setup for ease of use).

## Adding small fixes from review #314 

[d548dc0](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/d548dc0ffe6f24a34bcbe30619020a533016befc)  Fix comment in older PR: now configs warning does not appear when starting the TUI.

[98eef6c](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/98eef6c874406c5980913d4b34a86bc89bf0a652)  Test dicts in `persistent_settings` tests are factored out to their own function.

## Small changes

[2c58e74](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/2c58e748470209125886176a0427527c1c208cd6) Quick fix to the CSS styling on transfer legend which was dark in light mode. 

[2c45630](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/2c456303905595ccd205d7d67be2305192a709d5)  Add `gitpython` to dependencies so `fancylog` now includes git information in the logs.

[62bba48](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/62bba480a2d911773a5907eea2b2bb2361fbfc5f)  Fix an error (crash) that occurred when suggesting next subject or session if there was an invalid name in the project.

[60e2e84](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/60e2e841268d596b3fb9c9a205a0392d24f72929) 'Configure New Project' -> 'Make New Project' (simple name change).

[10238f8](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/10238f84c172c5832d3bb4124d6018ac38e55dca) Do not show hidden files and folders in the `DirectoryTree`.

[493cf96](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/493cf96e0796405f8e63405de265caa4e84552ff) `transfer-entire-project` methods are combined into a single log whereas previously they were split over two logs (one for `rawdata`, one for `derivatives`).

[89b3c42](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/89b3c4295650ec1a02647586ccea560cf9439910) Remove the `close` buttons from some TUI menu and rename to `Main Menu` and place in the top right hand corner for consistency across the TUI.

[3d0aa16](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/3d0aa16624253159ce376fb76aa020cf2a4247d7)  Move 'Overwrite Old Files' checkbox from TUI configs page to transfer page.

[f8cbc9e](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/f8cbc9e5e265723660049b833ebf056b84fd9a1b)  Rename `overwrite_old_files` to `overwrite_existing_files`.

[5b5799f](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/5b5799f91af4043f2ef6b726887cee57bb057f6e) Hide rather than disable the central path select when using SSH.

[e28a0af](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/e28a0af150140f8ae5d618aea63d471c6e7ed6c0) Show `Setup SSH Connection` button only after `Save` pressed when making a new project.

[8670208](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/8670208d07c65c1dbead3d96c48de444291de6c3) This has been later revised, basically start with `datashuttle launch`.

[c145531](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/c145531ea945ba1a7befc874e2981324e99a4a79)  Fix validation so that it updates after `DirectoryTree` rename or refresh.

[3382151](https://github.com/neuroinformatics-unit/datashuttle/pull/325/commits/33821519c1c26b96bcf7da63f19a497f537b65fd)  Reword the error that local / central path must end in project name (now outdated as error removed in later PR).

