### PR TITLE
Return paths from create folders

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -132,7 +132,7 @@ class DataShuttle:
         ses_names: Optional[Union[str, List[str]]] = None,
         datatype: Union[str, List[str]] = "",
         bypass_validation: bool = False,
-    ) -> None:
+    ) -> List[Path]:
         """
         Create a subject / session folder tree in the project
         folder. The passed subject / session names are
@@ -164,6 +164,10 @@ class DataShuttle:
         top_level_folder :
                 Whether to make the folders in `rawdata` or
                 `derivatives`.
+
+        bypass_validation :
+            If `True`, folders will be created even if they are not
+            valid to NeuroBlueprint style.
 
         Notes
         -----
@@ -214,7 +218,7 @@ class DataShuttle:
         )
 
         utils.log("\nMaking folders...")
-        folders.create_folder_trees(
+        created_paths = folders.create_folder_trees(
             self.cfg,
             top_level_folder,
             format_sub,
@@ -229,6 +233,8 @@ class DataShuttle:
         )
 
         ds_logger.close_log_filehandler()
+
+        return created_paths
 
     def _format_and_validate_names(
         self,

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -36,7 +36,7 @@ def create_folder_trees(
     ses_names: Union[str, list],
     datatype: Union[List[str], str],
     log: bool = True,
-) -> None:
+) -> List[Path]:
     """
     Entry method to make a full folder tree. It will
     iterate through all passed subjects, then sessions, then
@@ -64,6 +64,8 @@ def create_folder_trees(
         if is_invalid:
             utils.log_and_raise_error(message, NeuroBlueprintError)
 
+    all_paths = []
+
     for sub in sub_names:
         sub_path = cfg.make_path(
             "local",
@@ -73,8 +75,9 @@ def create_folder_trees(
 
         create_folders(sub_path, log)
 
-        if datatype_passed:
-            make_datatype_folders(cfg, datatype, sub_path, "sub")
+        if not any(ses_names):
+            all_paths.append(sub_path)
+            continue
 
         for ses in ses_names:
             ses_path = cfg.make_path(
@@ -86,7 +89,14 @@ def create_folder_trees(
             create_folders(ses_path, log)
 
             if datatype_passed:
-                make_datatype_folders(cfg, datatype, ses_path, "ses", log=log)
+                datatype_paths = make_datatype_folders(
+                    cfg, datatype, ses_path, "ses", log=log
+                )
+                all_paths.extend(datatype_paths)
+            else:
+                all_paths.append(ses_path)
+
+    return all_paths
 
 
 def make_datatype_folders(
@@ -95,7 +105,7 @@ def make_datatype_folders(
     sub_or_ses_level_path: Path,
     level: str,
     log: bool = True,
-) -> None:
+) -> List[Path]:
     """
     Make datatype folder (e.g. behav) at the sub or ses
     level. Checks folder_class.Folders attributes,
@@ -118,11 +128,16 @@ def make_datatype_folders(
     """
     datatype_items = cfg.get_datatype_as_dict_items(datatype)
 
+    all_datatype_paths = []
+
     for datatype_key, datatype_folder in datatype_items:  # type: ignore
         if datatype_folder.level == level:
             datatype_path = sub_or_ses_level_path / datatype_folder.name
 
             create_folders(datatype_path, log)
+            all_datatype_paths.append(datatype_path)
+
+    return all_datatype_paths
 
 
 # Create Folders Helpers --------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -252,7 +252,9 @@ def add_quotes(string: str):
 # -----------------------------------------------------------------------------
 
 
-def check_folder_tree_is_correct(base_folder, subs, sessions, folder_used):
+def check_folder_tree_is_correct(
+    base_folder, subs, sessions, folder_used, created_folder_list=None
+):
     """
     Automated test that folders are made based
     on the structure specified on project itself.
@@ -293,8 +295,12 @@ def check_folder_tree_is_correct(base_folder, subs, sessions, folder_used):
 
                 if folder_used[key]:
                     check_and_cd_folder(datatype_path)
+                    if created_folder_list:
+                        assert Path(datatype_path) in created_folder_list
                 else:
                     assert not os.path.isdir(datatype_path)
+                    if created_folder_list:
+                        assert Path(datatype_path) not in created_folder_list
 
 
 def check_and_cd_folder(path_):

--- a/tests/tests_integration/test_create_folders.py
+++ b/tests/tests_integration/test_create_folders.py
@@ -95,7 +95,9 @@ class TestMakeFolders(BaseTest):
         subs = ["sub-001", "sub-002"]
         sessions = ["ses-001", "ses-002"]
 
-        project.create_folders("rawdata", subs, sessions, datatypes_to_make)
+        created_folder_list = project.create_folders(
+            "rawdata", subs, sessions, datatypes_to_make
+        )
 
         # Check folder tree is not made but all others are
         test_utils.check_folder_tree_is_correct(
@@ -108,6 +110,7 @@ class TestMakeFolders(BaseTest):
                 "funcimg": funcimg,
                 "anat": anat,
             },
+            created_folder_list=created_folder_list,
         )
 
     def test_custom_folder_names(self, project, monkeypatch):


### PR DESCRIPTION
This PR makes `create_folders` return the created folders. This should be useful for using datashuttle in scripts as you can create folders then grab the path for saving data too.

This is in the new docs #334 and added to tests in this PR.