### PR TITLE
Update workflow file to install datashuttle.

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -23,6 +23,7 @@ jobs:
       run:
         shell: bash -l {0}
 
+    # This duplicates `test_conda_install` stratergy.
     strategy:
       matrix:
         os: [windows-latest, macos-latest, macos-14, ubuntu-latest]
@@ -37,11 +38,12 @@ jobs:
           auto-update-conda: true
           channels: conda-forge
           activate-environment: "true"
-      - name: Install RClone
+      - name: Install Conda Install
         run: |
           conda activate true
-          conda install -c conda-forge rclone
-      - name: Install dependencies
+          conda install -c conda-forge datashuttle
+          conda uninstall datashuttle
+      - name: Install local datashuttle
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -38,12 +38,12 @@ jobs:
           auto-update-conda: true
           channels: conda-forge
           activate-environment: "true"
-      - name: Install Conda Install
+      - name: Install datashuttle with conda
         run: |
           conda activate true
           conda install -c conda-forge datashuttle
           conda uninstall datashuttle --force
-      - name: Install local datashuttle
+      - name: Install local datashuttle for testing
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           conda activate true
           conda install -c conda-forge datashuttle
-          conda uninstall datashuttle
+          conda uninstall datashuttle --force
       - name: Install local datashuttle
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -42,9 +42,10 @@ jobs:
         run: |
           conda activate true
           conda install -c conda-forge datashuttle
-          conda uninstall datashuttle --force
       - name: Install local datashuttle for testing
         run: |
+          # --force will only uninstall datashuttle not dependencies
+          conda uninstall datashuttle --force
           python -m pip install --upgrade pip
           pip install .[dev]
       - name: Test

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -37,10 +37,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true
           channels: conda-forge
-          activate-environment: "true"
+          activate-environment: "datashuttle-test"
       - name: Install datashuttle with conda
         run: |
-          conda activate true
+          conda activate datashuttle-test
           conda install -c conda-forge datashuttle
       - name: Install local datashuttle for testing
         run: |

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -23,10 +23,9 @@ jobs:
       run:
         shell: bash -l {0}
 
-    # This duplicates `test_conda_install` stratergy.
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-14, macos-13]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -25,6 +25,7 @@ jobs:
 
     strategy:
       matrix:
+        # macos-14 is M1, macos-13 is intel
         os: [windows-latest, ubuntu-latest, macos-14, macos-13]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 


### PR DESCRIPTION
This PR changes the github workflow to install datashuttle as recommended in the docs. #393 shows that this was not sufficiently tested. 

Currently it's not ideal, the full datashuttle install is performed from conda. Then, the datashuttle package itself is uninstalled so that the local version that has the tests can be installed. It would be nicer in many respects to have this as a different job. The reason I did do it this way is because I could find no (simple) way to share the strategy matrix across jobs. It would also require all the conda activation setup, so basically copy and pasting the whole job to change one line. However, maybe the isolation between jobs would be worth it...

This change does now leave the dependency install from `pip` untested. This could also be tested by using a different job. However, I'm not sure if it is worth it due to the duplication issue mentioned above, and the required spin-up of lots more runners. If we test the recommended install method that should be enough?

