### PR TITLE
Fix error from new textualize from dismiss in call_after_refresh.

### DIFF
--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -72,9 +72,10 @@ class FinishTransferScreen(ModalScreen):
     taking user input ('OK' or 'Cancel').
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, transfer_func: Callable) -> None:
         super().__init__()
 
+        self.transfer_func = transfer_func
         self.message = message
 
     def compose(self) -> ComposeResult:
@@ -90,15 +91,15 @@ class FinishTransferScreen(ModalScreen):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "confirm_ok_button":
-            # Update the display to 'transferring' before TUI freezes
-            # during data transfer.
+            # Update the display to 'transferring' before
+            # TUI freezes during data transfer.
             self.query_one("#confirm_button_container").visible = False
             self.query_one("#confirm_message_label").update("Transferring...")
             self.query_one("#confirm_message_label").call_after_refresh(
-                lambda: self.dismiss(True)
+                lambda: self.transfer_func(True)
             )
         else:
-            self.dismiss(False)
+            self.transfer_func(False)
 
 
 class SelectDirectoryTreeScreen(ModalScreen):

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -287,7 +287,7 @@ class TransferTab(TreeAndInputTab):
         2) show 'Transferring...' 3) transfer data 4) tear down 'transferring'
         screen 5) show confirmation screen. This is not simple if we want to
         manage the actual transfer in this screen, which makes a lot of
-        sense as all options are held here The alternative is to pass all settings
+        sense as all options are held here. The alternative is to pass all settings
         to a `Transferring` modal dialog which seems even more convoluted. So,
         `FinishTransferScreen` calls back to `self.transfer_data`. If 'OK' was
         selected, the message is changed to 'Transferring'. Then, `self.transfer_data`

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -85,6 +85,7 @@ class TransferTab(TreeAndInputTab):
         self.show_legend = self.mainwindow.load_global_settings()[
             "show_transfer_tree_status"
         ]
+        self.finish_transfer_screen: Optional[FinishTransferScreen] = None
 
     # Setup
     # ----------------------------------------------------------------------------------
@@ -277,8 +278,22 @@ class TransferTab(TreeAndInputTab):
         to confirm that the user wishes to transfer their data
         (in the direction selected). If "Yes" is selected,
         `self.transfer_data` (see below) is run.
-        """
 
+        Notes
+        -----
+        The way that Textualize works makes it difficult (impossible?)
+        to render a screen but keep the main loop with another screen.
+        What we want to do is 1) select 'OK' to start transfer
+        2) show 'Transferring...' 3) transfer data 4) tear down 'transferring'
+        screen 5) show confirmation screen. This is not simple if we want to
+        manage the actual transfer in this screen, which makes a lot of
+        sense as all options are held here The alternative is to pass all settings
+        to a `Transferring` modal dialog which seems even more convoluted. So,
+        `FinishTransferScreen` calls back to `self.transfer_data`. If 'OK' was
+        selected, the message is changed to 'Transferring'. Then, `self.transfer_data`
+        handles data transfer, teardown of the `FinishTransferScreen`
+        and display of the confirmation screen.
+        """
         if event.button.id == "transfer_transfer_button":
             if not self.query_one("#transfer_switch").value:
                 direction = "upload"
@@ -294,9 +309,15 @@ class TransferTab(TreeAndInputTab):
                 " central filesystem.\n\nAre you sure you wish to proceed?\n",
             )
 
-            self.mainwindow.push_screen(
-                FinishTransferScreen(message), self.transfer_data
+            # This is very convoluted. See docstring for details.
+            assert (
+                self.finish_transfer_screen is None
+            ), "`finish_transfer_screen` should de cleaned up in `transfer_data`."
+
+            self.finish_transfer_screen = FinishTransferScreen(
+                message, self.transfer_data
             )
+            self.mainwindow.push_screen(self.finish_transfer_screen)
 
     def on_custom_directory_tree_directory_tree_special_key_press(
         self, event: CustomDirectoryTree.DirectoryTreeSpecialKeyPress
@@ -337,6 +358,12 @@ class TransferTab(TreeAndInputTab):
             transfer by clicking "Yes".
 
         """
+        # Teardown the screen first, whatever `transfer_bool` is.
+        # It will not be updated until the transfer is complete.
+        assert self.finish_transfer_screen is not None
+        self.finish_transfer_screen.dismiss()
+        self.finish_transfer_screen = None
+
         if transfer_bool:
             upload = not self.query_one("#transfer_switch").value
 

--- a/tests/tests_tui/test_tui_settings.py
+++ b/tests/tests_tui/test_tui_settings.py
@@ -77,7 +77,7 @@ class TestTuiSettings(TuiBase):
             with pytest.raises(BaseException) as e:
                 transfer_tab.query_one("#transfer_legend")
 
-            assert "No nodes match <DOMQuery query" in str(e)
+            assert "No nodes match" in str(e)
             await pilot.pause()
 
             # Go to the settings page and turn on transfer tree styling.


### PR DESCRIPTION
This PR is a bug fix, which addresses a new error that seems to have been caused by a `textualize` update. 

Because of the way the event loop works, as far as I can tell whenever a new `Screen` is made, it takes control of the application. This means if we are transferring data, if we want to show a 'Transferring' screen, then we need to pass a lot of options to a dialog class which itself runs the transfer. This approach seems a little strange, because the 'Transferring' window is just a lightweigh screen, whereas all options for the transfer are set and coordinated in the `Transfer` tab, so it makes sense for the transfer logic to be in the transfer-tab class.

To allow this, `FinishTransferScreen` provides an OK (proceed with transfer) or Cancel (dont transfer) button. If OK is pressed, previously is would change the message to 'Transferring' and call `self.dismiss(True)` within a `call_after_refresh`, that would (after GUI update) dismiss and trigger the callback function `transfer_data`. In [recent versions](https://github.com/Textualize/textual/issues/5049), this reaises an error.

As a workaround, a new (slightly messier) workflow means `FinishTransferScreen` directly calls the transfer function, and the transfer function tears down `FinishTransferScreen` itself. This is documented in a docstring in this PR. 

An alterantive approach would be:
1) in the transfer tab, call `FinishTransferScreen` and wait for response with `push_screen_wait`
2) if `True`, call a `run_transfer_data` function. This will create a `RunTransferDialog` class that shows 'Transferring', but will also require all options from the transfer tab to be passed to it, including the interface. Then the code to run the transfer will be run from this dialog window.
3) This push screen has a callback which handles displaying if the transfer worked or not.

Overall I like this approach less because a lot of the core transfer code is moved into an obscure dialog, rather on the transfer tab, which has the function to coordinate and run the transfer.

See #431 for a much nicer solution to implement ASAP.
