### PR TITLE
Deprecate Python 3.8 and add 3.12

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, macos-14, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ authors = [
     {name = "Adam Tyson", email = "code@adamltyson.com"},
     {name = "Niko Sirmpilatze", email = "niko.sirbiladze@gmail.com"},
 ]
-description = "DataShuttle automates the creation and management of standardised neuroscience project folders."
+description = "DataShuttle automates the creation, validation and transfer of neuroscience project folders."
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version"]
 license = {text = "BSD-3-Clause"}
 
@@ -28,10 +28,10 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License",
 ]
@@ -90,7 +90,7 @@ exclude = ["tests*", "docs*"]
 addopts = "--cov=datashuttle"
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']
 skip-string-normalization = false
 line-length = 79
 


### PR DESCRIPTION
This PR:

1) Deprecates python 3.8 (removes from `pyproject.toml` and test coverage)
2) Adds python 3.12
3) Changes the tagline in the `pyproject.toml`
4) Changes the development status in `pyproject.toml` from pre-alpha to beta.


No documentation or tests are required. 