### PR TITLE
Suggested num respect name template

### DIFF
--- a/datashuttle/datashuttle.py
+++ b/datashuttle/datashuttle.py
@@ -1080,6 +1080,11 @@ class DataShuttle:
             If `True, only get names from `local_path`, otherwise from
             `local_path` and `central_path`.
         """
+        name_template = self.get_name_templates()
+        name_template_regexp = (
+            name_template["sub"] if name_template["on"] else None
+        )
+
         return getters.get_next_sub_or_ses(
             self.cfg,
             top_level_folder,
@@ -1087,6 +1092,7 @@ class DataShuttle:
             local_only=local_only,
             return_with_prefix=return_with_prefix,
             search_str="sub-*",
+            name_template_regexp=name_template_regexp,
         )
 
     @check_configs_set
@@ -1117,6 +1123,11 @@ class DataShuttle:
             If `True, only get names from `local_path`, otherwise from
             `local_path` and `central_path`.
         """
+        name_template = self.get_name_templates()
+        name_template_regexp = (
+            name_template["ses"] if name_template["on"] else None
+        )
+
         return getters.get_next_sub_or_ses(
             self.cfg,
             top_level_folder,
@@ -1124,6 +1135,7 @@ class DataShuttle:
             local_only=local_only,
             return_with_prefix=return_with_prefix,
             search_str="ses-*",
+            name_template_regexp=name_template_regexp,
         )
 
     # Name Templates

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -5,8 +5,10 @@ from typing import (
     TYPE_CHECKING,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
+    Union,
 )
 
 if TYPE_CHECKING:
@@ -145,6 +147,10 @@ def get_max_sub_or_ses_num_and_value_length(
     the max_existing_num will be 2 and num_value_digits 4.
 
     """
+    assert isinstance(
+        default_num_value_digits, int
+    ), "`default_num_value_digits` must be int`"
+
     if len(all_folders) == 0:
 
         max_existing_num = 0
@@ -154,11 +160,9 @@ def get_max_sub_or_ses_num_and_value_length(
             num_value_digits = get_num_value_digits_from_regexp(
                 prefix, name_template_regexp
             )
+            if num_value_digits is False:
+                num_value_digits = default_num_value_digits
         else:
-            assert isinstance(
-                default_num_value_digits, int
-            ), "`default_num_value_digits` must be int`"
-
             num_value_digits = default_num_value_digits
 
     else:
@@ -225,7 +229,7 @@ def get_num_value_digits_from_project(
 
 def get_num_value_digits_from_regexp(
     prefix: Prefix, name_template_regexp: str
-) -> int:
+) -> Union[Literal[False], int]:
     """
     Given a name template regexp, find the number of values for the
     sub or ses key. These will be fixed with "\d" (digit) or ".?" (wildcard).

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -147,11 +147,11 @@ def get_max_sub_or_ses_num_and_value_length(
     the max_existing_num will be 2 and num_value_digits 4.
 
     """
-    assert isinstance(
-        default_num_value_digits, int
-    ), "`default_num_value_digits` must be int`"
-
     if len(all_folders) == 0:
+
+        assert isinstance(
+            default_num_value_digits, int
+        ), "`default_num_value_digits` must be int`"
 
         max_existing_num = 0
 

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -33,6 +33,7 @@ def get_next_sub_or_ses(
     local_only: bool = False,
     return_with_prefix: bool = True,
     default_num_value_digits: int = 3,
+    name_template_regexp: Optional[str] = None,
 ) -> str:
     """
     Suggest the next available subject or session number. This function will
@@ -93,7 +94,10 @@ def get_next_sub_or_ses(
         max_existing_num,
         num_value_digits,
     ) = get_max_sub_or_ses_num_and_value_length(
-        all_folders, prefix, default_num_value_digits
+        all_folders,
+        prefix,
+        default_num_value_digits,
+        name_template_regexp,
     )
 
     # calculate next sub number
@@ -110,6 +114,7 @@ def get_max_sub_or_ses_num_and_value_length(
     all_folders: List[str],
     prefix: Prefix,
     default_num_value_digits: Optional[int] = None,
+    name_template_regexp: Optional[str] = None,
 ) -> Tuple[int, int]:
     """
     Given a list of BIDS-style folder names, find the maximum subject or
@@ -141,12 +146,21 @@ def get_max_sub_or_ses_num_and_value_length(
 
     """
     if len(all_folders) == 0:
-        max_existing_num = 0
-        assert isinstance(
-            default_num_value_digits, int
-        ), "`default_num_value_digits` must be int`"
 
-        num_value_digits = default_num_value_digits
+        max_existing_num = 0
+
+        # Try and get the num digits from a name template, otherwise use default.
+        if name_template_regexp is not None:
+            num_value_digits = get_num_value_digits_from_regexp(
+                prefix, name_template_regexp
+            )
+        else:
+            assert isinstance(
+                default_num_value_digits, int
+            ), "`default_num_value_digits` must be int`"
+
+            num_value_digits = default_num_value_digits
+
     else:
         all_values_str = utils.get_values_from_bids_formatted_name(
             all_folders,
@@ -155,16 +169,22 @@ def get_max_sub_or_ses_num_and_value_length(
         )
 
         # First get the length of bids-key value across the project
-        # (e.g. sub-003 has three values).
-        all_num_value_digits = [len(value) for value in all_values_str]
-
-        if len(set(all_num_value_digits)) != 1:
-            utils.log_and_raise_error(
-                f"The number of value digits for the {prefix} level are not "
-                f"consistent. Cannot suggest a {prefix} number.",
-                NeuroBlueprintError,
+        # or name template if it exists (e.g. sub-003 has three values).
+        # If a name template exists but the length can't be determined from it,
+        # default back to the project.
+        if name_template_regexp is not None:
+            num_value_digits = get_num_value_digits_from_regexp(
+                prefix, name_template_regexp
             )
-        num_value_digits = all_num_value_digits[0]
+
+            if num_value_digits is False:
+                num_value_digits = get_num_value_digits_from_project(
+                    all_values_str, prefix
+                )
+        else:
+            num_value_digits = get_num_value_digits_from_project(
+                all_values_str, prefix
+            )
 
         # Then get the latest existing sub or ses number in the project.
         all_value_nums = sorted(
@@ -180,6 +200,56 @@ def get_max_sub_or_ses_num_and_value_length(
         max_existing_num = max(all_value_nums)
 
     return max_existing_num, num_value_digits
+
+
+def get_num_value_digits_from_project(
+    all_values_str: List[str], prefix: Prefix
+) -> int:
+    """
+    Find the number of digits for the sub or ses key within the project.
+    `all_values_str` is a list of all the sub or ses values from within
+    the project.
+    """
+    all_num_value_digits = [len(value) for value in all_values_str]
+
+    if len(set(all_num_value_digits)) != 1:
+        utils.log_and_raise_error(
+            f"The number of value digits for the {prefix} level are not "
+            f"consistent. Cannot suggest a {prefix} number.",
+            NeuroBlueprintError,
+        )
+    num_value_digits = all_num_value_digits[0]
+
+    return num_value_digits
+
+
+def get_num_value_digits_from_regexp(
+    prefix: Prefix, name_template_regexp: str
+) -> int:
+    """
+    Given a name template regexp, find the number of values for the
+    sub or ses key. These will be fixed with "\d" (digit) or ".?" (wildcard).
+    If there is length-unspecific wildcard (.*) in the sub key, then skip.
+    In practice, there should never really be a .* in the sub or ses
+    key of a name template, but handle it just in case.
+    """
+    all_values_str = utils.get_values_from_bids_formatted_name(
+        [name_template_regexp], prefix, return_as_int=False
+    )[0]
+
+    if "*" in all_values_str:
+        return False
+    else:
+        num_digits = len(
+            [char for char in all_values_str if char in ["d", "?"]]
+        )
+
+        if num_digits == 0:
+            # breaks assumption there is some usable regexp here,
+            # better to use project instead.
+            return False
+
+        return num_digits
 
 
 def get_existing_project_paths() -> List[Path]:

--- a/tests/tests_integration/test_create_folders.py
+++ b/tests/tests_integration/test_create_folders.py
@@ -423,6 +423,52 @@ class TestMakeFolders(BaseTest):
         )
         assert new_num == "ses-006" if return_with_prefix else "006"
 
+    def test_get_next_sub_and_ses_name_template(self, project):
+        """
+        In the case where a name template exists, these getters should use the
+        number of digits on the template (even if these are different
+        within the project!).
+        """
+        project.create_folders("rawdata", "sub-001", "ses-001")
+
+        name_templates = {
+            "on": True,
+            "sub": r"sub-\d.?.?.?\d_key-value",  # 5 digits
+            "ses": r"ses-\d_@DATE@",  # 2 digits
+        }
+        project.set_name_templates(name_templates)
+
+        new_num = project.get_next_sub(
+            "rawdata", return_with_prefix=False, local_only=True
+        )
+        assert new_num == "00002"
+
+        new_num = project.get_next_ses(
+            "rawdata", "sub-001", return_with_prefix=False, local_only=True
+        )
+        assert new_num == "2"
+
+        # Quick test on two cases that should not use name template.
+        # Test sub only as underlying code is the same. If name templates
+        # is off, use the num_digits from the project, same if the sub
+        # key value takes a length-unspecific wildcard (should never really happen).
+        name_templates["on"] = False
+        project.set_name_templates(name_templates)
+
+        new_num = project.get_next_sub(
+            "rawdata", return_with_prefix=False, local_only=True
+        )
+        assert new_num == "002"
+
+        name_templates["on"] = True
+        name_templates["sub"] = "sub-.*"
+        project.set_name_templates(name_templates)
+
+        new_num = project.get_next_sub(
+            "rawdata", return_with_prefix=False, local_only=True
+        )
+        assert new_num == "002"
+
     # ----------------------------------------------------------------------------------
     # Test Helpers
     # ----------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes an annoying behaviour for auto-suggested sub or ses names when name templates is set but there are no existing file in the project. Say you have a name template with a fixed number of leading zeros e.g. `ses-\d\d` for fixed two leading zeros. When you try and suggest a next ses number, it will use an existing ses to get the number of leading zeros, otherwise it will use default (3). However if you have your name template set to 2 this is confusing / frustrating.

This PR adds feature to get the num leading zeros from a name template if it exists. This will use the name template first, then check the project if the number of zeros cannot be generated from the template.

These function logic branches in `get_max_sub_or_ses_num_and_value_length()` is getting quite complex and could do with a refactor. However I'm not sure it has yet reached 'mission critical' and is still fairly easy to follow (?), if a bit convoluted. Therefore I'll think about coming back to this later if even more functionality needs to be added.

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes **(not required)**
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/) 
