### PR TITLE
Fix Out of Bounds error during testing.

### DIFF
--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -389,9 +389,9 @@ class TestTuiCreateFolders(TuiBase):
                 pilot, "#create_folders_create_folders_button"
             )
 
-            pilot.app.screen.query_one(
+            assert pilot.app.screen.query_one(
                 "#messagebox_message_label"
-            ).renderable = (
+            ).renderable == (
                 "The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
             await self.close_messagebox(pilot)

--- a/tests/tests_tui/tui_base.py
+++ b/tests/tests_tui/tui_base.py
@@ -182,6 +182,7 @@ class TuiBase:
         Perform general TUI checks during the navigation.
         """
         await pilot.click("#mainwindow_existing_project_button")
+        await pilot.pause()
 
         assert isinstance(pilot.app.screen, ProjectSelectorScreen)
         assert len(pilot.app.screen.project_names) == 1


### PR DESCRIPTION
Often in testing we were getting errors like:

```
FAILED test_tui_create_folders.py::TestTuiCreateFolders::test_create_folders_formatted_names - textual.pilot.OutOfBounds: Target offset is outside of currently-visible screen region.
```
This is due to the screen not being large enough, as discussed [here](https://github.com/Textualize/textual/issues/4412). They provided the very useful information that there is a function `app.save_screenshot()` that allows you to see the state of the screen at the test time.

It turned out at the issue (in this case) was that when clicking onto the project selector screen, it was completely blank. This led the terminal size of shrink and nothing was clicked on when the app tried to click on the project name.

The issue was that I forgot to add `pilot.pause()` after the call to click on the project selector screen 

```
 await pilot.click("#mainwindow_existing_project_button")
 ```

so the test was moving directly onto the next step (clicking the project button) before the screen had loaded.  
 

[EDIT]

Also, this fixed a case I found where forgot to add assert to a check. It was just easier to include on this PR.
 