### PR TITLE
Fix unspecific error when validating names

### DIFF
--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -412,11 +412,8 @@ def validate_names_against_project(
     check that these names are formatted consistently with the
     rest of the project.
 
-    For basic checks, the new subject / session names are concatenated
-    with the existing ones and checked for consistently in
-    `validate_list_of_names()`. Note this implicitly checks that the
-    passed names are consistent with each-other (i.e. within `sub_names`
-    and within `ses_names`).
+    The passed list of names is first validated in `validate_list_of_names()`
+    without reference to the existing project.
 
     Next, checks for duplicate subjects / sessions are performed. For subjects,
     duplicates are checked for project-wide. For sessions, duplicates are
@@ -460,7 +457,7 @@ def validate_names_against_project(
     # Check subjects
     if folder_names["sub"]:
         validate_list_of_names(
-            sub_names + folder_names["sub"],
+            sub_names,
             prefix="sub",
             check_duplicates=False,
             error_or_warn=error_or_warn,
@@ -476,10 +473,9 @@ def validate_names_against_project(
 
     # Check sessions
     if folder_names["sub"] and ses_names is not None:
-        all_ses_names = list(set(chain(*folder_names["ses"].values())))
 
         validate_list_of_names(
-            all_ses_names + ses_names,
+            ses_names,
             "ses",
             check_duplicates=False,
             error_or_warn=error_or_warn,

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -410,12 +410,20 @@ def validate_names_against_project(
     """
     Given a list of subject and (optionally) session names,
     check that these names are formatted consistently with the
-    rest of the project.
+    rest of the project. Unfortunately this function has become
+    quite complex due to the need to only validate the passed
+    list of subject / session names while ignoring validation errors
+    that may already exist in the project.
 
     The passed list of names is first validated in `validate_list_of_names()`
     without reference to the existing project.
 
-    Next, checks for duplicate subjects / sessions are performed. For subjects,
+    Next, checks for inconsistent length of sub or ses values are checked.
+    This cannot be run if there are inconsistent values within the project
+    itself, which will throw an error in this case. Only valid sub / ses
+    names within the project are checked.
+
+    Finally, checks for duplicate subjects / sessions are performed. For subjects,
     duplicates are checked for project-wide. For sessions, duplicates are
     checked for within the corresponding folders. This assumes that
     the passed `ses_names` will be created in all passed `sub_names`.
@@ -449,6 +457,12 @@ def validate_names_against_project(
 
     log : bool
         If `True`, errors or warnings are logged to "datashuttle" logger.
+
+    TODO
+    ----
+    This function is now very and confusing, and in general the validation
+    needs optimisation are there are frequent looping over the same
+    list under different circumstances. See issue #
     """
     folder_names = getters.get_all_sub_and_ses_names(
         cfg, top_level_folder, local_only
@@ -459,14 +473,21 @@ def validate_names_against_project(
         validate_list_of_names(
             sub_names,
             prefix="sub",
-            check_duplicates=False,
+            check_duplicates=True,
             error_or_warn=error_or_warn,
             name_templates=name_templates,
         )
 
+        valid_sub_in_project = strip_invalid_names(folder_names["sub"], "sub")
+
+        check_sub_names_value_length_are_consistent_with_project(
+            sub_names, valid_sub_in_project, error_or_warn, log
+        )
+
         for new_sub in sub_names:
+
             failed, message = new_name_duplicates_existing(
-                new_sub, folder_names["sub"], "sub"
+                new_sub, valid_sub_in_project, "sub"
             )
             if failed:
                 raise_error_or_warn(message, error_or_warn, log)
@@ -477,7 +498,7 @@ def validate_names_against_project(
         validate_list_of_names(
             ses_names,
             "ses",
-            check_duplicates=False,
+            check_duplicates=True,
             error_or_warn=error_or_warn,
         )
 
@@ -485,12 +506,96 @@ def validate_names_against_project(
         # for all sessions currently within those subjects.
         for new_sub in sub_names:
             if new_sub in folder_names["ses"]:
+
+                valid_ses_in_sub = strip_invalid_names(
+                    folder_names["ses"][new_sub], "ses"
+                )
+
+                check_ses_names_value_length_are_consistent_with_project(
+                    ses_names, valid_ses_in_sub, new_sub, error_or_warn, log
+                )
+
                 for new_ses in ses_names:
                     failed, message = new_name_duplicates_existing(
-                        new_ses, folder_names["ses"][new_sub], "ses"
+                        new_ses, valid_ses_in_sub, "ses"
                     )
                     if failed:
                         raise_error_or_warn(message, error_or_warn, log)
+
+
+def check_sub_names_value_length_are_consistent_with_project(
+    sub_names: List[str],
+    valid_sub_in_project: List[str],
+    error_or_warn: Literal["error", "warn"],
+    log: bool,
+) -> None:
+    """
+    Given a list of names we are validating, and a list of
+    all the other names that current exist in the project, check
+    the list of names has consistent value length with all the
+    other names in the project.
+
+    Note this will throw an error if the project odes not have
+    consistent value length as this check will not be possible
+    otherwise.
+    """
+    if value_lengths_are_inconsistent(valid_sub_in_project, "sub")[0]:
+        raise_error_or_warn(
+            "Cannot check names for inconsistent value lengths "
+            "because the subject value lengths are not consistent "
+            "across the project.",
+            error_or_warn,
+            log,
+        )
+    else:
+        failed, message = value_lengths_are_inconsistent(
+            sub_names + valid_sub_in_project, "sub"
+        )
+        if failed:
+            raise_error_or_warn(message, error_or_warn, log)
+
+
+def check_ses_names_value_length_are_consistent_with_project(
+    ses_names: List[str],
+    valid_ses_in_sub: List[str],
+    sub_name: str,
+    error_or_warn: Literal["error", "warn"],
+    log: bool,
+) -> None:
+    """
+    See check_sub_names_value_length_are_consistent_with_project(),
+    this performs the same function for session. Potential to merge
+    with that function, just some minor annoying differences.
+    """
+    if value_lengths_are_inconsistent(valid_ses_in_sub, "ses")[0]:
+        raise_error_or_warn(
+            f"Cannot check names for inconsistent value lengths "
+            f"because the session value lengths for subject "
+            f"{sub_name} are not consistent.",
+            error_or_warn,
+            log,
+        )
+    else:
+        failed, message = value_lengths_are_inconsistent(
+            ses_names + valid_ses_in_sub, "ses"
+        )
+        if failed:
+            raise_error_or_warn(message, error_or_warn, log)
+
+
+def strip_invalid_names(all_names: List[str], prefix: Prefix) -> List[str]:
+    """ """
+    new_list = []
+    for name in all_names:
+        try:
+            utils.get_values_from_bids_formatted_name(
+                [name], prefix, return_as_int=True
+            )[0]
+        except NeuroBlueprintError:
+            continue
+        new_list.append(name)
+
+    return new_list
 
 
 def new_name_duplicates_existing(
@@ -516,12 +621,10 @@ def new_name_duplicates_existing(
     )[0]
 
     for exist_name in existing_names:
-        try:
-            exist_name_id = utils.get_values_from_bids_formatted_name(
-                [exist_name], prefix, return_as_int=True
-            )[0]
-        except NeuroBlueprintError:
-            continue
+
+        exist_name_id = utils.get_values_from_bids_formatted_name(
+            [exist_name], prefix, return_as_int=True
+        )[0]
 
         if exist_name_id == new_name_id:
             if new_name != exist_name:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -520,9 +520,12 @@ def new_name_duplicates_existing(
     )[0]
 
     for exist_name in existing_names:
-        exist_name_id = utils.get_values_from_bids_formatted_name(
-            [exist_name], prefix, return_as_int=True
-        )[0]
+        try:
+            exist_name_id = utils.get_values_from_bids_formatted_name(
+                [exist_name], prefix, return_as_int=True
+            )[0]
+        except NeuroBlueprintError:
+            continue
 
         if exist_name_id == new_name_id:
             if new_name != exist_name:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -460,9 +460,9 @@ def validate_names_against_project(
 
     TODO
     ----
-    This function is now very and confusing, and in general the validation
+    This function is now quite confusing, and in general the validation
     needs optimisation are there are frequent looping over the same
-    list under different circumstances. See issue #
+    list under different circumstances. See issue #355
     """
     folder_names = getters.get_all_sub_and_ses_names(
         cfg, top_level_folder, local_only

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -181,7 +181,7 @@ class TestValidation(BaseTest):
         subs = ["sub-001_id-123", "sub-002_id-124"]
         project.create_folders("rawdata", subs)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub-001_id-125")
 
         assert (
@@ -195,7 +195,7 @@ class TestValidation(BaseTest):
         sessions = ["ses-001_date-1605", "ses-002_date-1606"]
         project.create_folders("rawdata", subs, sessions)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders(
                 "rawdata", "sub-001_id-123", "ses-002_date-1607"
             )
@@ -215,7 +215,7 @@ class TestValidation(BaseTest):
         """
         project.create_folders("rawdata", "sub-1")
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub-001")
 
         assert "Inconsistent value lengths for the key sub were found" in str(
@@ -224,7 +224,7 @@ class TestValidation(BaseTest):
 
         project.create_folders("rawdata", "sub-1", "ses-3")
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub-1", "ses-003")
 
         assert "Inconsistent value lengths for the key ses were found" in str(
@@ -239,13 +239,13 @@ class TestValidation(BaseTest):
         project.create_folders("rawdata", "sub-001")
 
         for bad_sub_name in ["sub-001_@DATE@", "sub-001_extra-key"]:
-            with pytest.raises(BaseException) as e:
+            with pytest.raises(NeuroBlueprintError) as e:
                 project.create_folders("rawdata", bad_sub_name, "ses-001")
             assert "A sub already exists" in str(e.value)
 
         project.create_folders("rawdata", "sub-001", "ses-001")
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders(
                 "rawdata", "sub-001", "ses-001_extra-key", "behav"
             )
@@ -253,13 +253,13 @@ class TestValidation(BaseTest):
             e.value
         )
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders(
                 "rawdata", "sub-001_extra-key", "ses-001", "behav"
             )
         assert "A sub already exists " in str(e.value)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders(
                 "rawdata", "sub-001_extra-key", "ses-001_@DATE@", "behav"
             )
@@ -271,7 +271,7 @@ class TestValidation(BaseTest):
 
         # Finally check that in a list of subjects, only the correct subject
         # with duplicate session is caught.
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders(
                 "rawdata", ["sub-001", "sub-002"], "ses-002_@DATE@", "ephys"
             )
@@ -289,14 +289,14 @@ class TestValidation(BaseTest):
         prefixed as 'sub-sub_100` but when the value if `sub-` is
         extracted, it is also "sub" and so an error is raised.
         """
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub_100")
 
         assert "Invalid character in subject or session value: sub" in str(
             e.value
         )
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub-001", "ses_100")
 
         assert "Invalid character in subject or session value: ses" in str(
@@ -328,7 +328,7 @@ class TestValidation(BaseTest):
         project.create_folders("rawdata", "sub-001")
 
         # Now the bad sub is caught as we check against central also.
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             project.validate_project(
                 "rawdata", error_or_warn="error", local_only=False
             )
@@ -528,7 +528,7 @@ class TestValidation(BaseTest):
         # Now check a clashing subject (sub-1) throws an error
         sub_names = ["sub-2_id-b", "sub-1_id-11", "sub-3_id-c"]
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             validation.validate_names_against_project(
                 project.cfg,
                 "rawdata",
@@ -587,7 +587,7 @@ class TestValidation(BaseTest):
             error_or_warn="error",
         )
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(NeuroBlueprintError) as e:
             validation.validate_names_against_project(
                 project.cfg,
                 "rawdata",


### PR DESCRIPTION
This fixes an annoying issue with validation on the TUI in which if there was an invalid name in the project it would show a validation error on the subject / session input box. This is quite confusing at it was unrelated to the actual name in the box.

This PR skips checking against invalid names for duplicate subject / sessions. This means it will only error if there is a duplicate with a valid NeuroBlueprint name. This is fine as if they input an invalid NeuroBlueprint name, even if there is a duplicate it will just show a standard NeuroBlueprint error.



