### PR TITLE
Unpin sphinx 7.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ requests
 rich
 setuptools_scm
 simplejson
-sphinx<7.2
+sphinx
 sphinx-argparse
 sphinx-design
 sphinx_autodoc_typehints


### PR DESCRIPTION
This PR unpins sphinx, closes #397 that describes the issue.

Tested locally and it builds OK, docs look good. No tests or further documentation required. However, in the new style, the dropdown menus all have a thick green border around them. I will probably turn this off unless @neuroinformatics-unit/neuroinformatics-all  particularly likes them (for me it makes the pages look too busy):

![image](https://github.com/neuroinformatics-unit/datashuttle/assets/55797454/9570246e-0650-454c-8404-606decda860a)






