### PR TITLE
Remove unused sphinx-argparse dependency.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,5 @@ rich
 setuptools_scm
 simplejson
 sphinx
-sphinx-argparse
 sphinx-design
 sphinx_autodoc_typehints

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,6 @@ extensions = [
     "nbsphinx",
     "sphinx_autodoc_typehints",
     "sphinx_design",
-    "sphinxarg.ext",
 ]
 
 # Configure the myst parser to enable cool markdown features


### PR DESCRIPTION
This PR removes the now unused `sphinx-argparse` dependency (that was left over from when we had CLI / CLI docs).

Tested by building locally, everything worked without any new warnings.