### PR TITLE
Improve developer install docs.

### DIFF
--- a/docs/source/pages/how_tos/install.md
+++ b/docs/source/pages/how_tos/install.md
@@ -56,16 +56,34 @@ pip install datashuttle
 :::
 
 :::{tab-item} Developers
-To get the latest development version, clone the
+
+`pip` must be used to install all developer tools. As
+[Rclone](https://rclone.org/)
+is not
+available through `pip`, you can
+install `Rclone` with `Conda`:
+
+```sh
+conda install -c conda-forge rclone
+```
+
+or using the [standalone RClone install](https://rclone.org/downloads/).
+
+Next, clone the **datashuttle**
 [GitHub repository](https://github.com/neuroinformatics-unit/datashuttle/)
-and then run from inside the repository
+to get the latest development version.
+
+To install **datashuttle** and its developer dependencies,
+run the follow commoand from inside the repository:
 
 ```sh
 pip install -e .[dev]  # works on most shells
 pip install -e '.[dev]'  # works on zsh (the default shell on macOS)
 ```
 
-This will install the package in editable mode, including all `dev` dependencies.
+This will install an 'editable' version of **datashuttle**, meaning
+any changes you make to the cloned code will be immediately
+reflected in the installed package.
 :::
 
 ::::

--- a/docs/source/pages/how_tos/install.md
+++ b/docs/source/pages/how_tos/install.md
@@ -61,20 +61,20 @@ pip install datashuttle
 [Rclone](https://rclone.org/)
 is not
 available through `pip`, you can
-install `Rclone` with `Conda`:
+install `Rclone` with `Conda`
 
 ```sh
 conda install -c conda-forge rclone
 ```
 
-or using the [standalone RClone install](https://rclone.org/downloads/).
+or using the [RClone's standalone installer](https://rclone.org/downloads/).
 
 Next, clone the **datashuttle**
 [GitHub repository](https://github.com/neuroinformatics-unit/datashuttle/)
 to get the latest development version.
 
 To install **datashuttle** and its developer dependencies,
-run the follow commoand from inside the repository:
+run the follow command from inside the repository:
 
 ```sh
 pip install -e .[dev]  # works on most shells

--- a/docs/source/pages/how_tos/install.md
+++ b/docs/source/pages/how_tos/install.md
@@ -29,7 +29,7 @@ Next, create and activate an environment.  You can call your environment whateve
 we've used `datashuttle-env`:
 
 ```sh
-conda create -n datashuttle-env python=3.10
+conda create -n datashuttle-env
 conda activate datashuttle-env
 ```
 
@@ -57,11 +57,10 @@ pip install datashuttle
 
 :::{tab-item} Developers
 
-`pip` must be used to install all developer tools. As
+`pip` must be used to install developer dependencies.
+As
 [Rclone](https://rclone.org/)
-is not
-available through `pip`, you can
-install `Rclone` with `Conda`
+is not available through `pip`, you can install `Rclone` with `Conda`
 
 ```sh
 conda install -c conda-forge rclone


### PR DESCRIPTION
Small improvement and additions to the 'Developers' tab on 'How to Install' page. It:

- Adds a section on installing rclone to the developer tab, which was missing
- Removes the pinned python version on conda install, as discussed in #389 