### PR TITLE
Rename `get_next_sub_number` and `get_next_ses_number`.

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -851,7 +851,7 @@ class DataShuttle:
         local_only: bool = False,
     ) -> str:
         """
-        Convenience function for get_next_sub_or_ses_number
+        Convenience function for get_next_sub_or_ses
         to find the next subject number.
 
         Parameters
@@ -864,7 +864,7 @@ class DataShuttle:
             If `True, only get names from `local_path`, otherwise from
             `local_path` and `central_path`.
         """
-        return getters.get_next_sub_or_ses_number(
+        return getters.get_next_sub_or_ses(
             self.cfg,
             top_level_folder,
             sub=None,
@@ -882,7 +882,7 @@ class DataShuttle:
         local_only: bool = False,
     ) -> str:
         """
-        Convenience function for get_next_sub_or_ses_number
+        Convenience function for get_next_sub_or_ses
         to find the next session number.
 
         Parameters
@@ -901,7 +901,7 @@ class DataShuttle:
             If `True, only get names from `local_path`, otherwise from
             `local_path` and `central_path`.
         """
-        return getters.get_next_sub_or_ses_number(
+        return getters.get_next_sub_or_ses(
             self.cfg,
             top_level_folder,
             sub=sub,

--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -844,7 +844,7 @@ class DataShuttle:
         return getters.get_existing_project_paths()
 
     @check_configs_set
-    def get_next_sub_number(
+    def get_next_sub(
         self,
         top_level_folder: TopLevelFolder,
         return_with_prefix: bool = True,
@@ -874,7 +874,7 @@ class DataShuttle:
         )
 
     @check_configs_set
-    def get_next_ses_number(
+    def get_next_ses(
         self,
         top_level_folder: TopLevelFolder,
         sub: str,

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -372,23 +372,23 @@ class Interface:
         cfg_to_load.convert_str_and_pathlib_paths(cfg_to_load, "path_to_str")
         return cfg_to_load
 
-    def get_next_sub_number(
+    def get_next_sub(
         self, top_level_folder: TopLevelFolder
     ) -> InterfaceOutput:
         try:
-            next_sub = self.project.get_next_sub_number(
+            next_sub = self.project.get_next_sub(
                 top_level_folder, return_with_prefix=True, local_only=True
             )
             return True, next_sub
         except BaseException as e:
             return False, str(e)
 
-    def get_next_ses_number(
+    def get_next_ses(
         self, top_level_folder: TopLevelFolder, sub: str
     ) -> InterfaceOutput:
 
         try:
-            next_ses = self.project.get_next_ses_number(
+            next_ses = self.project.get_next_ses(
                 top_level_folder, sub, return_with_prefix=True, local_only=True
             )
             return True, next_ses

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -276,9 +276,7 @@ class CreateFoldersTab(TreeAndInputTab):
         ]["create_tab"]
 
         if prefix == "sub":
-            success, output = self.interface.get_next_sub_number(
-                top_level_folder
-            )
+            success, output = self.interface.get_next_sub(top_level_folder)
             if not success:
                 self.mainwindow.show_modal_error_dialog(output)
                 return
@@ -306,7 +304,7 @@ class CreateFoldersTab(TreeAndInputTab):
             else:
                 sub = sub_names[0]
 
-            success, output = self.interface.get_next_ses_number(
+            success, output = self.interface.get_next_ses(
                 top_level_folder, sub
             )
             if not success:

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -25,7 +25,7 @@ from datashuttle.utils.custom_exceptions import (
 )
 
 
-def get_next_sub_or_ses_number(
+def get_next_sub_or_ses(
     cfg: Configs,
     top_level_folder,
     sub: Optional[str],
@@ -124,7 +124,7 @@ def get_max_sub_or_ses_num_and_value_length(
     all_folders : List[str]
         A list of BIDS-style formatted folder names.
 
-    see `get_next_sub_or_ses_number()` for other arguments.
+    see `get_next_sub_or_ses()` for other arguments.
 
     Returns
     -------

--- a/docs/source/pages/tutorials/getting_started.md
+++ b/docs/source/pages/tutorials/getting_started.md
@@ -344,8 +344,8 @@ If the folder names will break with the specification, an error will be
 raised and the folders will not be created.
 ```
 
-Two useful methods to automate folder creation are `get_next_sub_number()` and
-`get_next_ses_number()`. These can be used to automatically get the next subject
+Two useful methods to automate folder creation are `get_next_sub()` and
+`get_next_ses()`. These can be used to automatically get the next subject
 and session names in a project.
 
 For example, to get the next subject
@@ -353,8 +353,8 @@ in this project (`sub-002`) and the next session for that subject (in this case,
 as it is the first session for `sub-002`, it will be `ses-001`) we can run
 
 ```python
-next_sub = project.get_next_sub_number("rawdata", local_only=True)                # returns "sub-001"
-next_ses = project.get_next_ses_number("rawdata", sub=next_sub, local_only=True)  # returns "ses-001"
+next_sub = project.get_next_sub("rawdata", local_only=True)                # returns "sub-001"
+next_ses = project.get_next_ses("rawdata", sub=next_sub, local_only=True)  # returns "ses-001"
 
 project.create_folders(
     "rawdata",

--- a/tests/tests_integration/test_create_folders.py
+++ b/tests/tests_integration/test_create_folders.py
@@ -283,9 +283,7 @@ class TestMakeFolders(BaseTest):
 
     @pytest.mark.parametrize("top_level_folder", ["rawdata", "derivatives"])
     @pytest.mark.parametrize("return_with_prefix", [True, False])
-    def test_get_next_sub_number(
-        self, project, return_with_prefix, top_level_folder
-    ):
+    def test_get_next_sub(self, project, return_with_prefix, top_level_folder):
         """
         Test that the next subject number is suggested correctly.
         This takes the union of subjects available in the local and
@@ -297,9 +295,7 @@ class TestMakeFolders(BaseTest):
             project, top_level_folder, ["001", "002", "003"]
         )
 
-        new_num = project.get_next_sub_number(
-            top_level_folder, return_with_prefix
-        )
+        new_num = project.get_next_sub(top_level_folder, return_with_prefix)
 
         assert new_num == "sub-004" if return_with_prefix else "004"
 
@@ -308,38 +304,32 @@ class TestMakeFolders(BaseTest):
 
         shutil.rmtree(project.cfg["local_path"] / top_level_folder)
 
-        new_num = project.get_next_sub_number(
-            top_level_folder, return_with_prefix
-        )
+        new_num = project.get_next_sub(top_level_folder, return_with_prefix)
         assert new_num == "sub-004" if return_with_prefix else "004"
 
         # Add large-sub num folders to local and check all are detected.
         project.create_folders(top_level_folder, ["004", "005"])
 
-        new_num = project.get_next_sub_number(
-            top_level_folder, return_with_prefix
-        )
+        new_num = project.get_next_sub(top_level_folder, return_with_prefix)
         assert new_num == "sub-006" if return_with_prefix else "006"
 
         # check `local_path` option
         os.makedirs(project.cfg["central_path"] / top_level_folder / "sub-006")
-        new_num = project.get_next_sub_number(
+        new_num = project.get_next_sub(
             top_level_folder, return_with_prefix, local_only=False
         )
         assert new_num == "sub-007" if return_with_prefix else "007"
 
-        new_num = project.get_next_sub_number(
+        new_num = project.get_next_sub(
             top_level_folder, return_with_prefix, local_only=True
         )
         assert new_num == "sub-006" if return_with_prefix else "006"
 
     @pytest.mark.parametrize("top_level_folder", ["rawdata", "derivatives"])
     @pytest.mark.parametrize("return_with_prefix", [True, False])
-    def test_get_next_ses_number(
-        self, project, return_with_prefix, top_level_folder
-    ):
+    def test_get_next_ses(self, project, return_with_prefix, top_level_folder):
         """
-        Almost identical to test_get_next_sub_number() but with calls
+        Almost identical to test_get_next_sub() but with calls
         for searching sessions. This could be combined with
         above but reduces readability, so leave with some duplication.
 
@@ -353,12 +343,10 @@ class TestMakeFolders(BaseTest):
         )
 
         # Test the next sub and ses number are correct
-        new_num = project.get_next_sub_number(
-            top_level_folder, return_with_prefix
-        )
+        new_num = project.get_next_sub(top_level_folder, return_with_prefix)
         assert new_num == "sub-10" if return_with_prefix else "10"
 
-        new_num = project.get_next_ses_number(
+        new_num = project.get_next_ses(
             top_level_folder, sub, return_with_prefix
         )
         assert new_num == "ses-004" if return_with_prefix else "004"
@@ -369,12 +357,10 @@ class TestMakeFolders(BaseTest):
 
         shutil.rmtree(project.cfg["local_path"] / top_level_folder)
 
-        new_num = project.get_next_sub_number(
-            top_level_folder, return_with_prefix
-        )
+        new_num = project.get_next_sub(top_level_folder, return_with_prefix)
         assert new_num == "sub-10" if return_with_prefix else "10"
 
-        new_num = project.get_next_ses_number(
+        new_num = project.get_next_ses(
             top_level_folder, sub, return_with_prefix
         )
         assert new_num == "ses-004" if return_with_prefix else "004"
@@ -383,7 +369,7 @@ class TestMakeFolders(BaseTest):
         # the next session is updated accordingly.
         project.create_folders(top_level_folder, sub, ["004", "005"])
 
-        new_num = project.get_next_ses_number(
+        new_num = project.get_next_ses(
             top_level_folder, sub, return_with_prefix
         )
         assert new_num == "ses-006" if return_with_prefix else "006"
@@ -392,12 +378,12 @@ class TestMakeFolders(BaseTest):
         os.makedirs(
             project.cfg["central_path"] / top_level_folder / sub / "ses-006"
         )
-        new_num = project.get_next_ses_number(
+        new_num = project.get_next_ses(
             top_level_folder, sub, return_with_prefix, local_only=False
         )
         assert new_num == "ses-007" if return_with_prefix else "007"
 
-        new_num = project.get_next_ses_number(
+        new_num = project.get_next_ses(
             top_level_folder, sub, return_with_prefix, local_only=True
         )
         assert new_num == "ses-006" if return_with_prefix else "006"

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -72,14 +72,14 @@ class TestFormatting(BaseTest):
         )
 
         with pytest.warns(UserWarning) as w:
-            project.get_next_sub_number(top_level_folder)
+            project.get_next_sub(top_level_folder)
         assert (
             str(w[0].message) == "A subject number has been skipped, "
             "currently used subject numbers are: [1, 2, 4]"
         )
 
         with pytest.warns(UserWarning) as w:
-            project.get_next_ses_number(top_level_folder, "sub-02")
+            project.get_next_ses(top_level_folder, "sub-02")
         assert (
             str(w[0].message)
             == "A subject number has been skipped, currently "


### PR DESCRIPTION
Straight CTRL+R rename of `get_next_sub_number` and `get_next_ses_number` to `get_next_sub` and `get_next_ses` as these functions actually return by default the key-value pair (e.g. `sub-001`).

Performed on both `.py` files and `.md` files so should cover docs. Checked with hypen separators instead of underscore (but did not find any as we don't have CLI anymore).

