### PR TITLE
Add additional message when quitting SSH setup.

### DIFF
--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -138,7 +138,11 @@ def setup_ssh_key(
             "system terminal \nrather than through an IDE: "
         )
         if proceed != "y":
+            utils.print_message_to_user(
+                "Quitting SSH setup as 'y' not pressed."
+            )
             return
+
         password = input(
             "Please enter your password. Characters will not be hidden: "
         )


### PR DESCRIPTION
Just an additional message to confirm SSH setup was quit. I got confused at this stage and was entering my password here rather than pressing 'y' and SSH was silently not being set up.

NOTE: tests are failing due to known issue in #458 so I think okay to merge.