### PR TITLE
Fix dark mode after textual update

### DIFF
--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -58,10 +58,7 @@ class TuiApp(App):
         self.set_dark_mode(self.load_global_settings()["dark_mode"])
 
     def set_dark_mode(self, dark_mode: bool) -> None:
-        if dark_mode:
-            self.theme = "textual-dark"
-        else:
-            self.theme = "textual-light"
+        self.theme = "textual-dark" if dark_mode else "textual-light"
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -55,7 +55,13 @@ class TuiApp(App):
         )
 
     def on_mount(self) -> None:
-        self.dark = self.load_global_settings()["dark_mode"]
+        self.set_dark_mode(self.load_global_settings()["dark_mode"])
+
+    def set_dark_mode(self, dark_mode: bool) -> None:
+        if dark_mode:
+            self.theme = "textual-dark"
+        else:
+            self.theme = "textual-light"
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -66,9 +66,10 @@ class SettingsScreen(ModalScreen):
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         label = str(event.pressed.label)
         assert label in ["Light Mode", "Dark Mode"]
-        dark_mode = label == "Dark Mode"
 
-        self.mainwindow.dark = dark_mode
+        dark_mode = label == "Dark Mode"
+        self.mainwindow.set_dark_mode(dark_mode)
+
         self.global_settings["dark_mode"] = dark_mode
         self.mainwindow.save_global_settings(self.global_settings)
 

--- a/tests/tests_tui/test_tui_settings.py
+++ b/tests/tests_tui/test_tui_settings.py
@@ -10,7 +10,7 @@ class TestTuiSettings(TuiBase):
     """
 
     @pytest.mark.asyncio
-    async def test_light_dark_mode(self, empty_project_paths):
+    async def test_light_dark_mode(self):
         """
         Check the light / dark mode switch which is stored
         in the global tui settings. Global refers to set
@@ -24,13 +24,13 @@ class TestTuiSettings(TuiBase):
             )
 
             # Check default is dark mode, switch to light mode
-            assert pilot.app.dark is True
+            assert pilot.app.theme == "textual-dark"
             assert pilot.app.load_global_settings()["dark_mode"] is True
 
             await self.scroll_to_click_pause(
                 pilot, "#settings_screen_light_mode_radiobutton"
             )
-            assert pilot.app.dark is False
+            assert pilot.app.theme == "textual-light"
             assert pilot.app.load_global_settings()["dark_mode"] is False
 
             # Switch back to dark mode
@@ -38,7 +38,7 @@ class TestTuiSettings(TuiBase):
                 pilot, "#settings_screen_dark_mode_radiobutton"
             )
 
-            assert pilot.app.dark is True
+            assert pilot.app.theme == "textual-dark"
             assert pilot.app.load_global_settings()["dark_mode"] is True
 
             await pilot.pause()


### PR DESCRIPTION
Textual recently had a [breaking change](https://textual.textualize.io/guide/design/#__tabbed_1_1) where they added a lot of new themes (looks pretty cool [here](https://textual.textualize.io/guide/design/#__tabbed_1_1), could expose some!)

The `app.dark` attribute is now unused and `.theme` is used instead. This PR now sets `.theme` to the appropriate values to reproduce the old behaviour.

Tests are failing due to #446, which will be merged soon. Changes in this PR are only minimal on the main code (around setting light / dark mode).