### PR TITLE
Remove central local path exist requirement

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -110,8 +110,6 @@ def check_dict_values_raise_on_fail(config_dict: Configs) -> None:
     for path_type in ["local_path", "central_path"]:
         raise_on_bad_path_syntax(config_dict[path_type].as_posix(), path_type)
 
-    check_folder_above_project_name_exists(config_dict)
-
     # Check SSH settings
     if config_dict["connection_method"] == "ssh" and (
         not config_dict["central_host_id"]
@@ -160,49 +158,6 @@ def raise_on_bad_path_syntax(
                 "with no dot syntax.",
                 ConfigError,
             )
-
-
-def check_folder_above_project_name_exists(config_dict: Configs) -> None:
-    """
-    Throw an error if the path above the project root does not exist.
-    This validation is necessary (rather than simply
-    creating the passed folders) to ensure the `local_path` or
-    `central_path` are not accidentally set to a wrong
-    location.
-
-    If the `connection_method` is "ssh" it is not possible to check the central
-    path at this stage.
-    """
-
-    def base_error_message(path_name: str) -> str:
-        return (
-            f"The {path_name}: {config_dict[path_name].parent} "
-            f"that the project folder will reside in does not yet "
-            f"exist. Please ensure the path shown in this "
-            f"message exists before continuing."
-        )
-
-    if not (config_dict["local_path"].parent.is_dir()):
-        if config_dict["connection_method"] == "ssh":
-            extra_warning = (
-                "Also make sure the central_path` is correct, as datashuttle "
-                "cannot check it via SSH at this stage."
-            )
-        else:
-            extra_warning = ""
-
-        utils.log_and_raise_error(
-            f"{base_error_message('local_path')} {extra_warning}",
-            FileNotFoundError,
-        )
-
-    if (
-        config_dict["connection_method"] == "local_filesystem"
-        and not config_dict["central_path"].parent.is_dir()
-    ):
-        utils.log_and_raise_error(
-            base_error_message("central_path"), FileNotFoundError
-        )
 
 
 def check_config_types(config_dict: Configs) -> None:

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -94,35 +94,6 @@ class TestConfigs(BaseTest):
 
         assert "must contain the full folder path with no " in str(e.value)
 
-    @pytest.mark.parametrize("path_type", ["local_path", "central_path"])
-    def test_non_existant_local_path(
-        self, no_cfg_project, path_type, non_existent_path, existent_path
-    ):
-        """
-        Check that if the `local_path` and `central_path` that holds the
-        project root does not exist when passed to configs, that an error
-        is raised. Note that this error is only raised for `central_path`
-        if `connection_method` is `"local_filesystem"`.
-        See `test_additional_error_text_when_ssh_used()` for when ssh is used.
-        """
-        if path_type == "local_path":
-            local_path = non_existent_path
-            central_path = existent_path
-        else:
-            local_path = existent_path
-            central_path = non_existent_path
-
-        with pytest.raises(BaseException) as e:
-            no_cfg_project.make_config_file(
-                local_path / no_cfg_project.project_name,
-                central_path / no_cfg_project.project_name,
-                "local_filesystem",
-            )
-
-        assert f"The {path_type}: {non_existent_path} that the project" in str(
-            e.value
-        )
-
     def test_additional_error_text_when_ssh_used(
         self, no_cfg_project, non_existent_path, existent_path
     ):

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -94,41 +94,6 @@ class TestConfigs(BaseTest):
 
         assert "must contain the full folder path with no " in str(e.value)
 
-    def test_additional_error_text_when_ssh_used(
-        self, no_cfg_project, non_existent_path, existent_path
-    ):
-        """
-        If SSH is used as `connection_method`, if `local_path` does not exist
-        an extra message is printed to warn to check the `central_path`, because
-        it cannot be checked.
-
-        Currently if SSH is used and the central path does not exist,
-        no error is raised because it is not possible to check.
-        """
-        with pytest.raises(BaseException) as e:
-            no_cfg_project.make_config_file(
-                non_existent_path / no_cfg_project.project_name,
-                existent_path / no_cfg_project.project_name,
-                "ssh",
-                central_host_id="fake_id",
-                central_host_username="fake_username",
-            )
-
-        assert (
-            "Also make sure the central_path` is correct, as datashuttle "
-            "cannot check it via SSH at this stage." in str(e.value)
-        )
-
-        # This should not raise an error, even though the path does not
-        # exist, because it is not possible to check over SSH.
-        no_cfg_project.make_config_file(
-            existent_path / no_cfg_project.project_name,
-            non_existent_path / no_cfg_project.project_name,
-            "ssh",
-            central_host_id="fake_id",
-            central_host_username="fake_username",
-        )
-
     def test_no_ssh_options_set_on_make_config_file(self, no_cfg_project):
         """
         Check that program will assert if not all ssh options

--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -354,7 +354,7 @@ class TestTuiConfigs(TuiBase):
                 pilot, "#mainwindow_new_project_button"
             )
 
-            await self.fill_input(pilot, "#configs_name_input", "a")
+            await self.fill_input(pilot, "#configs_name_input", "a@@")
             await self.fill_input(pilot, "#configs_local_path_input", "a")
             await self.fill_input(pilot, "#configs_central_path_input", "b")
             await self.scroll_to_click_pause(
@@ -362,10 +362,10 @@ class TestTuiConfigs(TuiBase):
             )
 
             assert (
-                "The central_path: b that the project folder will reside in does not yet exist"
-                in pilot.app.screen.query_one(
+                pilot.app.screen.query_one(
                     "#messagebox_message_label"
                 ).renderable._text[0]
+                == "The project name must contain alphanumeric characters only."
             )
             await pilot.pause()
 


### PR DESCRIPTION
This PR removes the requirement for the path above the project folder to actually exist during project setup. I thought it was already removed 🤔.

No docs changes required, one test that checked the error was raised is removed.