### PR TITLE
Small TUI fixes

### DIFF
--- a/datashuttle/tui/css/tui_tab.tcss
+++ b/datashuttle/tui/css/tui_tab.tcss
@@ -124,7 +124,7 @@ TransferStatusTree {
 
 #transfer_legend {
     layer: top;
-    dock: left;
+    dock: bottom;
     align-vertical: bottom;
     background: $primary-background-darken-1;
     width: auto;

--- a/datashuttle/tui/css/tui_tab.tcss
+++ b/datashuttle/tui/css/tui_tab.tcss
@@ -55,6 +55,7 @@ TabScreen > TabbedContent {
 #transfer_radioset {
     layout: horizontal;
     background: transparent;
+    margin: 1 0 0 0;
 }
 
 #transfer_radioset:focus {

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -183,7 +183,7 @@ class TransferTab(TreeAndInputTab):
                         id="transfer_tab_overwrite_select",
                     ),
                 ),
-                # needs to be in horizontal or formats with large space for some rason.
+                # needs to be in horizontal or formats with large space for some reason.
                 Horizontal(
                     Checkbox(
                         "Dry Run",


### PR DESCRIPTION
A couple of fixes to the TUI which has become broken in breaking-change textual updates:

- fix the legend position to 'bottom' rather than 'left', it had moved to the top of the directory tree widget.
- add a small margin to the transfer radioset  (e.g. that contains radiobuttons like "all") etc so it aligns with the directory tree widget.
