### PR TITLE
pin textual version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fancylog",
     "simplejson",
     "pyperclip",
-    "textual",
+    "textual==0.54.0",
     "show-in-file-manager",
     "gitpython",
 ]


### PR DESCRIPTION
This PR tries to fix recent tests randomly failing by pinning to a `textual` version where I beleive this did not occur.

The issue is tests [randomly failing](https://github.com/neuroinformatics-unit/datashuttle/actions/runs/8612033113/job/23600375256)  with error:

`E           textual.pilot.OutOfBounds: Target offset is outside of currently-visible screen region.`

Usually re-running the tests fixes the issue. I believe it is a textual-side issue but that is not confirmed. Hopefully this version pin will shed some light on it. 