### PR TITLE
Fix tests after textual changes

### DIFF
--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -97,7 +97,7 @@ class TestTuiConfigs(TuiBase):
                 assert (
                     pilot.app.screen.query_one(
                         "#messagebox_message_label"
-                    ).renderable._text[0]
+                    ).renderable
                     == "A datashuttle project has now been created.\n\n Next, "
                     "setup the SSH connection. Once complete, navigate to "
                     "the 'Main Menu' and proceed to the project page, "
@@ -115,7 +115,7 @@ class TestTuiConfigs(TuiBase):
                 assert (
                     pilot.app.screen.query_one(
                         "#messagebox_message_label"
-                    ).renderable._text[0]
+                    ).renderable
                     == "A datashuttle project has now been created.\n\n "
                     "Next proceed to the project page, where you will "
                     "be able to create and transfer project folders."
@@ -232,7 +232,7 @@ class TestTuiConfigs(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#messagebox_message_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Configs saved."
             )
             await self.close_messagebox(pilot)
@@ -364,7 +364,7 @@ class TestTuiConfigs(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#messagebox_message_label"
-                ).renderable._text[0]
+                ).renderable
                 == "The project name must contain alphanumeric characters only."
             )
             await pilot.pause()

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -291,7 +291,7 @@ class TestTuiCreateFolders(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#messagebox_message_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Invalid character in subject or session value: abc"
             )
             await self.close_messagebox(pilot)
@@ -391,9 +391,9 @@ class TestTuiCreateFolders(TuiBase):
 
             pilot.app.screen.query_one(
                 "#messagebox_message_label"
-            ).renderable._text[
-                0
-            ] = "The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+            ).renderable = (
+                "The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+            )
             await self.close_messagebox(pilot)
 
             # Now make the correct folders respecting the name templates

--- a/tests/tests_tui/test_tui_get_help.py
+++ b/tests/tests_tui/test_tui_get_help.py
@@ -11,7 +11,7 @@ class TestTuiSettings(TuiBase):
     """
 
     @pytest.mark.asyncio
-    async def test_light_dark_mode(self, empty_project_paths):
+    async def test_get_help(self, empty_project_paths):
 
         app = TuiApp()
         async with app.run_test(size=self.tui_size()) as pilot:
@@ -21,10 +21,10 @@ class TestTuiSettings(TuiBase):
             )
 
             assert (
-                "For help getting started, check out the Documentation"
+                "For help getting started, check out the"
                 in pilot.app.screen.query_one(
                     "#get_help_label"
-                ).renderable._text[0]
+                ).renderable.strip()
             )
 
             await self.scroll_to_click_pause(pilot, "#all_main_menu_buttons")

--- a/tests/tests_tui/test_tui_logging.py
+++ b/tests/tests_tui/test_tui_logging.py
@@ -75,7 +75,7 @@ class TestTuiLogging(TuiBase):
                 "create-folders"
                 in logging_tab.query_one(
                     "#logging_most_recent_label"
-                ).renderable._text[0]
+                ).renderable
             )
 
             # Check log screen shows on button click

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -49,15 +49,11 @@ class TestTuiWidgets(TuiBase):
             # New Project Labels --------------------------------------------------
 
             assert (
-                configs_content.query_one(
-                    "#configs_banner_label"
-                ).renderable._text[0]
+                configs_content.query_one("#configs_banner_label").renderable
                 == "Make A New Project"
             )
             assert (
-                configs_content.query_one(
-                    "#configs_info_label"
-                ).renderable._text[0]
+                configs_content.query_one("#configs_info_label").renderable
                 == "Set your configurations for a new project. For more details on "
                 "each section,\nsee the Datashuttle documentation. Once configs "
                 "are set, you will be able\nto use the 'Create' and 'Transfer' tabs."
@@ -66,9 +62,7 @@ class TestTuiWidgets(TuiBase):
             # Project Name --------------------------------------------------------
 
             assert (
-                configs_content.query_one(
-                    "#configs_name_label"
-                ).renderable._text[0]
+                configs_content.query_one("#configs_name_label").renderable
                 == "Project Name"
             )
             assert configs_content.query_one("#configs_name_input").value == ""
@@ -82,7 +76,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 configs_content.query_one(
                     "#configs_local_path_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Local Path"
             )
             assert (
@@ -110,7 +104,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 configs_content.query_one(
                     "#configs_connect_method_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Connection Method"
             )
             assert (
@@ -125,7 +119,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 configs_content.query_one(
                     "#configs_central_path_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Central Path"
             )
             assert (
@@ -177,7 +171,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 configs_content.query_one(
                     "#configs_central_host_id_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Central Host ID"
             )
             assert (
@@ -198,7 +192,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 configs_content.query_one(
                     "#configs_central_host_username_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Central Host Username"
             )
             assert (
@@ -300,7 +294,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#create_folders_subject_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Subject(s)"
             )
             assert (
@@ -313,7 +307,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#create_folders_session_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Session(s)"
             )
             assert (
@@ -326,7 +320,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#create_folders_datatype_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Datatype(s)"
             )
 
@@ -397,7 +391,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#create_folders_settings_toplevel_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Top level folder:"
             )
             assert (
@@ -453,7 +447,7 @@ class TestTuiWidgets(TuiBase):
                 " A 'Template' can be set check subject or session names"
                 in pilot.app.screen.query_one(
                     "#template_message_label"
-                ).renderable._text[0]
+                ).renderable
             )
 
             assert (
@@ -1075,9 +1069,7 @@ class TestTuiWidgets(TuiBase):
 
             # All data label
             assert (
-                pilot.app.screen.query_one(
-                    "#transfer_all_label"
-                ).renderable._text[0]
+                pilot.app.screen.query_one("#transfer_all_label").renderable
                 == "All data from: \n\n - Rawdata \n - "
                 "Derivatives \n\nwill be transferred."
             )
@@ -1086,7 +1078,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_switch_upload_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Upload"
             )
             assert (
@@ -1095,7 +1087,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_switch_download_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Download"
             )
             assert (
@@ -1111,7 +1103,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_toplevel_label_top"
-                ).renderable._text[0]
+                ).renderable
                 == "Select top-level folder to transfer."
             )
             assert (
@@ -1125,7 +1117,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_custom_label_top"
-                ).renderable._text[0]
+                ).renderable
                 == "Select top-level folder to transfer."
             )
             assert (
@@ -1136,7 +1128,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_subject_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Subject(s)"
             )
             assert (
@@ -1149,7 +1141,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_session_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Session(s)"
             )
             assert (
@@ -1162,7 +1154,7 @@ class TestTuiWidgets(TuiBase):
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_datatype_label"
-                ).renderable._text[0]
+                ).renderable
                 == "Datatype(s)"
             )
 

--- a/tests/tests_tui/tui_base.py
+++ b/tests/tests_tui/tui_base.py
@@ -23,7 +23,7 @@ class TuiBase:
         The solution is to ensure the screen is large enough
         in the test environment.
         """
-        return (800, 600)
+        return None  # (500, 500)
 
     @pytest_asyncio.fixture(scope="function")
     async def empty_project_paths(self, tmp_path_factory, monkeypatch):

--- a/tests/tests_tui/tui_base.py
+++ b/tests/tests_tui/tui_base.py
@@ -23,7 +23,7 @@ class TuiBase:
         The solution is to ensure the screen is large enough
         in the test environment.
         """
-        return None  # (500, 500)
+        return (500, 500)
 
     @pytest_asyncio.fixture(scope="function")
     async def empty_project_paths(self, tmp_path_factory, monkeypatch):

--- a/tests/tests_tui/tui_base.py
+++ b/tests/tests_tui/tui_base.py
@@ -23,7 +23,7 @@ class TuiBase:
         The solution is to ensure the screen is large enough
         in the test environment.
         """
-        return (500, 500)
+        return (800, 600)
 
     @pytest_asyncio.fixture(scope="function")
     async def empty_project_paths(self, tmp_path_factory, monkeypatch):


### PR DESCRIPTION
The (private) `_text` attribute I was using to check label contents in tests was changed in recent textual version. This is now updated from `renderable._text[0]` to simply `renderable`.

Tests are failing, this is due to out-of-bound error issue in test suite only. For now will merge to incorporate these usueful fixes and follow up with [this issue](https://github.com/Textualize/textual/issues/4412).