### PR TITLE
Allow tags in name template regexp.

### DIFF
--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -237,13 +237,28 @@ def update_names_with_datetime(names: List[str]) -> None:
     Format using key-value pair for bids, i.e. date-20221223_time-
     """
     date = str(datetime.datetime.now().date().strftime("%Y%m%d"))
-    date_with_key = f"date-{date}"
+    date_with_key = format_date(date)
 
     time_ = datetime.datetime.now().time().strftime("%H%M%S")
-    time_with_key = f"time-{time_}"
+    time_with_key = format_time(time_)
 
-    datetime_with_key = f"datetime-{date}T{time_}"
+    datetime_with_key = format_datetime(date, time_)
 
+    replace_date_time_tags_in_name(
+        names, datetime_with_key, date_with_key, time_with_key
+    )
+
+
+def replace_date_time_tags_in_name(
+    names: List[str],
+    datetime_with_key: str,
+    date_with_key: str,
+    time_with_key: str,
+):
+    """
+    For all names in the list, do the replacement of tags
+    with their final values.
+    """
     for i, name in enumerate(names):
         # datetime conditional must come first.
         if tags("datetime") in name:
@@ -259,6 +274,18 @@ def update_names_with_datetime(names: List[str]) -> None:
         elif tags("time") in name:
             name = add_underscore_before_after_if_not_there(name, tags("time"))
             names[i] = name.replace(tags("time"), time_with_key)
+
+
+def format_date(date: str) -> str:
+    return f"date-{date}"
+
+
+def format_time(time_: str) -> str:
+    return f"time-{time_}"
+
+
+def format_datetime(date: str, time_: str) -> str:
+    return f"datetime-{date}T{time_}"
 
 
 def add_underscore_before_after_if_not_there(string: str, key: str) -> str:

--- a/docs/source/pages/how_tos/use-name-templates.md
+++ b/docs/source/pages/how_tos/use-name-templates.md
@@ -23,6 +23,8 @@ as a regexp where `\d` stands for 'any digit`:
 
 If this is defined as a Name Template, any name that
 does not take this form will result in a validation error.
+Name templates can include [convenience tags](create-folders-convenience-tags).
+(`@DATE@`, `@TIME@` or `@DATETIME@`.)
 
 ## Set up Name Templates
 ::::{tab-set}

--- a/tests/tests_unit/test_validation_unit.py
+++ b/tests/tests_unit/test_validation_unit.py
@@ -225,3 +225,31 @@ class TestValidationUnit:
             f"A {prefix} already exists with the same {prefix} id as {prefix}-3. "
             f"The existing folder is {prefix}-3_s-a." in message
         )
+
+    def test_tags_autoreplace_in_regexp(self):
+        """
+        Check the validation function `replace_tags_in_regexp()`
+        correctly replaces tags in a regexp with their regexp equivalent.
+
+        Test date, time and datetime with some random regexp that
+        implicitly check a few other cases (e.g. underscore filling around
+        the tag).
+        """
+        date_regexp = r"sub-\d\d@DATE@_some-tag"
+        fixed_date_regexp = validation.replace_tags_in_regexp(date_regexp)
+        assert fixed_date_regexp == r"sub-\d\d_date-\d\d\d\d\d\d\d\d_some-tag"
+
+        time_regexp = r"ses-\d\d\d\d@TIME@_some-.?.?tag"
+        fixed_time_regexp = validation.replace_tags_in_regexp(time_regexp)
+        assert (
+            fixed_time_regexp == r"ses-\d\d\d\d_time-\d\d\d\d\d\d_some-.?.?tag"
+        )
+
+        datetime_regexp = r"ses-.?.?.?@DATETIME@some-.?.?tag"
+        fixed_datetime_regexp = validation.replace_tags_in_regexp(
+            datetime_regexp
+        )
+        assert (
+            fixed_datetime_regexp
+            == r"ses-.?.?.?_datetime-\d\d\d\d\d\d\d\dT\d\d\d\d\d\d_some-.?.?tag"
+        )


### PR DESCRIPTION
This PR improves the way name templates handle tags. Previously, if a tag was used in a name template when it was compared against the formatted subject or session name it would fail e.g.

`project.make_folders("rawdata", "sub-001_@DATE@")` with the name template `sub-\d\d\d_@DATE@` will fail as it will compare `sub-001_date-<some_date>` to `sub-\d\d\d_@DATE@`. The solution here is to also pre-format the name templates to their regexp equivalent e.g. `sub-\d\d\d_@DATE@` -> `sub-\d\d\d_date-\d\d\d\d\d\d\d\d`. 

This reason this is implemented as it is very useful to use convenience tags in the name template as when autofilling the names in the TUI, if you could click to suggest next subject you would get `sub-001_@DATE@` which you can immediately click to create the folder. Previously, youd have to use `date-\d\d\d\d\d\d\d\d` in the name template and the auto-fill would be `sub-001_date-\d\d\d\d\d\d\d\d` which you would have to manually replace with `@DATE@.`

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
