### PR TITLE
Remove working top level folder

### DIFF
--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -1,5 +1,8 @@
+"""
+The CLI is not currently supported.
+"""
+
 import argparse
-import warnings
 from typing import Any, Callable, Dict
 
 import simplejson
@@ -7,7 +10,6 @@ import simplejson
 from datashuttle import DataShuttle
 from datashuttle.configs import canonical_configs, load_configs
 from datashuttle.tui.app import main as tui_main
-from datashuttle.utils import utils
 
 PROTECTED_TEST_PROJECT_NAME = "ds_protected_test_name"
 
@@ -192,7 +194,7 @@ def setup_ssh_connection_to_central_server(*args: Any) -> None:
 
 def create_folders(project: DataShuttle, args: Any) -> None:
     """"""
-    raise NotImplementedError("Requires adding 'top_level_folder")
+    # This function is missing top-level-folder argument
     kwargs = make_kwargs(args)
 
     filtered_kwargs = remove_nonetype_entries(kwargs)
@@ -225,7 +227,7 @@ def upload(project: DataShuttle, args: Any) -> None:
 
 def upload_all(*args: Any) -> None:
     """"""
-    raise NotImplementedError
+    # This function is missing top-level-folder argument
     project = args[0]
     project.upload_all()
 
@@ -260,7 +262,7 @@ def download(project: DataShuttle, args: Any) -> None:
 
 def download_all(*args: Any) -> None:
     """"""
-    raise NotImplementedError
+    # This function is missing top-level-folder argument
     project = args[0]
     project.download_all()
 
@@ -367,7 +369,7 @@ def get_existing_projects(*args: Any) -> None:
 
 def get_next_sub_number(*args: Any) -> None:
     """"""
-    raise NotImplementedError("This function is not stable.")
+    # This function is missing top-level-folder argument
     project = args[0]
     print(project.get_next_sub_number())
 
@@ -377,7 +379,7 @@ def get_next_sub_number(*args: Any) -> None:
 
 def get_next_ses_number(project: DataShuttle, args: Any) -> None:
     """"""
-    raise NotImplementedError("This function is not stable.")
+    # This function is missing top-level-folder argument
     kwargs = make_kwargs(args)
     print(project.get_next_ses_number(kwargs["sub"]))
 
@@ -396,7 +398,7 @@ def show_configs(*args: Any) -> None:
 
 def validate_project(*args: Any) -> None:
     """"""
-    raise NotImplementedError
+    # This function is missing top-level-folder argument
     project = args[0]
     project.validate_project(error_or_warn="warn", local_only=False)
 
@@ -923,8 +925,6 @@ def construct_parser():
     )
     return parser
 
-    return parser
-
 
 parser = construct_parser()
 
@@ -935,6 +935,10 @@ parser = construct_parser()
 
 def main() -> None:
     """
+    Update 29/03/2024. The CLI is not functionality
+    and may be deprecated. Only use to launch
+    datashuttle with `datashuttle launch.`
+
     All arguments from the CLI are collected and
     the function to call determined from the func
     properly on the CLI args. This command name
@@ -955,23 +959,11 @@ def main() -> None:
 
     if args.project_name in ["tui", "gui", "launch"]:
         tui_main()
-        return
-
-    if "func" in args and str(args.func.__name__) == "make_config_file":
-        warn = "ignore"
     else:
-        warn = "default"
-
-    warnings.filterwarnings(warn)  # type: ignore
-    project = DataShuttle(args.project_name, print_startup_message=False)
-    warnings.filterwarnings("default")
-
-    if len(vars(args)) > 1:
-        args.func(project, args)
-    else:
-        utils.print_message_to_user(
-            f"Datashuttle project: {args.project_name}. "
-            f"Add additional commands, see --help for details"
+        raise NotImplementedError(
+            "The command line interface is not supported"
+            "and may only be used to launch datashuttle"
+            "with `datashuttle launch"
         )
 
 

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -921,6 +921,7 @@ def construct_parser():
         nargs="+",
         help="Required: (str, single or multiple)",
     )
+    return parser
 
     return parser
 

--- a/datashuttle/command_line_interface.py
+++ b/datashuttle/command_line_interface.py
@@ -192,6 +192,7 @@ def setup_ssh_connection_to_central_server(*args: Any) -> None:
 
 def create_folders(project: DataShuttle, args: Any) -> None:
     """"""
+    raise NotImplementedError("Requires adding 'top_level_folder")
     kwargs = make_kwargs(args)
 
     filtered_kwargs = remove_nonetype_entries(kwargs)
@@ -224,6 +225,7 @@ def upload(project: DataShuttle, args: Any) -> None:
 
 def upload_all(*args: Any) -> None:
     """"""
+    raise NotImplementedError
     project = args[0]
     project.upload_all()
 
@@ -258,6 +260,7 @@ def download(project: DataShuttle, args: Any) -> None:
 
 def download_all(*args: Any) -> None:
     """"""
+    raise NotImplementedError
     project = args[0]
     project.download_all()
 
@@ -298,20 +301,6 @@ def download_specific_folder_or_file(project: DataShuttle, args: Any) -> None:
         project.download_specific_folder_or_file,
         kwargs.pop("filepath"),
         **kwargs,
-    )
-
-
-# Set Top Level Folder or File ------------------------------------------------
-
-
-def set_top_level_folder(project: DataShuttle, args: Any) -> None:
-    """"""
-    kwargs = make_kwargs(args)
-
-    run_command(
-        project,
-        project.set_top_level_folder,
-        kwargs["folder_name"],
     )
 
 
@@ -378,6 +367,7 @@ def get_existing_projects(*args: Any) -> None:
 
 def get_next_sub_number(*args: Any) -> None:
     """"""
+    raise NotImplementedError("This function is not stable.")
     project = args[0]
     print(project.get_next_sub_number())
 
@@ -387,6 +377,7 @@ def get_next_sub_number(*args: Any) -> None:
 
 def get_next_ses_number(project: DataShuttle, args: Any) -> None:
     """"""
+    raise NotImplementedError("This function is not stable.")
     kwargs = make_kwargs(args)
     print(project.get_next_ses_number(kwargs["sub"]))
 
@@ -400,20 +391,12 @@ def show_configs(*args: Any) -> None:
     project.show_configs()
 
 
-# Show Top Level Folder -------------------------------------------------------
-
-
-def get_top_level_folder(*args: Any) -> None:
-    """"""
-    project = args[0]
-    print(project.get_top_level_folder())
-
-
 # Validate Project  -----------------------------------------------------------
 
 
 def validate_project(*args: Any) -> None:
     """"""
+    raise NotImplementedError
     project = args[0]
     project.validate_project(error_or_warn="warn", local_only=False)
 
@@ -790,26 +773,6 @@ def construct_parser():
         help=help("flag_default_false"),
     )
 
-    # Set Top Level Folder
-    # -------------------------------------------------------------------------
-
-    set_top_level_folder_parser = subparsers.add_parser(
-        "set-top-level-folder",
-        aliases=["set_top_level_folder"],
-        description=process_docstring(
-            DataShuttle.set_top_level_folder.__doc__
-        ),
-        formatter_class=argparse.RawTextHelpFormatter,
-        help="",
-    )
-    set_top_level_folder_parser.set_defaults(func=set_top_level_folder)
-
-    set_top_level_folder_parser.add_argument(
-        "folder_name",
-        type=str,
-        help=help("required_str"),
-    )
-
     # Get Local Path
     # -------------------------------------------------------------------------
 
@@ -920,19 +883,6 @@ def construct_parser():
         help="",
     )
     show_configs_parser.set_defaults(func=show_configs)
-
-    # Show Top Level Folder
-    # -------------------------------------------------------------------------
-
-    get_top_level_folder_parser = subparsers.add_parser(
-        "get-top-level-folder",
-        aliases=["get_top_level_folder"],
-        description=process_docstring(
-            DataShuttle.get_top_level_folder.__doc__
-        ),
-        help="",
-    )
-    get_top_level_folder_parser.set_defaults(func=get_top_level_folder)
 
     # Validate Project
     # -------------------------------------------------------------------------

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -323,8 +323,7 @@ def get_persistent_settings_defaults() -> Dict:
     TUI checkboxes and name templates (i.e. regexp
     validation for sub and ses names) are stored.
     """
-    settings = {"top_level_folder": "rawdata"}
-
+    settings = {}
     settings.update(get_tui_config_defaults())
     settings.update(get_name_templates_defaults())
 

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -474,7 +474,7 @@ class DataShuttle:
 
     @check_configs_set
     def upload_specific_folder_or_file(
-        self, filepath: str, dry_run: bool = False
+        self, filepath: Union[str, Path], dry_run: bool = False
     ) -> None:
         """
         Upload a specific file or folder. If transferring
@@ -502,6 +502,9 @@ class DataShuttle:
             transfer was taking place, but no files will be moved. Useful
             to check which files will be moved on data transfer.
         """
+        if isinstance(filepath, str):
+            filepath = Path(filepath)
+
         self._start_log("upload-specific-folder-or-file", local_vars=locals())
 
         top_level_folder = self._get_top_level_folder_from_specific_filepath(
@@ -510,7 +513,7 @@ class DataShuttle:
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local", top_level_folder),
-            Path(filepath),
+            filepath,
         )
 
         include_list = [f"--include {processed_filepath.as_posix()}"]
@@ -528,7 +531,7 @@ class DataShuttle:
 
     @check_configs_set
     def download_specific_folder_or_file(
-        self, filepath: str, dry_run: bool = False
+        self, filepath: Union[str, Path], dry_run: bool = False
     ) -> None:
         """
         Download a specific file or folder. If transferring
@@ -556,6 +559,9 @@ class DataShuttle:
             transfer was taking place, but no files will be moved. Useful
             to check which files will be moved on data transfer.
         """
+        if isinstance(filepath, str):
+            filepath = Path(filepath)
+
         self._start_log(
             "download-specific-folder-or-file", local_vars=locals()
         )
@@ -566,7 +572,7 @@ class DataShuttle:
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central", top_level_folder),
-            Path(filepath),
+            filepath,
         )
 
         include_list = [f"--include /{processed_filepath.as_posix()}"]
@@ -582,7 +588,7 @@ class DataShuttle:
 
         ds_logger.close_log_filehandler()
 
-    def _get_top_level_folder_from_specific_filepath(self, filepath: str):
+    def _get_top_level_folder_from_specific_filepath(self, filepath: Path):
         """
         TODO: this is so hacky, it would be better just force passing
         file directly relative to rawdata and not accept entire file.

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -511,6 +511,9 @@ class DataShuttle:
             filepath
         )
 
+        if filepath.parts[0] == top_level_folder:
+            filepath = Path(*filepath.parts[1:])
+
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("local", top_level_folder),
             filepath,
@@ -569,6 +572,9 @@ class DataShuttle:
         top_level_folder = self._get_top_level_folder_from_specific_filepath(
             filepath
         )
+
+        if filepath.parts[0] == top_level_folder:
+            filepath = Path(*filepath.parts[1:])
 
         processed_filepath = utils.get_path_after_base_folder(
             self.cfg.get_base_folder("central", top_level_folder),

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -111,19 +111,11 @@ class DataShuttle:
         else:
             rclone.prompt_rclone_download_if_does_not_exist()
 
-        if print_startup_message:
-            if self.cfg:
-                self._display_top_level_folder()
-
     def _set_attributes_after_config_load(self) -> None:
         """
         Once config file is loaded, update all private attributes
         according to config contents.
         """
-        self.cfg.top_level_folder = self._load_persistent_settings()[
-            "top_level_folder"
-        ]
-
         self.cfg.init_paths()
 
         self._make_project_metadata_if_does_not_exist()
@@ -133,41 +125,12 @@ class DataShuttle:
     # -------------------------------------------------------------------------
 
     @check_configs_set
-    def set_top_level_folder(self, folder_name: str) -> None:
-        """
-        Set the working top level folder (e.g. 'rawdata', 'derivatives').
-
-        The top_level_folder defines in which top level folder new
-        sub-folders will be made (e.g. create_folders) or at which level
-        folders  are transferred with the commands upload / download
-        and upload_all / download all.
-
-        To upload the entire project (i.e. every top level
-        folder), use the 'command upload_entire_project' or
-        'download_entire_project'.
-        """
-        canonical_top_level_folders = canonical_folders.get_top_level_folders()
-
-        if folder_name not in canonical_top_level_folders:
-            utils.log_and_raise_error(
-                f"Folder name: {folder_name} "
-                f"is not in permitted top-level folder"
-                f" names: {canonical_top_level_folders}",
-                ValueError,
-            )
-
-        self.cfg.top_level_folder = folder_name
-
-        self._update_persistent_setting("top_level_folder", folder_name)
-
-        self._display_top_level_folder()
-
-    @check_configs_set
     def create_folders(
         self,
+        top_level_folder: Literal["rawdata", "derivatives"],
         sub_names: Union[str, List[str]],
         ses_names: Optional[Union[str, List[str]]] = None,
-        datatype: str = "",
+        datatype: Union[str, List[str]] = "",
         bypass_validation: bool = False,
     ) -> None:
         """
@@ -198,6 +161,10 @@ class DataShuttle:
                 NeuroBlueprint will be created. If "" is passed
                 no datatype will be created.
 
+        top_level_folder :
+                Whether to make the folders in `rawdata` or
+                `derivatives`.
+
         Notes
         -----
 
@@ -218,15 +185,14 @@ class DataShuttle:
 
         Examples
         --------
-        project.create_folders("sub-001", datatype="all")
+        project.create_folders("rawdata", "sub-001", datatype="all")
 
-        project.create_folders("sub-002@TO@005",
+        project.create_folders("rawdata",
+                             "sub-002@TO@005",
                              ["ses-001", "ses-002"],
                              ["ephys", "behav"])
         """
         self._start_log("create-folders", local_vars=locals())
-
-        self._display_top_level_folder()
 
         utils.log("\nFormatting Names...")
         ds_logger.log_names(["sub_names", "ses_names"], [sub_names, ses_names])
@@ -234,7 +200,12 @@ class DataShuttle:
         name_templates = self.get_name_templates()
 
         format_sub, format_ses = self._format_and_validate_names(
-            sub_names, ses_names, name_templates, bypass_validation, log=True
+            top_level_folder,
+            sub_names,
+            ses_names,
+            name_templates,
+            bypass_validation,
+            log=True,
         )
 
         ds_logger.log_names(
@@ -245,6 +216,7 @@ class DataShuttle:
         utils.log("\nMaking folders...")
         folders.create_folder_trees(
             self.cfg,
+            top_level_folder,
             format_sub,
             format_ses,
             datatype,
@@ -260,6 +232,7 @@ class DataShuttle:
 
     def _format_and_validate_names(
         self,
+        top_level_folder: Literal["rawdata", "derivatives"],
         sub_names: Union[str, List[str]],
         ses_names: Optional[Union[str, List[str]]],
         name_templates: Dict,
@@ -285,6 +258,7 @@ class DataShuttle:
         if not bypass_validation:
             validation.validate_names_against_project(
                 self.cfg,
+                top_level_folder,
                 format_sub,
                 format_ses,
                 local_only=True,
@@ -302,6 +276,7 @@ class DataShuttle:
     @check_configs_set
     def upload(
         self,
+        top_level_folder: Literal["rawdata", "derivatives"],
         sub_names: Union[str, list],
         ses_names: Union[str, list],
         datatype: Union[List[str], str] = "all",
@@ -317,6 +292,10 @@ class DataShuttle:
 
         Parameters
         ----------
+
+        top_level_folder :
+            The top-level folder (e.g. `rawdata`) to transfer files
+            and folders within.
 
         sub_names :
             a subject name / list of subject names. These must
@@ -363,11 +342,10 @@ class DataShuttle:
         if init_log:
             self._start_log("upload", local_vars=locals())
 
-        self._display_top_level_folder()
-
         TransferData(
             self.cfg,
             "upload",
+            top_level_folder,
             sub_names,
             ses_names,
             datatype,
@@ -381,6 +359,7 @@ class DataShuttle:
     @check_configs_set
     def download(
         self,
+        top_level_folder: Literal["rawdata", "derivatives"],
         sub_names: Union[str, list],
         ses_names: Union[str, list],
         datatype: Union[List[str], str] = "all",
@@ -402,11 +381,10 @@ class DataShuttle:
         if init_log:
             self._start_log("download", local_vars=locals())
 
-        self._display_top_level_folder()
-
         TransferData(
             self.cfg,
             "download",
+            top_level_folder,
             sub_names,
             ses_names,
             datatype,
@@ -418,7 +396,12 @@ class DataShuttle:
             ds_logger.close_log_filehandler()
 
     @check_configs_set
-    def upload_all(self, dry_run: bool = False, init_log: bool = True) -> None:
+    def upload_all(
+        self,
+        top_level_folder: Literal["rawdata", "derivatives"],
+        dry_run: bool = False,
+        init_log: bool = True,
+    ) -> None:
         """
         Convenience function to upload all data.
 
@@ -428,14 +411,24 @@ class DataShuttle:
         if init_log:
             self._start_log("upload-all", local_vars=locals())
 
-        self.upload("all", "all", "all", dry_run=dry_run, init_log=False)
+        self.upload(
+            top_level_folder,
+            "all",
+            "all",
+            "all",
+            dry_run=dry_run,
+            init_log=False,
+        )
 
         if init_log:
             ds_logger.close_log_filehandler()
 
     @check_configs_set
     def download_all(
-        self, dry_run: bool = False, init_log: bool = True
+        self,
+        top_level_folder: Literal["rawdata", "derivatives"],
+        dry_run: bool = False,
+        init_log: bool = True,
     ) -> None:
         """
         Convenience function to download all data.
@@ -445,7 +438,14 @@ class DataShuttle:
         if init_log:
             self._start_log("download-all", local_vars=locals())
 
-        self.download("all", "all", "all", dry_run=dry_run, init_log=False)
+        self.download(
+            top_level_folder,
+            "all",
+            "all",
+            "all",
+            dry_run=dry_run,
+            init_log=False,
+        )
 
         if init_log:
             ds_logger.close_log_filehandler()
@@ -494,7 +494,7 @@ class DataShuttle:
 
         filepath :
             a string containing the filepath to move,
-            relative to the project folder "rawdata"
+            from to the project folder "rawdata"
             or "derivatives" path (depending on which is currently
             set). Alternatively, the entire path is accepted.
         dry_run :
@@ -504,10 +504,12 @@ class DataShuttle:
         """
         self._start_log("upload-specific-folder-or-file", local_vars=locals())
 
-        self._display_top_level_folder()
+        top_level_folder = self._get_top_level_folder_from_specific_filepath(
+            filepath
+        )
 
         processed_filepath = utils.get_path_after_base_folder(
-            self.cfg.get_base_folder("local"),
+            self.cfg.get_base_folder("local", top_level_folder),
             Path(filepath),
         )
 
@@ -515,6 +517,7 @@ class DataShuttle:
         output = rclone.transfer_data(
             self.cfg,
             "upload",
+            top_level_folder,
             include_list,
             self.cfg.make_rclone_transfer_options(dry_run),
         )
@@ -557,10 +560,12 @@ class DataShuttle:
             "download-specific-folder-or-file", local_vars=locals()
         )
 
-        self._display_top_level_folder()
+        top_level_folder = self._get_top_level_folder_from_specific_filepath(
+            filepath
+        )
 
         processed_filepath = utils.get_path_after_base_folder(
-            self.cfg.get_base_folder("central"),
+            self.cfg.get_base_folder("central", top_level_folder),
             Path(filepath),
         )
 
@@ -568,6 +573,7 @@ class DataShuttle:
         output = rclone.transfer_data(
             self.cfg,
             "download",
+            top_level_folder,
             include_list,
             self.cfg.make_rclone_transfer_options(dry_run),
         )
@@ -575,6 +581,33 @@ class DataShuttle:
         utils.log(output.stderr.decode("utf-8"))
 
         ds_logger.close_log_filehandler()
+
+    def _get_top_level_folder_from_specific_filepath(self, filepath: str):
+        """
+        TODO: this is so hacky, it would be better just force passing
+        file directly relative to rawdata and not accept entire file.
+        then read the root of the path.
+        """
+        is_rawdata = "rawdata" in filepath
+        is_derivatives = "derivatives" in filepath
+
+        if is_rawdata and is_derivatives:
+            utils.log_and_raise_error(
+                "`filepath` cannot include both rawdata "
+                "and derivatives be either in derivatives "
+                "or rawdata.",
+                ValueError,
+            )
+
+        if not is_rawdata and not is_derivatives:
+            utils.log_and_raise_error(
+                "`filepath` must include the top-level folder "
+                "(`derivatives` or `rawdata`)",
+                ValueError,
+            )
+
+        top_level_folder = "rawdata" if is_rawdata else "derivatives"
+        return top_level_folder
 
     # -------------------------------------------------------------------------
     # SSH
@@ -827,24 +860,6 @@ class DataShuttle:
         """
         return self.cfg.logging_path
 
-    @check_configs_set
-    def get_top_level_folder(self) -> Path:
-        """
-        Get the current working top level folder (e.g.
-        'rawdata', 'derivatives')
-
-        The top_level_folder defines in which top level folder new
-        sub-folders will be made (e.g. create_folders) or
-        at which level folders are transferred with the commands
-        upload / download and upload_all / download all.
-        upload_specific_folder_or_file / download_specific_folder_or_file.
-
-        To upload the entire project (i.e. every top level
-        folder), use the 'command upload_entire_project' or
-        'download_entire_project'.
-        """
-        return self.cfg.top_level_folder
-
     @staticmethod
     def get_existing_projects() -> List[Path]:
         """
@@ -856,7 +871,10 @@ class DataShuttle:
 
     @check_configs_set
     def get_next_sub_number(
-        self, return_with_prefix: bool = True, local_only: bool = False
+        self,
+        top_level_folder: Literal["rawdata", "derivatives"],
+        return_with_prefix: bool = True,
+        local_only: bool = False,
     ) -> str:
         """
         Convenience function for get_next_sub_or_ses_number
@@ -874,6 +892,7 @@ class DataShuttle:
         """
         return getters.get_next_sub_or_ses_number(
             self.cfg,
+            top_level_folder,
             sub=None,
             local_only=local_only,
             return_with_prefix=return_with_prefix,
@@ -883,6 +902,7 @@ class DataShuttle:
     @check_configs_set
     def get_next_ses_number(
         self,
+        top_level_folder: Literal["rawdata", "derivatives"],
         sub: str,
         return_with_prefix: bool = True,
         local_only: bool = False,
@@ -893,6 +913,9 @@ class DataShuttle:
 
         Parameters
         ----------
+
+        top_level_folder:
+            "rawdata" or "derivatives"
 
         sub: Optional[str]
             Name of the subject to find the next session of.
@@ -906,6 +929,7 @@ class DataShuttle:
         """
         return getters.get_next_sub_or_ses_number(
             self.cfg,
+            top_level_folder,
             sub=sub,
             local_only=local_only,
             return_with_prefix=return_with_prefix,
@@ -963,7 +987,10 @@ class DataShuttle:
 
     @check_configs_set
     def validate_project(
-        self, error_or_warn: Literal["error", "warn"], local_only: bool = False
+        self,
+        top_level_folder: Literal["rawdata", "derivatives"],
+        error_or_warn: Literal["error", "warn"],
+        local_only: bool = False,
     ) -> None:
         """
         Perform validation on the project. This checks the subject
@@ -996,6 +1023,7 @@ class DataShuttle:
 
         validation.validate_project(
             self.cfg,
+            top_level_folder,
             local_only=local_only,
             error_or_warn=error_or_warn,
             name_templates=name_templates,
@@ -1062,14 +1090,9 @@ class DataShuttle:
             self.upload_all if direction == "upload" else self.download_all
         )
 
-        tmp_current_top_level_folder = copy.copy(self.cfg.top_level_folder)
-
-        for folder_name in canonical_folders.get_top_level_folders():
-            utils.log_and_message(f"Transferring `{folder_name}`")
-            self.cfg.top_level_folder = folder_name
-            transfer_all_func(init_log=False)
-
-        self.cfg.top_level_folder = tmp_current_top_level_folder
+        for top_level_folder in canonical_folders.get_top_level_folders():
+            utils.log_and_message(f"Transferring `{top_level_folder}`")
+            transfer_all_func(top_level_folder, init_log=False)
 
     def _start_log(
         self,
@@ -1259,14 +1282,3 @@ class DataShuttle:
 
         if "tui" not in settings:
             settings.update(canonical_configs.get_tui_config_defaults())
-
-    @check_configs_set
-    def _display_top_level_folder(self) -> None:
-        """
-        Print the current working top level folder (e.g.
-        'rawdata', 'derivatives')
-        """
-        utils.print_message_to_user(
-            f"\nThe working top level folder is: "
-            f"{self.cfg.top_level_folder}\n"
-        )

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -588,8 +588,8 @@ class DataShuttle:
         file directly relative to rawdata and not accept entire file.
         then read the root of the path.
         """
-        is_rawdata = "rawdata" in filepath
-        is_derivatives = "derivatives" in filepath
+        is_rawdata = "rawdata" in filepath.as_posix()
+        is_derivatives = "derivatives" in filepath.as_posix()
 
         if is_rawdata and is_derivatives:
             utils.log_and_raise_error(

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -159,8 +159,13 @@ class Interface:
         ses_names : List[str]
             List of session names to format.
         """
+        top_level_folder = self.tui_settings["top_level_folder_select"][
+            "create_tab"
+        ]
+
         try:
             format_sub, format_ses = self.project._format_and_validate_names(
+                top_level_folder,
                 sub_names,
                 ses_names,
                 self.get_name_templates(),

--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -222,7 +222,6 @@ class CreateFoldersSettingsScreen(ModalScreen):
             == "create_folders_settings_bypass_validation_checkbox"
         ):
             self.interface.update_tui_settings(is_on, "bypass_validation")
-            # self.interface.project.set_bypass_validation(on=is_on)
 
             self.query_one(
                 "#template_settings_validation_on_checkbox"

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -274,8 +274,14 @@ class CreateFoldersTab(TreeAndInputTab):
         input_id : str
             The textual input name to update.
         """
+        top_level_folder = self.tui_settings["top_level_folder_select"][
+            "create_tab"
+        ]
+
         if prefix == "sub":
-            success, output = self.interface.get_next_sub_number()
+            success, output = self.interface.get_next_sub_number(
+                top_level_folder
+            )
             if not success:
                 self.mainwindow.show_modal_error_dialog(output)
                 return
@@ -303,7 +309,9 @@ class CreateFoldersTab(TreeAndInputTab):
             else:
                 sub = sub_names[0]
 
-            success, output = self.interface.get_next_ses_number(sub)
+            success, output = self.interface.get_next_ses_number(
+                top_level_folder, sub
+            )
             if not success:
                 self.mainwindow.show_modal_error_dialog(output)
                 return

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -274,9 +274,9 @@ class CreateFoldersTab(TreeAndInputTab):
         input_id : str
             The textual input name to update.
         """
-        top_level_folder = self.tui_settings["top_level_folder_select"][
-            "create_tab"
-        ]
+        top_level_folder = self.interface.tui_settings[
+            "top_level_folder_select"
+        ]["create_tab"]
 
         if prefix == "sub":
             success, output = self.interface.get_next_sub_number(

--- a/datashuttle/tui/tabs/transfer_status_tree.py
+++ b/datashuttle/tui/tabs/transfer_status_tree.py
@@ -92,7 +92,7 @@ class TransferStatusTree(CustomDirectoryTree):
         Updates the transfer diffs used to style the DirectoryTree.
         """
         self.transfer_diffs = get_local_and_central_file_differences(
-            self.interface.get_configs(), all_top_level_folder=True
+            self.interface.get_configs(), top_level_folders_to_check=["all"]
         )
 
     # Overridden Methods

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -30,6 +31,7 @@ from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
 def create_folder_trees(
     cfg: Configs,
+    top_level_folder: Literal["rawdata", "derivatives"],
     sub_names: Union[str, list],
     ses_names: Union[str, list],
     datatype: Union[List[str], str],
@@ -66,6 +68,7 @@ def create_folder_trees(
         sub_path = cfg.make_path(
             "local",
             sub,
+            top_level_folder,
         )
 
         create_folders(sub_path, log)
@@ -77,6 +80,7 @@ def create_folder_trees(
             ses_path = cfg.make_path(
                 "local",
                 [sub, ses],
+                top_level_folder,
             )
 
             create_folders(ses_path, log)
@@ -156,7 +160,11 @@ def create_folders(paths: Union[Path, List[Path]], log: bool = True) -> None:
 
 
 def search_project_for_sub_or_ses_names(
-    cfg: Configs, sub: Optional[str], search_str: str, local_only: bool
+    cfg: Configs,
+    top_level_folder: Literal["rawdata", "derivatives"],
+    sub: Optional[str],
+    search_str: str,
+    local_only: bool,
 ) -> Dict:
     """
     If sub is None, the top-level level folder will be
@@ -173,7 +181,7 @@ def search_project_for_sub_or_ses_names(
     # Search local and central for folders that begin with "sub-*"
     local_foldernames, _ = search_sub_or_ses_level(
         cfg,
-        cfg.get_base_folder("local"),
+        cfg.get_base_folder("local", top_level_folder),
         "local",
         sub=sub,
         search_str=search_str,
@@ -187,7 +195,7 @@ def search_project_for_sub_or_ses_names(
     else:
         central_foldernames, _ = search_sub_or_ses_level(
             cfg,
-            cfg.get_base_folder("central"),
+            cfg.get_base_folder("central", top_level_folder),
             "central",
             sub,
             search_str=search_str,
@@ -203,6 +211,7 @@ def search_project_for_sub_or_ses_names(
 def items_from_datatype_input(
     cfg: Configs,
     local_or_central: str,
+    top_level_folder: Literal["rawdata", "derivatives"],
     datatype: Union[list, str],
     sub: str,
     ses: Optional[str] = None,
@@ -217,7 +226,7 @@ def items_from_datatype_input(
 
     see _transfer_datatype() for parameters.
     """
-    base_folder = cfg.get_base_folder(local_or_central)
+    base_folder = cfg.get_base_folder(local_or_central, top_level_folder)
 
     if datatype not in [
         "all",

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -27,6 +27,7 @@ from datashuttle.utils.custom_exceptions import (
 
 def get_next_sub_or_ses_number(
     cfg: Configs,
+    top_level_folder,
     sub: Optional[str],
     search_str: str,
     local_only: bool = False,
@@ -83,7 +84,7 @@ def get_next_sub_or_ses_number(
         prefix = "sub"
 
     folder_names = folders.search_project_for_sub_or_ses_names(
-        cfg, sub, search_str, local_only=local_only
+        cfg, top_level_folder, sub, search_str, local_only=local_only
     )
 
     all_folders = list(set(folder_names["local"] + folder_names["central"]))
@@ -216,7 +217,11 @@ def get_existing_project_paths() -> List[Path]:
     return existing_project_paths
 
 
-def get_all_sub_and_ses_names(cfg: Configs, local_only: bool) -> Dict:
+def get_all_sub_and_ses_names(
+    cfg: Configs,
+    top_level_folder: Literal["rawdata", "derivatives"],
+    local_only: bool,
+) -> Dict:
     """
     Get a list of every subject and session name in the
     local and central project folders. Local and central names are combined
@@ -236,7 +241,7 @@ def get_all_sub_and_ses_names(cfg: Configs, local_only: bool) -> Dict:
         `local_path` and `central_path`.
     """
     sub_folder_names = folders.search_project_for_sub_or_ses_names(
-        cfg, None, "sub-*", local_only
+        cfg, top_level_folder, None, "sub-*", local_only
     )
 
     if local_only:
@@ -249,7 +254,7 @@ def get_all_sub_and_ses_names(cfg: Configs, local_only: bool) -> Dict:
     all_ses_folder_names = {}
     for sub in all_sub_folder_names:
         ses_folder_names = folders.search_project_for_sub_or_ses_names(
-            cfg, sub, "ses-*", local_only
+            cfg, top_level_folder, sub, "ses-*", local_only
         )
 
         if local_only:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -316,6 +316,7 @@ def raise_error_or_warn(
 
 def validate_project(
     cfg: Configs,
+    top_level_folder: Literal["rawdata", "derivatives"],
     local_only: bool = False,
     error_or_warn: Literal["error", "warn"] = "error",
     log: bool = True,
@@ -338,6 +339,9 @@ def validate_project(
     cfg : Configs
         datashuttle Configs class.
 
+    top_level_folder:  Literal["rawdata", "derivatives"]
+        The top level folder to validate.
+
     local_only : bool
         If `True`, only project folders in the `local_path` will
         be validated. Otherwise, project folders in both the `local_path`
@@ -349,7 +353,9 @@ def validate_project(
     log : bool
         If `True`, errors or warnings are logged to "datashuttle" logger.
     """
-    folder_names = getters.get_all_sub_and_ses_names(cfg, local_only)
+    folder_names = getters.get_all_sub_and_ses_names(
+        cfg, top_level_folder, local_only
+    )
 
     # Check subjects
     sub_names = folder_names["sub"]
@@ -390,6 +396,7 @@ def validate_project(
 
 def validate_names_against_project(
     cfg: Configs,
+    top_level_folder: Literal["rawdata", "derivatives"],
     sub_names: List[str],
     ses_names: Optional[List[str]] = None,
     local_only: bool = False,
@@ -419,6 +426,9 @@ def validate_names_against_project(
     cfg : Configs
         datashuttle Configs class.
 
+    top_level_folder :  Literal["rawdata", "derivatives"]
+        The top level folder to validate
+
     sub_names : List[str]
         A list of subject-level names to validate against the
         subject names that exist in the project.
@@ -440,7 +450,9 @@ def validate_names_against_project(
     log : bool
         If `True`, errors or warnings are logged to "datashuttle" logger.
     """
-    folder_names = getters.get_all_sub_and_ses_names(cfg, local_only)
+    folder_names = getters.get_all_sub_and_ses_names(
+        cfg, top_level_folder, local_only
+    )
 
     # Check subjects
     if folder_names["sub"]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -348,7 +348,7 @@ def check_datatype_sub_ses_uploaded_correctly(
 
 
 def make_and_check_local_project_folders(
-    project, subs, sessions, datatype, folder_name="rawdata"
+    project, top_level_folder, subs, sessions, datatype
 ):
     """
     Make a local project folder tree with the specified datatype,
@@ -358,10 +358,12 @@ def make_and_check_local_project_folders(
     to write a placeholder file in all bottom-level
     directories so ensure they are transferred.
     """
-    make_local_folders_with_files_in(project, subs, sessions, datatype)
+    make_local_folders_with_files_in(
+        project, top_level_folder, subs, sessions, datatype
+    )
 
     check_folder_tree_is_correct(
-        get_top_level_folder_path(project, folder_name=folder_name),
+        get_top_level_folder_path(project, top_level_folder),
         subs,
         sessions,
         get_all_folders_used(),
@@ -369,9 +371,9 @@ def make_and_check_local_project_folders(
 
 
 def make_local_folders_with_files_in(
-    project, subs, sessions=None, datatype="all"
+    project, top_level_folder, subs, sessions=None, datatype="all"
 ):
-    project.create_folders(subs, sessions, datatype)
+    project.create_folders(top_level_folder, subs, sessions, datatype)
     for root, dirs, _ in os.walk(project.cfg["local_path"]):
         if not dirs:
             path_ = Path(root) / "placeholder_file.txt"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -363,7 +363,7 @@ def make_and_check_local_project_folders(
     )
 
     check_folder_tree_is_correct(
-        get_top_level_folder_path(project, top_level_folder),
+        get_top_level_folder_path(project, "local", top_level_folder),
         subs,
         sessions,
         get_all_folders_used(),

--- a/tests/tests_integration/deprecated_test_command_line_interface.py
+++ b/tests/tests_integration/deprecated_test_command_line_interface.py
@@ -388,9 +388,11 @@ class TestCommandLineInterface(BaseTest):
         in test_upload_download_all_variables() and
         test_upload_download_variables()
         """
+        raise NotImplementedError("need to add in top-level-folder")
         subs, sessions = test_utils.get_default_sub_sessions_to_test()
 
         test_utils.make_and_check_local_project_folders(
+            "rawdata",
             project,
             subs,
             sessions,
@@ -440,6 +442,7 @@ class TestCommandLineInterface(BaseTest):
 
         test_utils.make_and_check_local_project_folders(
             project,
+            "rawdata",
             subs,
             sessions,
             "all",
@@ -492,43 +495,6 @@ class TestCommandLineInterface(BaseTest):
         assert "['sub-01', 'sub-02', 'sub-03']" in stdout
 
     @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_set_top_level_folder(self, project, sep):
-        """
-        Test that the top level folder is "rawdata" by default,
-        setting the top level folder to a new folder ("derivatives")
-        updates the top level folder correctly. Finally, test
-        passing a not-allowed top-level-folder to
-        set-top-level-folder raises an error.
-        """
-        stdout, _ = test_utils.run_cli(
-            f"get{sep}top{sep}level{sep}folder", project.project_name
-        )
-
-        assert "rawdata" in stdout
-
-        stdout, stderr = test_utils.run_cli(
-            f"set{sep}top{sep}level{sep}folder derivatives",
-            project.project_name,
-        )
-        assert "derivatives" in stdout
-
-        stdout, _ = test_utils.run_cli(
-            f"get{sep}top{sep}level{sep}folder", project.project_name
-        )
-
-        assert "derivatives" in stdout
-
-        _, stderr = test_utils.run_cli(
-            f"set{sep}top{sep}level{sep}folder NOT_RECOGNISED",
-            project.project_name,
-        )
-
-        assert (
-            "Folder name: NOT_RECOGNISED is not in permitted top-level folder names"
-            in stderr
-        )
-
-    @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_get_paths(self, project, sep):
         """
         Check that all CLI commands to return a path
@@ -558,19 +524,6 @@ class TestCommandLineInterface(BaseTest):
             f"get{sep}logging{sep}path", project.project_name
         )
         assert str(project.get_logging_path()) in stdout
-
-    @pytest.mark.parametrize("sep", ["-", "_"])
-    def test_cli_get_top_level_folder(self, project, sep):
-        """
-        Check the CLI command to get the top-level-folder
-        shows the correct name.
-        """
-        project.set_top_level_folder("derivatives")
-
-        stdout, stderr = test_utils.run_cli(
-            f"get{sep}top{sep}level{sep}folder", project.project_name
-        )
-        assert str(project.get_top_level_folder()) in stdout
 
     @pytest.mark.parametrize("sep", ["-", "_"])
     def test_cli_existing_projects(self, project, sep):

--- a/tests/tests_integration/deprecated_test_command_line_interface.py
+++ b/tests/tests_integration/deprecated_test_command_line_interface.py
@@ -388,7 +388,6 @@ class TestCommandLineInterface(BaseTest):
         in test_upload_download_all_variables() and
         test_upload_download_variables()
         """
-        raise NotImplementedError("need to add in top-level-folder")
         subs, sessions = test_utils.get_default_sub_sessions_to_test()
 
         test_utils.make_and_check_local_project_folders(

--- a/tests/tests_integration/test_create_folders.py
+++ b/tests/tests_integration/test_create_folders.py
@@ -24,7 +24,7 @@ class TestMakeFolders(BaseTest):
         """
         subs = ["00011", "sub-00002", "30303"]
 
-        project.create_folders(subs)
+        project.create_folders("rawdata", subs)
 
         test_utils.check_folder_tree_is_correct(
             base_folder=test_utils.get_top_level_folder_path(project),
@@ -46,7 +46,7 @@ class TestMakeFolders(BaseTest):
 
         sessions = ["ses-00001", "50432"]
 
-        project.create_folders(subs, sessions, "all")
+        project.create_folders("rawdata", subs, sessions, "all")
 
         base_folder = test_utils.get_top_level_folder_path(project)
 
@@ -95,7 +95,7 @@ class TestMakeFolders(BaseTest):
         subs = ["sub-001", "sub-002"]
         sessions = ["ses-001", "ses-002"]
 
-        project.create_folders(subs, sessions, datatypes_to_make)
+        project.create_folders("rawdata", subs, sessions, datatypes_to_make)
 
         # Check folder tree is not made but all others are
         test_utils.check_folder_tree_is_correct(
@@ -133,7 +133,7 @@ class TestMakeFolders(BaseTest):
         sub = "sub-001"
         ses = "ses-001"
 
-        project.create_folders(sub, ses, "all")
+        project.create_folders("rawdata", sub, ses, "all")
 
         # Check the correct folder names were made
         base_folder = test_utils.get_top_level_folder_path(project)
@@ -178,7 +178,7 @@ class TestMakeFolders(BaseTest):
         """
         sub = "sub-001"
         ses = "ses-001"
-        project.create_folders(sub, ses, files_to_test)
+        project.create_folders("rawdata", sub, ses, files_to_test)
 
         base_folder = test_utils.get_top_level_folder_path(project)
 
@@ -209,6 +209,7 @@ class TestMakeFolders(BaseTest):
         date, time_ = self.get_formatted_date_and_time()
 
         project.create_folders(
+            "rawdata",
             ["sub-001", "sub-002"],
             [f"ses-001_{tags('date')}", f"002_{tags('date')}"],
             "ephys",
@@ -230,6 +231,7 @@ class TestMakeFolders(BaseTest):
         date, time_ = self.get_formatted_date_and_time()
 
         project.create_folders(
+            "rawdata",
             ["sub-001", "sub-002"],
             [f"ses-001_{tags('datetime')}", f"002_{tags('datetime')}"],
             "ephys",
@@ -266,7 +268,7 @@ class TestMakeFolders(BaseTest):
         subs = ["sub-001", "sub-002"]
         sessions = ["ses-001", "ses-003"]
 
-        project.create_folders(subs, sessions, "all")
+        project.create_folders("rawdata", subs, sessions, "all")
 
         # Check folder tree is made in the desired top level folder
         test_utils.check_working_top_level_folder_only_exists(
@@ -313,7 +315,7 @@ class TestMakeFolders(BaseTest):
         assert new_num == "sub-004" if return_with_prefix else "004"
 
         # Add large-sub num folders to local and check all are detected.
-        project.create_folders(["004", "005"])
+        project.create_folders("rawdata", ["004", "005"])
 
         new_num = project.get_next_sub_number(
             top_level_folder, return_with_prefix
@@ -383,7 +385,7 @@ class TestMakeFolders(BaseTest):
 
         # Now make a couple more sessions locally, and check
         # the next session is updated accordingly.
-        project.create_folders(sub, ["004", "005"])
+        project.create_folders("rawdata", sub, ["004", "005"])
 
         new_num = project.get_next_ses_number(
             top_level_folder, sub, return_with_prefix

--- a/tests/tests_integration/test_create_folders.py
+++ b/tests/tests_integration/test_create_folders.py
@@ -259,16 +259,12 @@ class TestMakeFolders(BaseTest):
     def test_all_top_level_folders(self, project, top_level_folder):
         """
         Check that when switching the top level folder (e.g. rawdata, derivatives)
-        new folders are made in the correct folder. The code that underpins this
-        is very simple (all the path for folder creation / transfer is determined
-        only by project.cfg.top_level_folder. Therefore if these tests pass,
-        any test that passes for rawdata (all other tests are for rawdata) should
-        pass for all top-level folders.
+        new folders are made in the correct folder.
         """
         subs = ["sub-001", "sub-002"]
         sessions = ["ses-001", "ses-003"]
 
-        project.create_folders("rawdata", subs, sessions, "all")
+        project.create_folders(top_level_folder, subs, sessions, "all")
 
         # Check folder tree is made in the desired top level folder
         test_utils.check_working_top_level_folder_only_exists(
@@ -305,9 +301,9 @@ class TestMakeFolders(BaseTest):
         assert new_num == "sub-004" if return_with_prefix else "004"
 
         # Upload to central, now local and central folders match
-        project.upload_all("rawdata")
+        project.upload_all(top_level_folder)
 
-        shutil.rmtree(project.cfg["local_path"] / "rawdata")
+        shutil.rmtree(project.cfg["local_path"] / top_level_folder)
 
         new_num = project.get_next_sub_number(
             top_level_folder, return_with_prefix
@@ -315,7 +311,7 @@ class TestMakeFolders(BaseTest):
         assert new_num == "sub-004" if return_with_prefix else "004"
 
         # Add large-sub num folders to local and check all are detected.
-        project.create_folders("rawdata", ["004", "005"])
+        project.create_folders(top_level_folder, ["004", "005"])
 
         new_num = project.get_next_sub_number(
             top_level_folder, return_with_prefix
@@ -323,7 +319,7 @@ class TestMakeFolders(BaseTest):
         assert new_num == "sub-006" if return_with_prefix else "006"
 
         # check `local_path` option
-        os.makedirs(project.cfg["central_path"] / "rawdata" / "sub-006")
+        os.makedirs(project.cfg["central_path"] / top_level_folder / "sub-006")
         new_num = project.get_next_sub_number(
             top_level_folder, return_with_prefix, local_only=False
         )
@@ -369,9 +365,9 @@ class TestMakeFolders(BaseTest):
 
         # Now upload the data, delete locally, and check the
         # suggested values are correct based on the `central` path.
-        project.upload_all("rawdata")
+        project.upload_all(top_level_folder)
 
-        shutil.rmtree(project.cfg["local_path"] / "rawdata")
+        shutil.rmtree(project.cfg["local_path"] / top_level_folder)
 
         new_num = project.get_next_sub_number(
             top_level_folder, return_with_prefix
@@ -385,7 +381,7 @@ class TestMakeFolders(BaseTest):
 
         # Now make a couple more sessions locally, and check
         # the next session is updated accordingly.
-        project.create_folders("rawdata", sub, ["004", "005"])
+        project.create_folders(top_level_folder, sub, ["004", "005"])
 
         new_num = project.get_next_ses_number(
             top_level_folder, sub, return_with_prefix
@@ -393,7 +389,9 @@ class TestMakeFolders(BaseTest):
         assert new_num == "ses-006" if return_with_prefix else "006"
 
         # check `local_path` object
-        os.makedirs(project.cfg["central_path"] / "rawdata" / sub / "ses-006")
+        os.makedirs(
+            project.cfg["central_path"] / top_level_folder / sub / "ses-006"
+        )
         new_num = project.get_next_ses_number(
             top_level_folder, sub, return_with_prefix, local_only=False
         )

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -576,7 +576,7 @@ class TestFileTransfer(BaseTest):
                 project.cfg[transfer_from] / formatted_to_transfer
             )
         else:
-            transfer_function(Path(*formatted_to_transfer.parts[1:]))
+            transfer_function(Path(*formatted_to_transfer.parts))
 
         transferred_files = [
             path_

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -534,16 +534,6 @@ class TestFileTransfer(BaseTest):
         """
         Test upload_specific_folder_or_file() and download_specific_folder_or_file().
 
-        This test has a few different parameterisations. It tests
-        1) transfer_file : this transfers a file or folder. if transferring
-           a folder, all contents are transferred with /** wildcard.
-        2) full path : the functions can accept full path or path
-           relative to rawdata/ . Test both these instances
-        3) upload_or_download : Test the direction. As it is more convenient
-           to  make all test project file in local_path then swap the paths
-           if downloading, this is done here (see
-           test_utils.swap_local_and_central_paths()) for details.
-
         Make a project with two different files (just to
         ensure non-target files are not transferred). Transfer
         a single file or the folder containing the file. Check that

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -63,20 +63,23 @@ class TestFormatting(BaseTest):
             "sub-6",
         ]
 
-    def test_warning_non_consecutive_numbers(self, project):
+    @pytest.mark.parametrize("top_level_folder", ["rawdata", "derivatives"])
+    def test_warning_non_consecutive_numbers(self, project, top_level_folder):
         project.create_folders(
-            ["sub-01", "sub-02", "sub-04"], ["ses-05", "ses-10"]
+            top_level_folder,
+            ["sub-01", "sub-02", "sub-04"],
+            ["ses-05", "ses-10"],
         )
 
         with pytest.warns(UserWarning) as w:
-            project.get_next_sub_number()
+            project.get_next_sub_number(top_level_folder)
         assert (
             str(w[0].message) == "A subject number has been skipped, "
             "currently used subject numbers are: [1, 2, 4]"
         )
 
         with pytest.warns(UserWarning) as w:
-            project.get_next_ses_number("sub-02")
+            project.get_next_ses_number(top_level_folder, "sub-02")
         assert (
             str(w[0].message)
             == "A subject number has been skipped, currently "

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -136,7 +136,7 @@ class TestLogging:
 
         ses = ["ses-123", "ses-101"]
 
-        project.create_folders(subs, ses, datatype="all")
+        project.create_folders("rawdata", subs, ses, datatype="all")
 
         log = self.read_log_file(project.cfg.logging_path)
 
@@ -201,6 +201,7 @@ class TestLogging:
 
         test_utils.make_and_check_local_project_folders(
             project,
+            "rawdata",
             subs,
             sessions,
             "all",
@@ -220,9 +221,9 @@ class TestLogging:
         self.delete_log_files(project.cfg.logging_path)
 
         (
-            transfer_function()
+            transfer_function("rawdata")
             if use_all_alias
-            else transfer_function("all", "all", "all")
+            else transfer_function("rawdata", "all", "all", "all")
         )
 
         log = self.read_log_file(project.cfg.logging_path)
@@ -261,6 +262,7 @@ class TestLogging:
         """
         test_utils.make_and_check_local_project_folders(
             project,
+            "rawdata",
             subs=["sub-001"],
             sessions=["ses-001"],
             datatype="all",
@@ -386,12 +388,12 @@ class TestLogging:
 
     def test_logs_bad_create_folders_error(self, project):
         """"""
-        project.create_folders("sub-001", datatype="all")
+        project.create_folders("rawdata", "sub-001", datatype="all")
         self.delete_log_files(project.cfg.logging_path)
 
         with pytest.raises(NeuroBlueprintError):
             project.create_folders(
-                "sub-001_datetime-123213T123122", datatype="all"
+                "rawdata", "sub-001_datetime-123213T123122", datatype="all"
             )
         log = self.read_log_file(project.cfg.logging_path)
 
@@ -407,7 +409,7 @@ class TestLogging:
         and warnings to file.
         """
         # Make conflicting subject folders
-        project.create_folders(["sub-001", "sub-002"])
+        project.create_folders("rawdata", ["sub-001", "sub-002"])
         for sub in ["sub-1", "sub-002_date-2023"]:
             os.makedirs(project.cfg["local_path"] / "rawdata" / sub)
 
@@ -415,7 +417,7 @@ class TestLogging:
 
         # Check a validation error is logged.
         with pytest.raises(BaseException) as e:
-            project.validate_project(error_or_warn="error")
+            project.validate_project("rawdata", error_or_warn="error")
 
         log = self.read_log_file(project.cfg.logging_path)
         assert "ERROR" in log
@@ -425,7 +427,7 @@ class TestLogging:
 
         # Check that validation warnings are logged.
         with pytest.warns(UserWarning) as w:
-            project.validate_project(error_or_warn="warn")
+            project.validate_project("rawdata", error_or_warn="warn")
 
         log = self.read_log_file(project.cfg.logging_path)
 
@@ -440,11 +442,11 @@ class TestLogging:
         `make_project_folders` is called, that it logs errors
         to file. Warnings are not tested.
         """
-        project.create_folders("sub-001")
+        project.create_folders("rawdata", "sub-001")
         self.delete_log_files(project.cfg.logging_path)  #
 
         with pytest.raises(BaseException) as e:
-            project.create_folders("sub-001_id-a")
+            project.create_folders("rawdata", "sub-001_id-a")
 
         log = self.read_log_file(project.cfg.logging_path)
 

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -280,9 +280,13 @@ class TestLogging:
         self.delete_log_files(project.cfg.logging_path)
 
         if upload_or_download == "upload":
-            project.upload_specific_folder_or_file("sub-001/ses-001")
+            project.upload_specific_folder_or_file(
+                "rawdata", "sub-001/ses-001"
+            )
         else:
-            project.download_specific_folder_or_file("sub-001/ses-001")
+            project.download_specific_folder_or_file(
+                "rawdata", "sub-001/ses-001"
+            )
 
         log = self.read_log_file(project.cfg.logging_path)
 
@@ -290,11 +294,7 @@ class TestLogging:
             f"Starting logging for command {upload_or_download}-specific-folder-or-file"
             in log
         )
-        assert (
-            "\n\nVariablesState:\nlocals: {'filepath': 'sub-001/ses-001', "
-            "'dry_run': False}\ncfg: {'local_path':" in log
-        )
-        assert """sub-001/ses-001"]""" in log
+        assert "sub-001/ses-001" in log
         assert "Using config file from" in log
         assert "Waiting for checks to finish" in log
 

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -143,9 +143,8 @@ class TestLogging:
         assert "Formatting Names..." in log
 
         assert (
-            "\n\nVariablesState:\nlocals: {'sub_names': ['sub-111', "
-            "'sub-002@TO@004'], 'ses_names': ['ses-123', 'ses-101'], "
-            "'datatype': 'all" in log
+            "VariablesState:\nlocals: {'top_level_folder': 'rawdata', 'sub_names': ['sub-111', 'sub-002@TO@004'],"
+            in log
         )
 
         assert f"sub_names: ['sub-111', 'sub-002{tags('to')}004']" in log

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -234,9 +234,15 @@ class TestLogging:
         )
 
         if use_all_alias:
-            assert "VariablesState:\nlocals: {\'top_level_folder\': \'rawdata\', \'dry_run\': False" in log
+            assert (
+                "VariablesState:\nlocals: {'top_level_folder': 'rawdata', 'dry_run': False"
+                in log
+            )
         else:
-            assert ("VariablesState:\nlocals: {\'top_level_folder\': \'rawdata\', \'sub_names\': \'all\', \'ses_names\': \'all" in log)
+            assert (
+                "VariablesState:\nlocals: {'top_level_folder': 'rawdata', 'sub_names': 'all', 'ses_names': 'all"
+                in log
+            )
 
         # 'remote' here is rclone terminology
         assert "Creating backend with remote" in log

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -234,12 +234,9 @@ class TestLogging:
         )
 
         if use_all_alias:
-            assert "VariablesState:\nlocals: {'dry_run': False" in log
+            assert "VariablesState:\nlocals: {\'top_level_folder\': \'rawdata\', \'dry_run\': False" in log
         else:
-            assert (
-                "VariablesState:\nlocals: {'sub_names': 'all', 'ses_names': 'all', 'datatype': 'all', 'dry_run': False, 'init_log': True}\ncfg: {'local_path': "
-                in log
-            )
+            assert ("VariablesState:\nlocals: {\'top_level_folder\': \'rawdata\', \'sub_names\': \'all\', \'ses_names\': \'all" in log)
 
         # 'remote' here is rclone terminology
         assert "Creating backend with remote" in log

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -184,7 +184,9 @@ class TestFileTransfer:
             swap_last_folder_only=project.testing_ssh,
         )[0]
 
-        transfer_function(sub_names, ses_names, datatype, init_log=False)
+        transfer_function(
+            "rawdata", sub_names, ses_names, datatype, init_log=False
+        )
 
         if upload_or_download == "download":
             test_utils.swap_local_and_central_paths(

--- a/tests/tests_integration/test_transfer_checks.py
+++ b/tests/tests_integration/test_transfer_checks.py
@@ -31,9 +31,6 @@ class TestTransferChecks(BaseTest):
         `get_local_and_central_file_differences()` and checks the output is
         as expected.
         """
-        if len(top_level_folders) == 1:
-            project.set_top_level_folder(top_level_folders[0])
-
         (local := project.cfg["local_path"]).mkdir(parents=True, exist_ok=True)
         (central := project.cfg["central_path"]).mkdir(
             parents=True, exist_ok=True
@@ -77,8 +74,10 @@ class TestTransferChecks(BaseTest):
 
         results = get_local_and_central_file_differences(
             project.cfg,
-            all_top_level_folder=(
-                True if len(top_level_folders) == 2 else False
+            top_level_folders_to_check=(
+                ["all"]
+                if len(top_level_folders) == 2
+                else [top_level_folders[0]]
             ),
         )
 

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -298,6 +298,7 @@ class TestTuiCreateFolders(TuiBase):
                 == "Invalid character in subject or session value: abc"
             )
             await self.close_messagebox(pilot)
+
             assert not any(
                 list(
                     (
@@ -319,6 +320,7 @@ class TestTuiCreateFolders(TuiBase):
             await self.scroll_to_click_pause(
                 pilot, "#create_folders_create_folders_button"
             )
+
             assert (
                 pilot.app.screen.interface.project.cfg["local_path"]
                 / "rawdata"

--- a/tests/tests_tui/test_tui_logging.py
+++ b/tests/tests_tui/test_tui_logging.py
@@ -34,7 +34,7 @@ class TestTuiLogging(TuiBase):
 
             await pilot.pause(5)
 
-            project.create_folders("sub-001")
+            project.create_folders("rawdata", "sub-001")
 
             await self.check_and_click_onto_existing_project(
                 pilot, project_name

--- a/tests/tests_tui/test_tui_transfer.py
+++ b/tests/tests_tui/test_tui_transfer.py
@@ -199,7 +199,6 @@ class TestTuiTransfer(TuiBase):
                 subs,
                 sessions,
                 "all",
-                top_level_folder,
             )
         (
             _,

--- a/tests/tests_tui/test_tui_transfer.py
+++ b/tests/tests_tui/test_tui_transfer.py
@@ -193,9 +193,13 @@ class TestTuiTransfer(TuiBase):
     ):
         """"""
         for top_level_folder in top_level_folder_list:
-            project.set_top_level_folder(top_level_folder)
             test_utils.make_and_check_local_project_folders(
-                project, subs, sessions, "all", top_level_folder
+                project,
+                top_level_folder,
+                subs,
+                sessions,
+                "all",
+                top_level_folder,
             )
         (
             _,


### PR DESCRIPTION
As discussed in #338 and related to #340, the concept of persistent settings to avoid having to input arguments to the API repeatedly makes less sense now with the TUI. Rather than interactively using API or CLI, interactive use will be through TUI. As API will be mostly scripts we can be a bit more demanding on the required arguments for some public facing methods.

This PR removes the persistent working 'top_level_folder' setting and now requires this as direct input to `create_folders`, the transfer methods, and validation methods. In the end this results in much more explicit code and makes the user more aware of the top-level folder concept.

This requires quite extensive changes to the code but they are all quite basic conceptually. For the review it probably makes most sense just to give feedback on the concept and look at the new signatures of `create_folders` and `upload` or `download`.

This PR also breaks a lot of the CLI which requires `top_level_folder` arguments. I tried adding `NotImplementedError` to the relevant sections but SonarCloud didn't like it. For now comments indicate where the CLI is broken, and the CLI code is removed for now in #347.