### PR TITLE
Reworking logging.

### DIFF
--- a/datashuttle/utils/ds_logger.py
+++ b/datashuttle/utils/ds_logger.py
@@ -27,9 +27,8 @@ def get_logger():
 
 def logging_is_active():
     logger_exists = get_logger_name() in logging.root.manager.loggerDict
-    if logger_exists:
-        if get_logger().handlers != []:
-            return True
+    if logger_exists and get_logger().handlers != []:
+        return True
     return False
 
 

--- a/datashuttle/utils/ds_logger.py
+++ b/datashuttle/utils/ds_logger.py
@@ -26,7 +26,11 @@ def get_logger():
 
 
 def logging_is_active():
-    return get_logger_name() in logging.root.manager.loggerDict
+    logger_exists = get_logger_name() in logging.root.manager.loggerDict
+    if logger_exists:
+        if get_logger().handlers != []:
+            return True
+    return False
 
 
 def start(
@@ -109,6 +113,7 @@ def close_log_filehandler() -> None:
     Remove handlers from all loggers.
     """
     logger = get_logger()
+    logger.debug("Finished logging.")
     handlers = logger.handlers[:]
     for handler in handlers:
         logger.removeHandler(handler)

--- a/datashuttle/utils/ds_logger.py
+++ b/datashuttle/utils/ds_logger.py
@@ -17,6 +17,18 @@ import datashuttle as package_to_log
 from datashuttle.utils import utils
 
 
+def get_logger_name():
+    return "datashuttle"
+
+
+def get_logger():
+    return logging.getLogger(get_logger_name())
+
+
+def logging_is_active():
+    return get_logger_name() in logging.root.manager.loggerDict
+
+
 def start(
     path_to_log: Path,
     command_name: str,
@@ -38,8 +50,10 @@ def start(
         file_log_level="DEBUG",
         write_git=True,
         log_to_console=False,
+        logger_name=get_logger_name(),
     )
-    logging.info(f"Starting logging for command {command_name}")
+    logger = get_logger()
+    logger.info(f"Starting logging for command {command_name}")
 
 
 def get_logging_filename(command_name: str) -> str:
@@ -94,7 +108,7 @@ def close_log_filehandler() -> None:
     """
     Remove handlers from all loggers.
     """
-    logger = logging.getLogger()
+    logger = get_logger()
     handlers = logger.handlers[:]
     for handler in handlers:
         logger.removeHandler(handler)

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -25,7 +25,6 @@ def log(message: str) -> None:
     """
     if ds_logger.logging_is_active():
         logger = ds_logger.get_logger()
-        breakpoint()
         logger.debug(message)
 
 
@@ -49,6 +48,14 @@ def log_and_raise_error(message: str, exception: Any) -> None:
     raise_error(message, exception)
 
 
+def warn(message: str, log: bool) -> None:
+    """ """
+    if log and ds_logger.logging_is_active():
+        logger = ds_logger.get_logger()
+        logger.warning(message)
+    warnings.warn(message)
+
+
 def raise_error(message: str, exception) -> None:
     """
     Centralized way to raise an error. The logger is closed
@@ -57,14 +64,6 @@ def raise_error(message: str, exception) -> None:
     """
     ds_logger.close_log_filehandler()
     raise exception(message)
-
-
-def warn(message: str, log: bool) -> None:
-    """ """
-    if log and ds_logger.logging_is_active():
-        logger = ds_logger.get_logger()
-        logger.warning(message)
-    warnings.warn(message)
 
 
 def print_message_to_user(

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import re
 import traceback
 import warnings
@@ -24,8 +23,10 @@ def log(message: str) -> None:
     Log the message to the main initialised
     logger.
     """
-    logger = logging.getLogger("datashuttle")
-    logger.debug(message)
+    if ds_logger.logging_is_active():
+        logger = ds_logger.get_logger()
+        breakpoint()
+        logger.debug(message)
 
 
 def log_and_message(message: str, use_rich: bool = False) -> None:
@@ -41,8 +42,8 @@ def log_and_raise_error(message: str, exception: Any) -> None:
     """
     Log the message before raising the same message as an error.
     """
-    if "datashuttle" in logging.root.manager.loggerDict.keys():
-        logger = logging.getLogger("datashuttle")
+    if ds_logger.logging_is_active():
+        logger = ds_logger.get_logger()
         logger.error(f"\n\n{' '.join(traceback.format_stack(limit=5))}")
         logger.error(message)
     raise_error(message, exception)
@@ -60,8 +61,8 @@ def raise_error(message: str, exception) -> None:
 
 def warn(message: str, log: bool) -> None:
     """ """
-    if log:
-        logger = logging.getLogger("datashuttle")
+    if log and ds_logger.logging_is_active():
+        logger = ds_logger.get_logger()
         logger.warning(message)
     warnings.warn(message)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "PyYAML",
     "requests",
     "rich",
-    "fancylog",
+    "fancylog>=0.4.1",
     "simplejson",
     "pyperclip",
     "textual",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "PyYAML",
     "requests",
     "rich",
-    "fancylog>=0.4.1",
+    "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
     "textual",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -581,7 +581,7 @@ def set_datashuttle_loggers(disable):
     of test_logging.py and turned back off during
     tear-down.
     """
-    for name in ["datashuttle", "rich"]:
+    for name in [ds_logger.get_logger_name(), "rich"]:
         logger = logging.getLogger(name)
         logger.disabled = disable
 


### PR DESCRIPTION
This PR rewords how the logging works due to a regression in which the root logger rather than a named `"datashuttle"` logger was used. I am quite confused as to what happened here as `fancylog` has never created a named logger. It happened to work because `"datashuttle"` logger was propagating through the `FileHandler` stream on the root logger that `fancylog` had setup. 

Anyway, this PR:

1) Is based on recent fancylog changes (v0.4.2) which allow starting a named logger (i.e. `logger=getLogger("some_name")` rather than `logger=getLogger()` which gets the root).
2) Now all interaction with the logger in datashuttle is ensured to be through this named logger. This is supported by a number of convenience functions in `ds_logger.py`.
3) Add tests that the logger is setup and logging as expected.


This PR requires #387 for tests to pass, as new version of `fancylog` requires >=Python3.9. It requires no further tests or documentation changes.

