### PR TITLE
Extend validation

### DIFF
--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -242,7 +242,7 @@ class Configs(UserDict):
 
     def make_and_get_logging_path(
         self,
-    ) -> Path:  # TODO: this function is really weird
+    ) -> Path:
         """
         Build (and create if does not exist) the path where
         logs are stored.

--- a/datashuttle/configs/config_class.py
+++ b/datashuttle/configs/config_class.py
@@ -240,7 +240,9 @@ class Configs(UserDict):
 
         self.logging_path = self.make_and_get_logging_path()
 
-    def make_and_get_logging_path(self) -> Path:
+    def make_and_get_logging_path(
+        self,
+    ) -> Path:  # TODO: this function is really weird
         """
         Build (and create if does not exist) the path where
         logs are stored.

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1239,6 +1239,14 @@ class DataShuttle:
             If ``True``, only the local project is validated. Otherwise, both
             local and central projects are validated. If in local-project mode,
             this flag is ignored.
+
+        strict_mode: bool
+            If `True`, only allow NeuroBlueprint-formatted folders to exist in
+            the project. By default, non-NeuroBlueprint folders (e.g. a folder
+            called 'my_stuff' in the 'rawdata') are allowed, and only folders
+            starting with sub- or ses- prefix are checked. In `Strict Mode`,
+            any folder not prefixed with sub-, ses- or a valid datatype will
+            raise a validation issue.
         """
         self._start_log(
             "validate-project",

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -34,6 +34,7 @@ from datashuttle.configs import (
     load_configs,
 )
 from datashuttle.configs.config_class import Configs
+from datashuttle.datashuttle_functions import format_top_level_folder
 from datashuttle.utils import (
     ds_logger,
     folders,
@@ -1218,7 +1219,7 @@ class DataShuttle:
     @check_configs_set
     def validate_project(
         self,
-        top_level_folder: TopLevelFolder,
+        top_level_folder: Optional[TopLevelFolder],
         display_mode: DisplayMode,
         local_only: bool = False,
         strict_mode: bool = False,
@@ -1230,6 +1231,10 @@ class DataShuttle:
 
         Parameters
         ----------
+
+        top_level_folder : TopLevelFolder | None
+            Folder to check, either "rawdata" or "derivatives". If ``None``,
+            will check both folders.
 
         display_mode : DisplayMode
             The validation issues are displayed as ``"error"`` (raise error)
@@ -1258,9 +1263,13 @@ class DataShuttle:
         if self.is_local_project():
             local_only = True
 
+        top_level_folder_to_validate = format_top_level_folder(
+            top_level_folder
+        )
+
         error_messages = validation.validate_project(
             self.cfg,
-            top_level_folder,
+            top_level_folder_to_validate,
             local_only=local_only,
             display_mode=display_mode,
             name_templates=name_templates,

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1255,7 +1255,7 @@ class DataShuttle:
         """
         utils.print_message_to_user(
             f"Logs of the validation will be stored in: "
-            f"{self.cfg.make_and_get_logging_path()}.\n\nValidation results:"
+            f"{self.cfg.make_and_get_logging_path()}\n\nValidation results:"
         )
 
         self._start_log(

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -165,27 +165,27 @@ class DataShuttle:
         ----------
 
         top_level_folder : TopLevelFolder
-                Whether to make the folders in `rawdata` or
-                `derivatives`.
+            Whether to make the folders in `rawdata` or
+            `derivatives`.
 
         sub_names : Union[str, List[str]]
-                subject name / list of subject names to make
-                within the top-level project folder
-                (if not already, these will be prefixed with
-                "sub-")
+            subject name / list of subject names to make
+            within the top-level project folder
+            (if not already, these will be prefixed with
+            "sub-")
 
         ses_names : Optional[Union[str, List[str]]]
-                (Optional). session name / list of session names.
-                (if not already, these will be prefixed with
-                "ses-"). If no session is provided, no session-level
-                folders are made.
+            (Optional). session name / list of session names.
+            (if not already, these will be prefixed with
+            "ses-"). If no session is provided, no session-level
+            folders are made.
 
         datatype : Union[str, List[str]]
-                The datatype to make in the sub / ses folders.
-                (e.g. "ephys", "behav", "anat"). If "" is
-                passed no datatype will be created. Broad or
-                Narrow canonical NeuroBlueprint datatypes are
-                accepted.
+            The datatype to make in the sub / ses folders.
+            (e.g. "ephys", "behav", "anat"). If "" is
+            passed no datatype will be created. Broad or
+            Narrow canonical NeuroBlueprint datatypes are
+            accepted.
 
         bypass_validation : bool
             If `True`, folders will be created even if they are not
@@ -209,27 +209,22 @@ class DataShuttle:
 
         sub_names or ses_names may contain formatting tags
 
-            @TO@ :
-                used to make a range of subjects / sessions.
-                Boundaries of the range must be either side of the tag
-                e.g. sub-001@TO@003 will generate
-                 ["sub-001", "sub-002", "sub-003"]
+        @TO@
+            used to make a range of subjects / sessions.
+            Boundaries of the range must be either side of the tag
+            e.g. sub-001@TO@003 will generate ["sub-001", "sub-002", "sub-003"]
 
-            @DATE@, @TIME@ @DATETIME@ :
-                will add date-<value>, time-<value> or
-                date-<value>_time-<value> keys respectively. Only one per-name
-                is permitted.
-                e.g. sub-001_@DATE@ will generate sub-001_date-20220101
-                (on the 1st january, 2022).
+        @DATE@, @TIME@ @DATETIME@
+            will add date-<value>, time-<value> or
+            date-<value>_time-<value> keys respectively. Only one per-name
+            is permitted.
+            e.g. sub-001_@DATE@ will generate sub-001_date-20220101 (on the 1st january, 2022).
 
         Examples
         --------
         project.create_folders("rawdata", "sub-001", datatype="behav")
 
-        project.create_folders("rawdata",
-                             "sub-002@TO@005",
-                             ["ses-001", "ses-002"],
-                             ["ephys", "behav"])
+        project.create_folders("rawdata", "sub-002@TO@005", ["ses-001", "ses-002"], ["ephys", "behav"])
         """
         if log:
             self._start_log("create-folders", local_vars=locals())

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -34,7 +34,7 @@ from datashuttle.configs import (
     load_configs,
 )
 from datashuttle.configs.config_class import Configs
-from datashuttle.datashuttle_functions import format_top_level_folder
+from datashuttle.datashuttle_functions import _format_top_level_folder
 from datashuttle.utils import (
     ds_logger,
     folders,
@@ -344,7 +344,7 @@ class DataShuttle:
         ----------
 
         top_level_folder :
-            The top-level folder (e.g. `rawdata`) to transfer files
+            The top-level folder (e.g. `"rawdata"`, `"derivatives"`) to transfer files
             and folders within.
 
         sub_names :
@@ -1263,7 +1263,7 @@ class DataShuttle:
         if self.is_local_project():
             local_only = True
 
-        top_level_folder_to_validate = format_top_level_folder(
+        top_level_folder_to_validate = _format_top_level_folder(
             top_level_folder
         )
 

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1253,6 +1253,11 @@ class DataShuttle:
             any folder not prefixed with sub-, ses- or a valid datatype will
             raise a validation issue.
         """
+        utils.print_message_to_user(
+            f"Logs of the validation will be stored in: "
+            f"{self.cfg.make_and_get_logging_path()}.\n\nValidation results:"
+        )
+
         self._start_log(
             "validate-project",
             local_vars=locals(),

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1222,7 +1222,7 @@ class DataShuttle:
         display_mode: DisplayMode,
         local_only: bool = False,
         strict_mode: bool = False,
-    ) -> None:
+    ) -> List[str]:
         """
         Perform validation on the project. This checks the subject
         and session level folders to ensure there are no NeuroBlueprint
@@ -1250,7 +1250,7 @@ class DataShuttle:
         if self.is_local_project():
             local_only = True
 
-        validation.validate_project(
+        error_messages = validation.validate_project(
             self.cfg,
             top_level_folder,
             local_only=local_only,
@@ -1260,6 +1260,8 @@ class DataShuttle:
         )
 
         ds_logger.close_log_filehandler()
+
+        return error_messages
 
     @staticmethod
     def check_name_formatting(names: Union[str, list], prefix: Prefix) -> None:

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1221,6 +1221,7 @@ class DataShuttle:
         top_level_folder: TopLevelFolder,
         display_mode: DisplayMode,
         local_only: bool = False,
+        strict_mode: bool = False,
     ) -> None:
         """
         Perform validation on the project. This checks the subject
@@ -1255,6 +1256,7 @@ class DataShuttle:
             local_only=local_only,
             display_mode=display_mode,
             name_templates=name_templates,
+            strict_mode=strict_mode,
         )
 
         ds_logger.close_log_filehandler()

--- a/datashuttle/datashuttle_functions.py
+++ b/datashuttle/datashuttle_functions.py
@@ -55,7 +55,7 @@ def quick_validate_project(
     # at least one top-level folder
     if not project_path.is_dir():
         raise FileNotFoundError(
-            f"No file or folder found at `project_path`: {project_path}"
+            f"Cannot perform validation. No file or folder found at `project_path`: {project_path}"
         )
     if (
         not (project_path / "rawdata").is_dir()

--- a/datashuttle/datashuttle_functions.py
+++ b/datashuttle/datashuttle_functions.py
@@ -41,7 +41,7 @@ def quick_validate_project(
         name, and hold a "rawdata" or "derivatives" folder.
 
     top_level_folder : TopLevelFolder
-        The top-level folder ("rawdata" or "derivatives" to
+        The top-level folder ("rawdata" or "derivatives") to
         perform validation. If `None`, both are checked.
 
     display_mode : DisplayMode
@@ -62,7 +62,7 @@ def quick_validate_project(
             f"Cannot perform validation. No file or folder found at `project_path`: {project_path}"
         )
 
-    top_level_folders_to_validate = format_top_level_folder(top_level_folder)
+    top_level_folders_to_validate = _format_top_level_folder(top_level_folder)
 
     # Create some mock configs for the validation call,
     # then for each top-level folder, run the validation
@@ -88,10 +88,14 @@ def quick_validate_project(
     return error_messages
 
 
-def format_top_level_folder(
+def _format_top_level_folder(
     top_level_folder: TopLevelFolder | None,
 ) -> List[TopLevelFolder]:
-    """ """
+    """
+    Take a `top_level_folder` ("rawdata" or "derivatives" str) and
+    convert to list, if `None`, convert it to a list
+    of both possible top-level folders.
+    """
     rawdata_and_derivatives: List[TopLevelFolder] = ["rawdata", "derivatives"]
 
     formatted_top_level_folders: List[TopLevelFolder]

--- a/datashuttle/datashuttle_functions.py
+++ b/datashuttle/datashuttle_functions.py
@@ -77,9 +77,7 @@ def quick_validate_project(
         input_dict=placeholder_configs,
     )
 
-    error_messages = []
-
-    error_messages += validation.validate_project(
+    error_messages = validation.validate_project(
         cfg=cfg,
         top_level_folder_list=top_level_folders_to_validate,
         local_only=True,

--- a/datashuttle/tui/screens/datatypes.py
+++ b/datashuttle/tui/screens/datatypes.py
@@ -122,7 +122,7 @@ class DisplayedDatatypesScreen(ModalScreen):
             Vertical(
                 Label(
                     "Select datatype checkboxes to display:",
-                    id="display_datatypes_toplevel_label",  # TODO: CHANGE NAME
+                    id="display_datatypes_toplevel_label",
                 ),
                 SelectionList[int](
                     *selections, id="displayed_datatypes_selection_list"

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -248,9 +248,7 @@ class TransferTab(TreeAndInputTab):
             )
 
     def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
-        if (
-            event.checkbox.id == "transfer_tab_dry_run_checkbox"
-        ):  # TODO: UPDATE NAMES TO INC. TAB! ALSO UPDATE TOOLTIPS
+        if event.checkbox.id == "transfer_tab_dry_run_checkbox":
             self.interface.save_tui_settings(
                 event.checkbox.value,
                 "dry_run",

--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -216,7 +216,8 @@ class TransferData:
         top-level-folder. Split the output based onto files / folders
         within "sub-" prefixed folders or not.
         """
-        top_level_folders, top_level_files = folders.search_sub_or_ses_level(
+        top_level_folders: List[str]
+        top_level_folders, top_level_files = folders.search_sub_or_ses_level(  # type: ignore
             self.__cfg,
             self.__cfg.get_base_folder(
                 self.__local_or_central, self.__top_level_folder
@@ -242,7 +243,8 @@ class TransferData:
         For the subject, get a list of files / folders that are
         not within "ses-" prefixed folders.
         """
-        sub_level_folders, sub_level_files = folders.search_sub_or_ses_level(
+        sub_level_folders: List[str]
+        sub_level_folders, sub_level_files = folders.search_sub_or_ses_level(  # type: ignore
             self.__cfg,
             self.__cfg.get_base_folder(
                 self.__local_or_central, self.__top_level_folder
@@ -278,10 +280,11 @@ class TransferData:
         For a specific subject and session, get a list of files / folders
         that are not in canonical datashuttle datatype folders.
         """
+        ses_level_folders: List[str]
         (
             ses_level_folders,
             ses_level_filenames,
-        ) = folders.search_sub_or_ses_level(
+        ) = folders.search_sub_or_ses_level(  # type: ignore
             self.__cfg,
             self.__cfg.get_base_folder(
                 self.__local_or_central, self.__top_level_folder
@@ -443,7 +446,8 @@ class TransferData:
             prefix = "ses"
 
         if names_checked in [["all"], [f"all_{prefix}"]]:
-            processed_names = folders.search_sub_or_ses_level(
+            processed_names: List[str]
+            processed_names = folders.search_sub_or_ses_level(  # type: ignore
                 self.__cfg,
                 self.__base_folder,
                 self.__local_or_central,

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -205,6 +205,7 @@ def search_project_for_sub_or_ses_names(
     sub: Optional[str],
     search_str: str,
     local_only: bool,
+    return_full_path: bool = False,
 ) -> Dict:
     """
     If sub is None, the top-level level folder will be
@@ -226,6 +227,7 @@ def search_project_for_sub_or_ses_names(
         sub=sub,
         search_str=search_str,
         verbose=False,
+        return_full_path=return_full_path,
     )
 
     central_foldernames: List
@@ -240,6 +242,7 @@ def search_project_for_sub_or_ses_names(
             sub,
             search_str=search_str,
             verbose=False,
+            return_full_path=return_full_path,
         )
     return {"local": local_foldernames, "central": central_foldernames}
 
@@ -434,6 +437,7 @@ def search_sub_or_ses_level(
     ses: Optional[str] = None,
     search_str: str = "*",
     verbose: bool = True,
+    return_full_path: bool = False,
 ) -> Tuple[List[str], List[str]]:
     """
     Search project folder at the subject or session level.
@@ -482,6 +486,7 @@ def search_sub_or_ses_level(
         local_or_central,
         search_str,
         verbose,
+        return_full_path,
     )
 
     return all_folder_names, all_filenames
@@ -493,6 +498,7 @@ def search_for_folders(
     local_or_central: str,
     search_prefix: str,
     verbose: bool = True,
+    return_full_path: bool = False,
 ) -> Tuple[List[Any], List[Any]]:
     """
     Wrapper to determine the method used to search for search
@@ -513,6 +519,7 @@ def search_for_folders(
             search_prefix,
             cfg,
             verbose,
+            return_full_path,
         )
     else:
         if not search_path.exists():
@@ -523,13 +530,13 @@ def search_for_folders(
             return [], []
 
         all_folder_names, all_filenames = search_filesystem_path_for_folders(
-            search_path / search_prefix
+            search_path / search_prefix, return_full_path
         )
     return all_folder_names, all_filenames
 
 
 def search_filesystem_path_for_folders(
-    search_path_with_prefix: Path,
+    search_path_with_prefix: Path, return_full_path: bool = False
 ) -> Tuple[List[str], List[str]]:
     """
     Use glob to search the full search path (including prefix) with glob.
@@ -538,9 +545,16 @@ def search_filesystem_path_for_folders(
     all_folder_names = []
     all_filenames = []
     for file_or_folder in glob.glob(search_path_with_prefix.as_posix()):
+
+        file_or_folder = Path(file_or_folder)
+
         if os.path.isdir(file_or_folder):
-            all_folder_names.append(os.path.basename(file_or_folder))
+            all_folder_names.append(
+                file_or_folder if return_full_path else file_or_folder.name
+            )
         else:
-            all_filenames.append(os.path.basename(file_or_folder))
+            all_filenames.append(
+                file_or_folder if return_full_path else file_or_folder.name
+            )
 
     return all_folder_names, all_filenames

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -398,17 +398,18 @@ def search_for_wildcards(
         will search for subjects rather than sessions.
 
     """
-    new_all_names = []
+    new_all_names: List[str] = []
     for name in all_names:
         if canonical_tags.tags("*") in name:
             name = name.replace(canonical_tags.tags("*"), "*")
 
+            matching_names: List[str]
             if sub:
-                matching_names = search_sub_or_ses_level(
+                matching_names = search_sub_or_ses_level(  # type: ignore
                     cfg, base_folder, local_or_central, sub, search_str=name
                 )[0]
             else:
-                matching_names = search_sub_or_ses_level(
+                matching_names = search_sub_or_ses_level(  # type: ignore
                     cfg, base_folder, local_or_central, search_str=name
                 )[0]
 
@@ -428,6 +429,7 @@ def search_for_wildcards(
 # -----------------------------------------------------------------------------
 
 
+# @overload: Cannot get type overloading to work with this function.
 def search_sub_or_ses_level(
     cfg: Configs,
     base_folder: Path,
@@ -437,7 +439,7 @@ def search_sub_or_ses_level(
     search_str: str = "*",
     verbose: bool = True,
     return_full_path: bool = False,
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[str] | List[Path], List[str]]:
     """
     Search project folder at the subject or session level.
     Only returns folders

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -63,11 +63,11 @@ def create_folder_trees(
         )
 
     if datatype_passed:
-        is_invalid, message = validation.datatypes_are_invalid(
-            datatype, allow_all=False
+        error_message = validation.check_datatypes_are_valid(
+            datatype, allow_all=True
         )
-        if is_invalid:
-            utils.log_and_raise_error(message, NeuroBlueprintError)
+        if error_message:
+            utils.log_and_raise_error(error_message, NeuroBlueprintError)
 
         all_paths: Dict = {}
     else:

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -547,7 +547,10 @@ def search_filesystem_path_for_folders(
     all_folder_names = []
     all_filenames = []
 
-    for file_or_folder_str in glob.glob(search_path_with_prefix.as_posix()):
+    all_files_and_folders = list(glob.glob(search_path_with_prefix.as_posix()))
+    sorter_files_and_folders = sorted(all_files_and_folders)
+
+    for file_or_folder_str in sorter_files_and_folders:
 
         file_or_folder = Path(file_or_folder_str)
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from datashuttle.utils.custom_types import TopLevelFolder
 
 import glob
-import os
 from pathlib import Path
 
 from datashuttle.configs import canonical_folders, canonical_tags
@@ -535,20 +534,22 @@ def search_for_folders(
     return all_folder_names, all_filenames
 
 
+# Actual function implementation
 def search_filesystem_path_for_folders(
     search_path_with_prefix: Path, return_full_path: bool = False
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[Path | str], List[Path | str]]:
     """
     Use glob to search the full search path (including prefix) with glob.
     Files are filtered out of results, returning folders only.
     """
     all_folder_names = []
     all_filenames = []
-    for file_or_folder in glob.glob(search_path_with_prefix.as_posix()):
 
-        file_or_folder = Path(file_or_folder)
+    for file_or_folder_str in glob.glob(search_path_with_prefix.as_posix()):
 
-        if os.path.isdir(file_or_folder):
+        file_or_folder = Path(file_or_folder_str)
+
+        if file_or_folder.is_dir():
             all_folder_names.append(
                 file_or_folder if return_full_path else file_or_folder.name
             )

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -71,7 +71,6 @@ def check_and_format_names(
             formatted_names,
             prefix,
             "error",
-            check_duplicates=True,
             name_templates=name_templates,
             log=True,
         )

--- a/datashuttle/utils/formatting.py
+++ b/datashuttle/utils/formatting.py
@@ -67,13 +67,13 @@ def check_and_format_names(
     formatted_names = format_names(names_to_format, prefix)
 
     if not bypass_validation:
-        validation.validate_list_of_names(
+        error_messages = validation.validate_list_of_names(
             formatted_names,
             prefix,
-            "error",
             name_templates=name_templates,
-            log=True,
         )
+        for message in error_messages:
+            validation.raise_display_mode(message, "error", log=True)
 
     return formatted_names + reserved_keywords
 

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -29,7 +29,7 @@ from datashuttle.utils.custom_exceptions import (
 
 def get_next_sub_or_ses(
     cfg: Configs,
-    top_level_folder,
+    top_level_folder: TopLevelFolder,
     sub: Optional[str],
     search_str: str,
     local_only: bool = False,
@@ -52,6 +52,9 @@ def get_next_sub_or_ses(
     ----------
     cfg : Configs
         datashuttle configs class
+
+    top_level_folder: TopLevelFolder
+        The top-level folder (e.g. `"rawdata"`, `"derivatives"`)
 
     sub : Optional[str]
         subject name to search within if searching for sessions, otherwise None
@@ -310,11 +313,14 @@ def get_all_sub_and_ses_paths(
     cfg : Configs
         datashuttle Configs
 
+    top_level_folder: TopLevelFolder
+        The top-level folder (e.g. `"rawdata"`, `"derivatives"`)
+
     local_only : bool
         If `True, only get names from `local_path`, otherwise from
         `local_path` and `central_path`.
     """
-    sub_folder_names = folders.search_project_for_sub_or_ses_names(
+    sub_folder_paths = folders.search_project_for_sub_or_ses_names(
         cfg,
         top_level_folder,
         None,
@@ -324,18 +330,18 @@ def get_all_sub_and_ses_paths(
     )
 
     if local_only:
-        all_sub_folder_names = sub_folder_names["local"]
+        all_sub_folder_paths = sub_folder_paths["local"]
     else:
-        all_sub_folder_names = (
-            sub_folder_names["local"] + sub_folder_names["central"]
+        all_sub_folder_paths = (
+            sub_folder_paths["local"] + sub_folder_paths["central"]
         )
 
-    all_ses_folder_names = {}
-    for sub_path in all_sub_folder_names:
+    all_ses_folder_paths = {}
+    for sub_path in all_sub_folder_paths:
 
         sub = sub_path.name
 
-        ses_folder_names = folders.search_project_for_sub_or_ses_names(
+        ses_folder_paths = folders.search_project_for_sub_or_ses_names(
             cfg,
             top_level_folder,
             sub,
@@ -345,10 +351,10 @@ def get_all_sub_and_ses_paths(
         )
 
         if local_only:
-            all_ses_folder_names[sub] = ses_folder_names["local"]
+            all_ses_folder_paths[sub] = ses_folder_paths["local"]
         else:
-            all_ses_folder_names[sub] = (
-                ses_folder_names["local"] + ses_folder_names["central"]
+            all_ses_folder_paths[sub] = (
+                ses_folder_paths["local"] + ses_folder_paths["central"]
             )
 
-    return {"sub": all_sub_folder_names, "ses": all_ses_folder_names}
+    return {"sub": all_sub_folder_paths, "ses": all_ses_folder_paths}

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -314,15 +314,13 @@ def get_all_sub_and_ses_paths(
         If `True, only get names from `local_path`, otherwise from
         `local_path` and `central_path`.
     """
-    sub_folder_names = (
-        folders.search_project_for_sub_or_ses_names(  # TODO: RENAME
-            cfg,
-            top_level_folder,
-            None,
-            "sub-*",
-            local_only,
-            return_full_path=True,
-        )
+    sub_folder_names = folders.search_project_for_sub_or_ses_names(
+        cfg,
+        top_level_folder,
+        None,
+        "sub-*",
+        local_only,
+        return_full_path=True,
     )
 
     if local_only:

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -295,7 +295,6 @@ def get_all_sub_and_ses_names(
     cfg: Configs,
     top_level_folder: TopLevelFolder,
     local_only: bool,
-    return_full_path: bool = False,
 ) -> Dict:
     """
     Get a list of every subject and session name in the
@@ -316,7 +315,7 @@ def get_all_sub_and_ses_names(
         `local_path` and `central_path`.
     """
     sub_folder_names = folders.search_project_for_sub_or_ses_names(
-        cfg, top_level_folder, None, "sub-*", local_only, return_full_path
+        cfg, top_level_folder, None, "sub-*", local_only, return_full_path=True
     )
 
     if local_only:
@@ -327,9 +326,17 @@ def get_all_sub_and_ses_names(
         )
 
     all_ses_folder_names = {}
-    for sub in all_sub_folder_names:
+    for sub_path in all_sub_folder_names:
+
+        sub = sub_path.name
+
         ses_folder_names = folders.search_project_for_sub_or_ses_names(
-            cfg, top_level_folder, sub, "ses-*", local_only, return_full_path
+            cfg,
+            top_level_folder,
+            sub,
+            "ses-*",
+            local_only,
+            return_full_path=True,
         )
 
         if local_only:

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -295,6 +295,7 @@ def get_all_sub_and_ses_names(
     cfg: Configs,
     top_level_folder: TopLevelFolder,
     local_only: bool,
+    return_full_path: bool = False,
 ) -> Dict:
     """
     Get a list of every subject and session name in the
@@ -315,7 +316,7 @@ def get_all_sub_and_ses_names(
         `local_path` and `central_path`.
     """
     sub_folder_names = folders.search_project_for_sub_or_ses_names(
-        cfg, top_level_folder, None, "sub-*", local_only
+        cfg, top_level_folder, None, "sub-*", local_only, return_full_path
     )
 
     if local_only:
@@ -328,7 +329,7 @@ def get_all_sub_and_ses_names(
     all_ses_folder_names = {}
     for sub in all_sub_folder_names:
         ses_folder_names = folders.search_project_for_sub_or_ses_names(
-            cfg, top_level_folder, sub, "ses-*", local_only
+            cfg, top_level_folder, sub, "ses-*", local_only, return_full_path
         )
 
         if local_only:

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -291,7 +291,7 @@ def get_existing_project_paths() -> List[Path]:
     return existing_project_paths
 
 
-def get_all_sub_and_ses_names(
+def get_all_sub_and_ses_paths(
     cfg: Configs,
     top_level_folder: TopLevelFolder,
     local_only: bool,

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -314,8 +314,15 @@ def get_all_sub_and_ses_names(
         If `True, only get names from `local_path`, otherwise from
         `local_path` and `central_path`.
     """
-    sub_folder_names = folders.search_project_for_sub_or_ses_names(
-        cfg, top_level_folder, None, "sub-*", local_only, return_full_path=True
+    sub_folder_names = (
+        folders.search_project_for_sub_or_ses_names(  # TODO: RENAME
+            cfg,
+            top_level_folder,
+            None,
+            "sub-*",
+            local_only,
+            return_full_path=True,
+        )
     )
 
     if local_only:

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -244,6 +244,7 @@ def search_ssh_central_for_folders(
     search_prefix: str,
     cfg: Configs,
     verbose: bool = True,
+    return_full_path: bool = False,
 ) -> Tuple[List[Any], List[Any]]:
     """
     Search for the search prefix in the search path over SSH.
@@ -274,6 +275,7 @@ def search_ssh_central_for_folders(
             search_path,
             search_prefix,
             verbose,
+            return_full_path,
         )
 
     return all_folder_names, all_filenames
@@ -284,6 +286,7 @@ def get_list_of_folder_names_over_sftp(
     search_path: Path,
     search_prefix: str,
     verbose: bool = True,
+    return_full_path: bool = False,
 ) -> Tuple[List[Any], List[Any]]:
     """
     Use paramiko's sftp to search a path
@@ -307,13 +310,19 @@ def get_list_of_folder_names_over_sftp(
     all_filenames = []
     try:
         for file_or_folder in sftp.listdir_attr(search_path.as_posix()):
+
             if file_or_folder.st_mode is not None and fnmatch.fnmatch(
                 file_or_folder.filename, search_prefix
             ):
+                to_append = (
+                    search_path / file_or_folder.filename
+                    if return_full_path
+                    else file_or_folder.filename
+                )
                 if stat.S_ISDIR(file_or_folder.st_mode):
-                    all_folder_names.append(file_or_folder.filename)
+                    all_folder_names.append(to_append)
                 else:
-                    all_filenames.append(file_or_folder.filename)
+                    all_filenames.append(to_append)
 
     except FileNotFoundError:
         if verbose:

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -129,23 +129,28 @@ def get_values_from_bids_formatted_name(
     Find the values associated with a key from a list of all
     BIDS-formatted file / folder names. This is typically used to
     find sub / ses values.
+
+    Notes
+    -----
+    This function does not raise through datashuttle because we
+    don't want to turn off logging, as some times these exceptions
+    are caught and skipped.
     """
     all_values = []
     for name in all_names:
 
         if key not in name:
-            log_and_raise_error(
+            raise NeuroBlueprintError(
                 f"The key {key} is not found in {name}", KeyError
             )
 
         value = get_value_from_key_regexp(name, key)
 
         if len(value) > 1:
-            log_and_raise_error(
+            raise NeuroBlueprintError(
                 f"There is more than one instance of {key} in {name}. "
                 f"NeuroBlueprint names must contain only one instance of "
                 f"each key.",
-                NeuroBlueprintError,
             )
 
         if return_as_int:
@@ -165,9 +170,8 @@ def sub_or_ses_value_to_int(value: str) -> int:
     try:
         int_value = int(value)
     except ValueError:
-        log_and_raise_error(
+        raise NeuroBlueprintError(
             f"Invalid character in subject or session value: {value}",
-            NeuroBlueprintError,
         )
     return int_value
 

--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -132,6 +132,7 @@ def get_values_from_bids_formatted_name(
     """
     all_values = []
     for name in all_names:
+
         if key not in name:
             log_and_raise_error(
                 f"The key {key} is not found in {name}", KeyError

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -987,3 +987,16 @@ def datatypes_are_invalid(
         return True, message
 
     return False, ""
+
+
+# TODO: check all docstrings, tidy up existing
+# TODO: tidy up some functions
+
+# TODO: check_high_level_project_structure
+# TODO: check broad vs. narrow
+# TODO: tidy up check_high_level_project_structure
+
+# 1) get all datatype folders
+# 2) perform the validation checks
+
+# do docs

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from itertools import chain
 from pathlib import Path
+
 from datashuttle.configs import canonical_folders
 from datashuttle.utils import formatting, getters, utils
 from datashuttle.utils.custom_exceptions import NeuroBlueprintError
@@ -69,17 +70,23 @@ def validate_list_of_names(
         lambda: names_include_special_characters(path_or_name_list),
         lambda: dashes_and_underscore_alternate_incorrectly(path_or_name_list),
         lambda: value_lengths_are_inconsistent(path_or_name_list, prefix),
-        lambda: names_dont_match_templates(path_or_name_list, prefix, name_templates),
+        lambda: names_dont_match_templates(
+            path_or_name_list, prefix, name_templates
+        ),
     ]
     if check_duplicates:
-        tests_to_run += [lambda: duplicated_prefix_values(path_or_name_list, prefix)]
+        tests_to_run += [
+            lambda: duplicated_prefix_values(path_or_name_list, prefix)
+        ]
 
     for test in tests_to_run:
 
         error_messages = test()
 
         for message in error_messages:
-            raise_display_mode(message, display_mode, log)  # check logging here, will log error per file?
+            raise_display_mode(
+                message, display_mode, log
+            )  # check logging here, will log error per file?
 
 
 def names_dont_match_templates(
@@ -122,8 +129,7 @@ def names_dont_match_templates(
 
 
 def get_path_and_name(path_or_name) -> Tuple[Optional[Path], str]:
-    """
-    """
+    """ """
     if isinstance(path_or_name, Path):
         return path_or_name, path_or_name.name
     else:
@@ -193,7 +199,7 @@ def name_begins_with_bad_key(
 
 
 def names_include_special_characters(
-    path_or_names_list: List[Path] | List[str]
+    path_or_names_list: List[Path] | List[str],
 ) -> List[str]:
     """
     Check that a list of NeuroBlueprint formatted
@@ -210,16 +216,17 @@ def names_include_special_characters(
 
         if name_has_special_character(name):
             error_messages.append(
-            f"The name: {name}, contains characters which are not alphanumeric, dash or underscore. Path: {path_}",
+                f"The name: {name}, contains characters which are not alphanumeric, dash or underscore. Path: {path_}",
             )
     return error_messages
+
 
 def name_has_special_character(name: str) -> bool:
     return not re.match("^[A-Za-z0-9_-]*$", name)
 
 
 def dashes_and_underscore_alternate_incorrectly(
-    path_or_names_list: List[Path] | List[str]
+    path_or_names_list: List[Path] | List[str],
 ) -> List[str]:
     """
     Check a list of NeuroBlueprint formatted names
@@ -272,7 +279,10 @@ def value_lengths_are_inconsistent(
     with a message detailing the error.
     """
     # TODO: this is all getting insane...
-    names_list = [path_or_name if isinstance(path_or_name, str) else path_or_name.name for path_or_name in path_or_names_list]
+    names_list = [
+        path_or_name if isinstance(path_or_name, str) else path_or_name.name
+        for path_or_name in path_or_names_list
+    ]
 
     prefix_values = utils.get_values_from_bids_formatted_name(
         names_list, prefix, return_as_int=False
@@ -407,7 +417,10 @@ def validate_project(
     # but need to do with SSH too. can embed somewhere...?
 
     folder_names = getters.get_all_sub_and_ses_names(  # could extend massively, also getting datatype as well as non-NB folders...
-        cfg, top_level_folder, local_only, return_full_path=True,
+        cfg,
+        top_level_folder,
+        local_only,
+        return_full_path=True,
     )
 
     # Check subjects
@@ -422,9 +435,10 @@ def validate_project(
         name_templates=name_templates,
     )
 
-
     for sub_path in all_sub_paths:
-        error_messages = new_name_duplicates_existing(sub_path.name, all_sub_paths, "sub")
+        error_messages = new_name_duplicates_existing(
+            sub_path.name, all_sub_paths, "sub"
+        )
         for message in error_messages:
             raise_display_mode(message, display_mode, log)
 
@@ -440,10 +454,12 @@ def validate_project(
     )
 
     # TODO: explain this! for each name, find all duplicates! (might be multiple...)
-    for ses_paths in folder_names["ses"].values():  # TODO: what is difference from above?
+    for ses_paths in folder_names[
+        "ses"
+    ].values():  # TODO: what is difference from above?
         for path_ in ses_paths:
             error_messages = new_name_duplicates_existing(
-                path_, ses_paths, "ses"
+                path_.name, ses_paths, "ses"
             )
             for message in error_messages:
                 raise_display_mode(message, display_mode, log)
@@ -519,6 +535,7 @@ def validate_names_against_project(
     folder_names = getters.get_all_sub_and_ses_names(
         cfg, top_level_folder, local_only, return_full_path=True
     )
+    breakpoint()
 
     # Check subjects
     if folder_names["sub"]:
@@ -530,7 +547,9 @@ def validate_names_against_project(
             name_templates=name_templates,
         )
 
-        valid_sub_in_project = strip_invalid_names(folder_names["sub"], "sub")  # TODO: need to do some work here...?
+        valid_sub_in_project = strip_invalid_names(
+            folder_names["sub"], "sub"
+        )  # TODO: need to do some work here...?
 
         check_sub_names_value_length_are_consistent_with_project(
             sub_names, valid_sub_in_project, display_mode, log
@@ -562,7 +581,7 @@ def validate_names_against_project(
                 valid_ses_in_sub = strip_invalid_names(
                     folder_names["ses"][new_sub], "ses"
                 )
-
+                breakpoint()
                 check_ses_names_value_length_are_consistent_with_project(
                     ses_names, valid_ses_in_sub, new_sub, display_mode, log
                 )
@@ -635,8 +654,9 @@ def check_ses_names_value_length_are_consistent_with_project(
             raise_display_mode(error_message[0], display_mode, log)
 
 
-
-def strip_invalid_names(path_or_names_list: List[Path] | List[str], prefix: Prefix) -> List[Path] | List[str]:
+def strip_invalid_names(
+    path_or_names_list: List[Path] | List[str], prefix: Prefix
+) -> List[Path] | List[str]:
     """ """
     new_list = []
     for path_or_name in path_or_names_list:
@@ -692,7 +712,7 @@ def new_name_duplicates_existing(
             if new_name != exist_name:
                 error_messages.append(
                     f"The prefix for {new_name} duplicates the name : {exist_name} at path: {exist_path}"
-            )
+                )
     return error_messages
 
 

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -97,7 +97,7 @@ def validate_list_of_names(
     check_duplicates: bool = True,
     name_templates: Optional[Dict] = None,
     log: bool = True,
-) -> None:
+) -> List[str]:
     """
     Validate a list of subject or session names, ensuring
     they are formatted as per NeuroBlueprint.
@@ -130,7 +130,7 @@ def validate_list_of_names(
     is modular. However for large projects this may become slow.
     """
     if len(path_or_name_list) == 0:
-        return
+        return []
 
     tests_to_run = [
         lambda: name_begins_with_bad_key(path_or_name_list, prefix),
@@ -432,7 +432,7 @@ def duplicated_prefix_values(
     error_message = []
     if (
         has_duplicate_ids
-    ):  # TOOD: this is an edge case that is only relevant for a passed list of names. Maybe we can remove this...
+    ):  # TODO: this is an edge case that is only relevant for a passed list of names. Maybe we can remove this...
         error_message.append(
             f"{prefix} names must all have unique integer ids"
             f" after the {prefix} prefix."
@@ -898,7 +898,7 @@ def strip_invalid_names(
     prefix: Prefix,
     display_mode,
     log,
-) -> List[Path]: ...
+) -> Tuple[List[Path], List[str]]: ...
 
 
 @overload
@@ -907,7 +907,7 @@ def strip_invalid_names(
     prefix: Prefix,
     display_mode,
     log,
-) -> List[str]: ...
+) -> Tuple[List[str], List[str]]: ...
 
 
 def strip_invalid_names(
@@ -915,7 +915,7 @@ def strip_invalid_names(
     prefix: Prefix,
     display_mode,
     log,
-) -> List[Path] | List[str]:
+) -> Tuple[List[Path] | List[str], List[str]]:
     """ """
     error_messages = []
     new_list = []

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -568,8 +568,11 @@ def validate_project(
         )
 
     # Display the collected errors using the selected method
-    for message in error_messages:
-        raise_display_mode(message, display_mode, log)
+    if any(error_messages):
+        for message in error_messages:
+            raise_display_mode(message, display_mode, log)
+    else:
+        utils.print_message_to_user("No validation issues detected.")
 
     return error_messages
 

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -105,7 +105,7 @@ def get_datatype_error(datatype_name, path_):
 
 def handle_path(message, path_):
     if path_:
-        message += f" Path: {path_}"
+        message += f" Path: {path_.as_posix()}"
     return message
 
 

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 if TYPE_CHECKING:
     from datashuttle.configs.config_class import Configs
@@ -24,59 +33,59 @@ from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 # -----------------------------------------------------------------------------
 
 
-def get_missing_prefix_error(name, prefix, path_):
+def get_missing_prefix_error(name: str, prefix, path_: Path | None) -> str:
     return handle_path(
         f"MISSING_PREFIX: The prefix {prefix} was not found in the name: {name}",
         path_,
     )
 
 
-def get_bad_value_error(name, prefix, path_):
+def get_bad_value_error(name: str, prefix, path_: Path | None) -> str:
     return handle_path(
         f"BAD_VALUE: The value for prefix {prefix} in name {name} is not an integer.",
         path_,
     )
 
 
-def get_duplicate_prefix_error(name, prefix, path_):
+def get_duplicate_prefix_error(name: str, prefix, path_: Path | None) -> str:
     return handle_path(
         f"DUPLICATE_PREFIX: The name: {name} of contains more than one instance of the prefix {prefix}.",
         path_,
     )
 
 
-def get_name_error(name, prefix, path_):
+def get_name_error(name: str, prefix: Prefix, path_: Path | None) -> str:
     return handle_path(
         f"BAD_NAME: The name: {name} of type: {prefix} is not valid.", path_
     )
 
 
-def get_special_char_error(name, path_):
+def get_special_char_error(name: str, path_: Path | None) -> str:
     return handle_path(
         f"SPECIAL_CHAR: The name: {name}, contains characters which are not alphanumeric, dash or underscore.",
         path_,
     )
 
 
-def get_name_format_error(name, path_):
+def get_name_format_error(name: str, path_: Path | None) -> str:
     return handle_path(
         f"NAME_FORMAT: The name {name} does not consist of key-value pairs separated by underscores.",
         path_,
     )
 
 
-def get_value_length_error(prefix):
+def get_value_length_error(prefix: Prefix) -> str:
     return f"VALUE_LENGTH: Inconsistent value lengths for the prefix: {prefix} were found in the project."
 
 
-def get_datetime_error(key, name, strfmt, path_):
+def get_datetime_error(key, name: str, strfmt: str, path_: Path | None) -> str:
     return handle_path(
         f"DATETIME: Name {name} contains an invalid {key}. It should be ISO format: {strfmt}.",
         path_,
     )
 
 
-def get_template_error(name, regexp, path_):
+def get_template_error(name: str, regexp: str, path_: Path | None) -> str:
     """
     The missing full-stop at the end is intentional, to avoid
     confusion when reading the regexp.
@@ -88,27 +97,31 @@ def get_template_error(name, regexp, path_):
 
 
 # TODO: TYPE HINTS!
-def get_missing_top_level_folder_error(path_, local_or_central):
+def get_missing_top_level_folder_error(
+    path_: Path | None, local_or_central: Literal["local", "central"]
+) -> str:
     return handle_path(
         f"TOP_LEVEL_FOLDER: The {local_or_central} project must contain a 'rawdata' or 'derivatives' folder.",
         path_,
     )
 
 
-def get_duplicate_name_error(new_name, exist_name, exist_path):
+def get_duplicate_name_error(
+    new_name: str, exist_name: str, exist_path: Path | None
+) -> str:
     return handle_path(
         f"DUPLICATE_NAME: The prefix for {new_name} duplicates the name: {exist_name}.",
         exist_path,
     )
 
 
-def get_datatype_error(datatype_name, path_):
+def get_datatype_error(datatype_name: str, path_: Path | None) -> str:
     return handle_path(
         f"DATATYPE: {datatype_name} is not a valid datatype name.", path_
     )
 
 
-def handle_path(message, path_):
+def handle_path(message: str, path_: Path | None) -> str:
     if path_:
         message += f" Path: {path_.as_posix()}"
     return message
@@ -830,7 +843,7 @@ def check_strict_mode(
         sub_level_name = sub_level_path.name
 
         if sub_level_name[:4] != "sub-":
-            message = get_name_error(sub_level_name, "sub-", sub_level_path)
+            message = get_name_error(sub_level_name, "sub", sub_level_path)
             error_messages.append(message)
             continue
 
@@ -850,9 +863,7 @@ def check_strict_mode(
             ses_level_name = ses_level_path.name
 
             if ses_level_name[:4] != "ses-":
-                message = get_name_error(
-                    ses_level_name, "ses-", ses_level_path
-                )
+                message = get_name_error(ses_level_name, "ses", ses_level_path)
                 error_messages.append(message)
 
             base_folder = cfg.get_base_folder("local", top_level_folder)

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -420,7 +420,6 @@ def validate_project(
         cfg,
         top_level_folder,
         local_only,
-        return_full_path=True,
     )
 
     # Check subjects
@@ -533,9 +532,8 @@ def validate_names_against_project(
     list under different circumstances. See issue #355
     """
     folder_names = getters.get_all_sub_and_ses_names(
-        cfg, top_level_folder, local_only, return_full_path=True
+        cfg, top_level_folder, local_only
     )
-    breakpoint()
 
     # Check subjects
     if folder_names["sub"]:
@@ -581,16 +579,15 @@ def validate_names_against_project(
                 valid_ses_in_sub = strip_invalid_names(
                     folder_names["ses"][new_sub], "ses"
                 )
-                breakpoint()
                 check_ses_names_value_length_are_consistent_with_project(
                     ses_names, valid_ses_in_sub, new_sub, display_mode, log
                 )
 
                 for new_ses in ses_names:
-                    failed, message = new_name_duplicates_existing(
+                    error_messages = new_name_duplicates_existing(
                         new_ses, valid_ses_in_sub, "ses"
                     )
-                    if failed:
+                    for message in error_messages:
                         raise_display_mode(message, display_mode, log)
 
 
@@ -638,7 +635,7 @@ def check_ses_names_value_length_are_consistent_with_project(
     this performs the same function for session. Potential to merge
     with that function, just some minor annoying differences.
     """
-    if value_lengths_are_inconsistent(valid_ses_in_sub, "ses")[0]:
+    if any(value_lengths_are_inconsistent(valid_ses_in_sub, "ses")):
         raise_display_mode(
             f"Cannot check names for inconsistent value lengths "
             f"because the session value lengths for subject "

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -91,7 +91,10 @@ def get_missing_top_level_folder_error(path_):
 
 
 def get_duplicate_name_error(new_name, exist_name, exist_path):
-    return f"DUPLICATE_NAME: The prefix for {new_name} duplicates the name : {exist_name} at path: {exist_path}"
+    return handle_path(
+        f"DUPLICATE_NAME: The prefix for {new_name} duplicates the name: {exist_name}.",
+        exist_path,
+    )
 
 
 def get_datatype_error(datatype_name, path_):
@@ -195,7 +198,7 @@ def prefix_is_duplicate_or_has_bad_values(
     """
     TODO
     """
-    value = utils.get_value_from_key_regexp(name, prefix)
+    value = re.findall(f"{prefix}(.*?)(?=_|$)", name)
 
     if len(value) == 0:
         return [get_missing_prefix_error(name, prefix, path_)]
@@ -374,9 +377,11 @@ def dashes_and_underscore_alternate_incorrectly(
     )
 
     if (
-        (dashes_underscores[0] != 1)
+        not any(dashes_underscores)
+        or dashes_underscores[0] != 1  # first must be -
+        or dashes_underscores[-1] != 1  # last must be -
         or underscore_dash_not_interleaved
-        or (name[-1] in discrim.keys())
+        or (name[-1] in discrim.keys())  # name cannot end with - or _
     ):
         return [get_name_format_error(name, path_)]
     else:
@@ -771,6 +776,7 @@ def validate_names_against_project(
     return error_messages
 
 
+# TODO: FIXUP!
 def check_high_level_project_structure(
     cfg: Configs, local_only: bool
 ) -> List[str]:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -425,6 +425,9 @@ def validate_project(
     # Check subjects
     all_sub_paths = folder_names["sub"]
 
+    all_sub_paths = strip_invalid_names(
+        all_sub_paths, "sub", display_mode, log
+    )
     validate_list_of_names(
         all_sub_paths,
         prefix="sub",
@@ -444,6 +447,10 @@ def validate_project(
     # Check sessions
     all_ses_paths = list(chain(*folder_names["ses"].values()))
 
+    all_ses_paths = strip_invalid_names(
+        all_ses_paths, "ses", display_mode, log
+    )
+
     validate_list_of_names(
         all_ses_paths,
         "ses",
@@ -453,9 +460,7 @@ def validate_project(
     )
 
     # TODO: explain this! for each name, find all duplicates! (might be multiple...)
-    for ses_paths in folder_names[
-        "ses"
-    ].values():  # TODO: what is difference from above?
+    for ses_paths in folder_names["ses"].values():
         for path_ in ses_paths:
             error_messages = new_name_duplicates_existing(
                 path_.name, ses_paths, "ses"
@@ -537,6 +542,11 @@ def validate_names_against_project(
 
     # Check subjects
     if folder_names["sub"]:
+
+        valid_sub_in_project = strip_invalid_names(
+            folder_names["sub"], "sub", display_mode, log
+        )
+
         validate_list_of_names(
             sub_names,
             prefix="sub",
@@ -544,10 +554,6 @@ def validate_names_against_project(
             display_mode=display_mode,
             name_templates=name_templates,
         )
-
-        valid_sub_in_project = strip_invalid_names(
-            folder_names["sub"], "sub"
-        )  # TODO: need to do some work here...?
 
         check_sub_names_value_length_are_consistent_with_project(
             sub_names, valid_sub_in_project, display_mode, log
@@ -577,7 +583,7 @@ def validate_names_against_project(
             if new_sub in folder_names["ses"]:
 
                 valid_ses_in_sub = strip_invalid_names(
-                    folder_names["ses"][new_sub], "ses"
+                    folder_names["ses"][new_sub], "ses", display_mode, log
                 )
                 check_ses_names_value_length_are_consistent_with_project(
                     ses_names, valid_ses_in_sub, new_sub, display_mode, log
@@ -652,7 +658,10 @@ def check_ses_names_value_length_are_consistent_with_project(
 
 
 def strip_invalid_names(
-    path_or_names_list: List[Path] | List[str], prefix: Prefix
+    path_or_names_list: List[Path] | List[str],
+    prefix: Prefix,
+    display_mode,
+    log,
 ) -> List[Path] | List[str]:
     """ """
     new_list = []
@@ -665,7 +674,10 @@ def strip_invalid_names(
                 [name], prefix, return_as_int=True
             )[0]
         except NeuroBlueprintError:
+            message = f"Invalid name: {name}. Path: {path_}"
+            raise_display_mode(message, display_mode, log)
             continue
+
         if path_:
             new_list.append(path_)
         else:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -77,8 +77,12 @@ def get_datetime_error(key, name, strfmt, path_):
 
 
 def get_template_error(name, regexp, path_):
+    """
+    The missing full-stop at the end is intentional, to avoid
+    confusion when reading the regexp.
+    """
     return handle_path(
-        f"TEMPLATE: The name: {name} does not match the template: {regexp}.",
+        f"TEMPLATE: The name: {name} does not match the template: {regexp}",
         path_,
     )
 
@@ -167,7 +171,7 @@ def validate_list_of_names(
             name, path_
         )
         error_messages += datetime_are_iso_format(name, path_)
-        error_messages + names_dont_match_templates(
+        error_messages += names_dont_match_templates(
             name, path_, prefix, name_templates
         )
 
@@ -610,7 +614,10 @@ def validate_project(
     for ses_paths in folder_paths["ses"].values():
 
         error_messages += validate_list_of_names(
-            ses_paths, "ses", check_value_lengths=False
+            ses_paths,
+            "ses",
+            check_value_lengths=False,
+            name_templates=name_templates,  # TODO: why did tests miss this!?!?
         )
 
     # Next, check inconsistent value lengths across the entire project
@@ -723,8 +730,7 @@ def validate_names_against_project(
 
         # First, validate the list of passed session names
         error_messages += validate_list_of_names(
-            ses_names,
-            "ses",
+            ses_names, "ses", name_templates=name_templates
         )
 
         if folder_paths["sub"]:

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -635,7 +635,7 @@ def validate_names_against_project(
     display_mode: DisplayMode = "error",
     log: bool = True,
     name_templates: Optional[Dict] = None,
-) -> List[str]:
+) -> None:
     """
     Given a list of subject and (optionally) session names,
     check that these names are formatted consistently with the
@@ -772,8 +772,6 @@ def validate_names_against_project(
     # Display the collected errors using the selected method
     for message in error_messages:
         raise_display_mode(message, display_mode, log)
-
-    return error_messages
 
 
 # TODO: FIXUP!

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -96,7 +96,6 @@ def get_template_error(name: str, regexp: str, path_: Path | None) -> str:
     )
 
 
-# TODO: TYPE HINTS!
 def get_missing_top_level_folder_error(
     path_: Path | None, local_or_central: Literal["local", "central"]
 ) -> str:
@@ -163,6 +162,7 @@ def validate_list_of_names(
 
     error_messages = []
 
+    # First, just validate each name individually
     for path_or_name in path_or_name_list:
 
         path_, name = get_path_and_name(path_or_name)
@@ -180,7 +180,11 @@ def validate_list_of_names(
             name, path_, prefix, name_templates
         )
 
-    # both of these are O(n^2)
+    # Next, check interactions between names (e.g. duplicates,
+    # inconsistent value lengths).  To do this we must strip names
+    # in which the ids (e.g. sub-001) is invalid).
+    # Note this called functions again loop over the list (O(n^2)) so
+    # this is not very efficient but these lists should never be that long.
     stripped_path_or_names_list = strip_uncheckable_names(
         path_or_name_list, prefix
     )

--- a/docs/source/pages/tutorials.md
+++ b/docs/source/pages/tutorials.md
@@ -15,10 +15,27 @@ Walk-through starting a new experiment with **datashuttle**.
 :::
 ::::
 
+
+::::{grid} 1 2 2 2
+:gutter: 4
+
+:::{grid-item-card} {fas}`desktop;sd-text-primary` Project Validation
+:link: tutorials/validation
+:link-type: doc
+:class-img-top: tutorial-link-image
+
+Check a project for
+[NeuroBlueprint](https://neuroblueprint.neuroinformatics.dev/latest/index.html)
+formatting issues.
+
+:::
+::::
+
 ```{toctree}
 :maxdepth: 2
 :caption: tutorials
 :hidden:
 
 tutorials/getting_started
+tutorials/validation
 ```

--- a/docs/source/pages/tutorials/validation.md
+++ b/docs/source/pages/tutorials/validation.md
@@ -6,7 +6,7 @@
 [NeuroBlueprint specification](https://neuroblueprint.neuroinformatics.dev/latest/specification.html).
 This will find and display a list of all formatting errors in the project.
 
-To quickly validate an existing project with only the project path, see [quick-validate-projects](how-to-validate-project).
+To quickly validate an existing project with only the project path, see [quick-validate-projects](quick-validate-projects).
 
 Otherwise, below we will cover how to validate a datashuttle project (which will additionally save validation results in a log file).
 Currently, validation is not available through the terminal-user interface.

--- a/docs/source/pages/tutorials/validation.md
+++ b/docs/source/pages/tutorials/validation.md
@@ -1,0 +1,121 @@
+(tutorial-validation)=
+
+# Project Validation
+
+**datashuttle** can validate a project against the
+[NeuroBlueprint specification](https://neuroblueprint.neuroinformatics.dev/latest/specification.html).
+This will find and display a list of all formatting errors in the project.
+
+To quickly validate an existing project with only the project path, see [quick-validate-projects](how-to-validate-project).
+
+Otherwise, below we will cover how to validate a datashuttle project (which will additionally save validation results in a log file).
+Currently, validation is not available through the terminal-user interface.
+
+# Validating a local project
+
+Project validation can be run with the [](datashuttle.DataShuttle.validate_project) function.
+
+This function will highlight validation errors within a project. For example, consider
+``my_project``, which has a NeuroBlueprint error (a subject that does not have an integer value):
+
+```shell
+└── my_project/
+    └── rawdata/
+        └── sub-abc
+```
+
+Violations of the NeuroBlueprint can be set to raise an error, be displayed as warnings or printed as output.
+They are also returned in a list of strings.
+
+```python
+from datashuttle import DataShuttle
+
+project = DataShuttle("my_project")
+
+project.make_config_file(local_path="/path/to/my/project")  # only required once, on initial project set up
+
+error_messages = project.validate_project(
+    "rawdata",
+    display_mode="warn",
+)
+# UserWarning: BAD_VALUE: The value for prefix sub in name sub-abc is not an integer. Path: <path to folder>
+```
+
+This outputs any NeuroBlueprint validation as a warning.
+
+The returned ``error_messages`` is a last of strings containing all validation errors, to be used if required e.g.:
+
+```python
+print(error_messages)
+# [BAD_VALUE: The value for prefix sub in name sub-abc is not an integer. Path: <path to folder>]
+```
+
+The options for `display_mode` and ``"error"``, ``"warn"`` and ``"print"``.
+For `"error"`, only the first  encountered NeuroBlueprint violation will be raised.
+
+:::{note}
+
+By default, only ``sub-`` and ``ses-`` prefixed folders are validated
+in the project. To validate all folders (including
+[datatypes](https://neuroblueprint.neuroinformatics.dev/latest/specification.html#datatype))
+use ``strict_mode``.
+
+:::
+
+
+## ``strict_mode``
+
+In strict-mode, all folders outside the
+``datatype`` ]()
+folder (e.g. ``"ephys"``) must be NeuroBlueprint-formatted.
+
+NeuroBlueprint does not require all folders in the project to be NeuroBlueprint-formatted ``sub-``, ``ses-`` or
+datatype folders.
+
+For example, ``some_other_folder``:
+
+```shell
+└── my_project/
+    └── rawdata/
+        ├── sub-001/
+        │   └── ...
+        └── some_other_folder/
+            └── ...
+```
+
+However, this means it is hard to validate all folder names, as it is not possible to determine whether
+these are mistkaes e.g. ``rat-001`` or auxiliary folders. By default, **datashuttle** will only look for
+``sub-`` or ``ses-`` prefixed files to validate.
+
+In ``strict_mode``, non-NeuroBlueprint formatted folders are not allowed (except within datatype folders).
+Therefore, any additional folders at the subject or session level will raise a validation error, for example:
+
+```python
+project.validate_project(
+    "rawdata",
+    display_mode="print",
+    strict_mode=True
+)
+
+# BAD_NAME: The name: some_other_folder of type: sub- is not valid. Path: <path to folder>
+
+```
+
+# Validating local and central together
+
+Validation can be performed across all folders in projects in which data is transferred
+between a 'local' and 'central' machine. The validation will combine ``sub-`` and ``ses-``
+folders across 'local' and 'central' before validation. This is useful check against inconsistent value lengths
+(e.g. `sub-001` vs `sub-02`) and duplicate names (e.g. ``sub-001`` and ``sub-001_date-20240101``) across
+the 'local' and 'central' project.
+
+To perform this type of validation, connection configurations [must be set](make-a-full-project_target).
+The ``local_only`` argument must be set to ``False``:
+
+```python
+error_messages = project.validate_project(
+    "rawdata",
+    display_mode="warn",
+    local_only=False
+)
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,14 +20,14 @@ from types import SimpleNamespace
 import pytest
 import test_utils
 
-test_ssh = False
+test_ssh = True
 username = "jziminski"
-central_host_id = "hpc-gw1.hpc.swc.ucl.ac.uk"
+central_host_id = "ssh.swc.ucl.ac.uk"
 server_path = r"/ceph/neuroinformatics/neuroinformatics/scratch/datashuttle_tests/fake_data"
 
 
 if platform.system() == "Windows":
-    ssh_key_path = r"C:\Users\User\.datashuttle\test_file_conflicts_ssh_key"
+    ssh_key_path = r"C:\Users\Joe\.datashuttle\test_file_conflicts_ssh_key"
     filesystem_path = "X:/neuroinformatics/scratch/datashuttle_tests/fake_data"
 
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 import pytest
 import test_utils
 
-test_ssh = True
+test_ssh = False
 username = "jziminski"
 central_host_id = "ssh.swc.ucl.ac.uk"
 server_path = r"/ceph/neuroinformatics/neuroinformatics/scratch/datashuttle_tests/fake_data"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -559,12 +559,18 @@ def swap_local_and_central_paths(project, swap_last_folder_only=False):
     os.makedirs(central_path, exist_ok=True)
 
     if swap_last_folder_only:
-        new_local_path = local_path.parent / central_path.name
+        new_local_path = (
+            local_path.parent.parent
+            / central_path.parent.name
+            / central_path.name
+        )
         os.makedirs(new_local_path, exist_ok=True)
 
         project.update_config_file(local_path=new_local_path)
         project.update_config_file(
-            central_path=central_path.parent / local_path.name
+            central_path=central_path.parent.parent
+            / local_path.parent.name
+            / local_path.name
         )
     else:
         os.makedirs(local_path, exist_ok=True)

--- a/tests/tests_integration/test_formatting.py
+++ b/tests/tests_integration/test_formatting.py
@@ -28,12 +28,12 @@ class TestFormatting(BaseTest):
         """
         with pytest.raises(NeuroBlueprintError) as e:
             formatting.check_and_format_names(
-                ["1", "2", "3", "3", "4"], prefix
+                ["1", "2", "3", "3_id-hello", "4"], prefix
             )
 
         assert (
-            f"{prefix} names must all have unique integer "
-            f"ids after the {prefix} prefix." == str(e.value)
+            f"DUPLICATE_NAME: The prefix for {prefix}-3 duplicates the name: {prefix}-3_id-hello."
+            == str(e.value)
         )
 
     def test_format_names_prefix(self):

--- a/tests/tests_integration/test_local_only_mode.py
+++ b/tests/tests_integration/test_local_only_mode.py
@@ -98,6 +98,9 @@ class TestLocalOnlyProject(BaseTest):
         project.update_config_file(
             central_path=central_path, connection_method="local_filesystem"
         )
+        (project.cfg["central_path"] / "rawdata").mkdir(
+            parents=True
+        )  # to pass validation
 
         paths_ = project.create_folders(
             "rawdata", "sub-001", "ses-001", "ephys"

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -75,15 +75,13 @@ class TestLogging:
         """
         Check that errors are caught and logged properly.
         """
-        try:
+        with pytest.raises(NeuroBlueprintError):
             project.create_folders("rawdata", "sob-001")
-        except:
-            pass
 
         log = test_utils.read_log_file(project.cfg.logging_path)
 
         assert "ERROR" in log
-        assert "Problem with name:" in log
+        assert "BAD_VALUE:" in log
 
     # -------------------------------------------------------------------------
     # Functional Tests
@@ -451,9 +449,8 @@ class TestLogging:
         log = test_utils.read_log_file(project.cfg.logging_path)
 
         assert (
-            "A sub already exists with the same "
-            "sub id as sub-001_datetime-123213T123122. "
-            "The existing folder is sub-001" in log
+            "DUPLICATE_NAME: The prefix for sub-001_datetime-123213T123122 duplicates the name: sub-001"
+            in log
         )
 
     @pytest.mark.parametrize("project", ["local", "full"], indirect=True)

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -62,11 +62,11 @@ class TestPersistentSettings(BaseTest):
         # Bad sub name
         with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", bad_sub)
+
         assert (
-            str(e.value) == "The name: "
-            "sub-3_id-abC_random-helloworld "
-            "does not match the template: "
-            "sub-\d_id-.?.?_random-.*"
+            str(e.value)
+            == "TEMPLATE: The name: sub-3_id-abC_random-helloworld "
+            "does not match the template: sub-\\d_id-.?.?_random-.*"
         )
 
         # Good sub name (should not raise)
@@ -77,10 +77,9 @@ class TestPersistentSettings(BaseTest):
             project.create_folders("rawdata", good_sub, bad_ses)
 
         assert (
-            str(e.value) == "The name: "
-            "ses-33_id-xyz_ranDUM-helloworld "
-            "does not match the template: "
-            "ses-\\d\\d_id-.?.?.?_random-.*"
+            str(e.value)
+            == "TEMPLATE: The name: ses-33_id-xyz_ranDUM-helloworld "
+            "does not match the template: ses-\\d\\d_id-.?.?.?_random-.*"
         )
 
         # Good ses name (should not raise)
@@ -162,8 +161,8 @@ class TestPersistentSettings(BaseTest):
             project.create_folders("rawdata", "sub-@@@")
 
         assert (
-            "The name: name: sub-@@@, contains characters which are not alphanumeric"
-            in str(e)
+            "BAD_VALUE: The value for prefix sub in name sub-@@@ is not an integer."
+            == str(e.value)
         )
 
     def get_settings_default(self):

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -18,7 +18,7 @@ class TestFileTransfer:
     @pytest.fixture(
         scope="class",
         params=[  # Set running SSH or local filesystem (see docstring).
-            False,
+            # False,
             pytest.param(
                 True,
                 marks=pytest.mark.skipif(
@@ -88,7 +88,7 @@ class TestFileTransfer:
             ssh_test_utils.setup_project_for_ssh(
                 project,
                 test_utils.make_test_path(
-                    central_path, test_project_name, "central"
+                    central_path, "central", test_project_name
                 ),
                 ssh_config.CENTRAL_HOST_ID,
                 ssh_config.USERNAME,
@@ -126,10 +126,10 @@ class TestFileTransfer:
         [
             ["all"],
             ["all_sub"],
-            ["all_non_sub"],
-            ["sub-001"],
-            ["sub-003_date-20231901"],
-            ["sub-002", "all_non_sub"],
+            #         ["all_non_sub"],
+            #         ["sub-001"],
+            #         ["sub-003_date-20231901"],
+            #         ["sub-002", "all_non_sub"],
         ],
     )
     @pytest.mark.parametrize(
@@ -137,10 +137,10 @@ class TestFileTransfer:
         [
             ["all"],
             ["all_non_ses"],
-            ["all_ses"],
-            ["ses-001"],
-            ["ses-002_random-key"],
-            ["all_non_ses", "ses-001"],
+            #       ["all_ses"],
+            #       ["ses-001"],
+            #       ["ses-002_random-key"],
+            #       ["all_non_ses", "ses-001"],
         ],
     )
     @pytest.mark.parametrize(
@@ -148,12 +148,12 @@ class TestFileTransfer:
         [
             ["all"],
             ["all_non_datatype"],
-            ["all_datatype"],
-            ["behav"],
-            ["ephys"],
-            ["anat"],
-            ["funcimg"],
-            ["anat", "behav", "all_non_datatype"],
+            #        ["all_datatype"],
+            #        ["behav"],
+            #        ["ephys"],
+            #        ["anat"],
+            #       ["funcimg"],
+            #        ["anat", "behav", "all_non_datatype"],
         ],
     )
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])

--- a/tests/tests_integration/test_ssh_file_transfer.py
+++ b/tests/tests_integration/test_ssh_file_transfer.py
@@ -126,10 +126,10 @@ class TestFileTransfer:
         [
             ["all"],
             ["all_sub"],
-            #         ["all_non_sub"],
-            #         ["sub-001"],
-            #         ["sub-003_date-20231901"],
-            #         ["sub-002", "all_non_sub"],
+            ["all_non_sub"],
+            ["sub-001"],
+            ["sub-003_date-20231901"],
+            ["sub-002", "all_non_sub"],
         ],
     )
     @pytest.mark.parametrize(
@@ -137,10 +137,10 @@ class TestFileTransfer:
         [
             ["all"],
             ["all_non_ses"],
-            #       ["all_ses"],
-            #       ["ses-001"],
-            #       ["ses-002_random-key"],
-            #       ["all_non_ses", "ses-001"],
+            ["all_ses"],
+            ["ses-001"],
+            ["ses-002_random-key"],
+            ["all_non_ses", "ses-001"],
         ],
     )
     @pytest.mark.parametrize(
@@ -148,12 +148,12 @@ class TestFileTransfer:
         [
             ["all"],
             ["all_non_datatype"],
-            #        ["all_datatype"],
-            #        ["behav"],
-            #        ["ephys"],
-            #        ["anat"],
-            #       ["funcimg"],
-            #        ["anat", "behav", "all_non_datatype"],
+            ["all_datatype"],
+            ["behav"],
+            ["ephys"],
+            ["anat"],
+            ["funcimg"],
+            ["anat", "behav", "all_non_datatype"],
         ],
     )
     @pytest.mark.parametrize("upload_or_download", ["upload", "download"])

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -572,13 +572,11 @@ class TestValidation(BaseTest):
                 local_only=True,
                 display_mode="error",
             )
+
         assert (
             "Cannot check names for inconsistent value lengths because the subject value"
             in str(e.value)
         )
-
-        # Just a cursory check the path is included in the output
-        assert "Path" in str(e.value)
 
     @pytest.mark.parametrize("project", ["local", "full"], indirect=True)
     def test_validate_names_against_project_interactions(self, project):

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -888,11 +888,11 @@ class TestValidation(BaseTest):
             )
 
         assert (
-            "BAD_NAME: The name: bad_sub_name of type: sub- is not valid"
+            "BAD_NAME: The name: bad_sub_name of type: sub is not valid"
             in str(w[0].message)
         )
         assert (
-            "BAD_NAME: The name: bad_sesname of type: ses- is not valid."
+            "BAD_NAME: The name: bad_sesname of type: ses is not valid."
             in str(w[1].message)
         )
         assert (

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -343,9 +343,9 @@ class TestValidation(BaseTest):
             project.validate_project(
                 "rawdata", display_mode="warn", local_only=False
             )
-        assert "VALUE_LENGTH" in str(w[0].message)
+        assert "DUPLICATE_NAME" in str(w[0].message)
         assert "DUPLICATE_NAME" in str(w[1].message)
-        assert "DUPLICATE_NAME" in str(w[2].message)
+        assert "VALUE_LENGTH" in str(w[2].message)
 
         # Finally, check that some bad sessions (ses-01) are caught.
         project.create_folders(
@@ -363,8 +363,8 @@ class TestValidation(BaseTest):
             project.validate_project(
                 "rawdata", display_mode="warn", local_only=False
             )
-        assert "VALUE_LENGTH" in str(w[0].message)
-        assert "VALUE_LENGTH" in str(w[3].message)
+        assert "VALUE_LENGTH" in str(w[2].message)
+        assert "VALUE_LENGTH" in str(w[5].message)
 
     # -------------------------------------------------------------------------
     # Test validate names against project
@@ -404,7 +404,11 @@ class TestValidation(BaseTest):
             validation.validate_names_against_project(
                 project.cfg, "rawdata", ["sab-001"], local_only=True
             )
-        assert "BAD_NAME" in str(e.value)
+        assert (
+            "MISSING_PREFIX: The prefix sub was not found in the name: sab-001"
+            in str(e.value)
+        )
+
         # Now check the bad names don't interfere with
         # inconsistent value lengths or duplicate names.
         project.create_folders("rawdata", "sub-004", "ses-001")

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -56,6 +56,7 @@ class TestValidation(BaseTest):
 
         os.makedirs(project.cfg["local_path"] / "rawdata" / sub_name)
         os.makedirs(project.cfg["local_path"] / "rawdata" / bad_sub_name)
+
         self.check_inconsistent_sub_or_ses_value_length_warning(
             project, "sub", local_only=True
         )
@@ -288,15 +289,17 @@ class TestValidation(BaseTest):
         with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub_100")
 
-        assert "Invalid character in subject or session value: sub" in str(
-            e.value
+        assert (
+            "BAD_VALUE: The value for prefix sub in name sub-sub_100 is not an integer."
+            == str(e.value)
         )
 
         with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub-001", "ses_100")
 
-        assert "Invalid character in subject or session value: ses" in str(
-            e.value
+        assert (
+            "BAD_VALUE: The value for prefix ses in name ses-ses_100 is not an integer."
+            == str(e.value)
         )
 
     # -------------------------------------------------------------------------
@@ -661,7 +664,6 @@ class TestValidation(BaseTest):
             "rawdata",
             "sub-03@TIME@",
         )
-
         with pytest.raises(NeuroBlueprintError):
             # use misspelled time tag, should raise
             project.create_folders(

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -348,6 +348,7 @@ class TestValidation(BaseTest):
                 "rawdata", display_mode="error", local_only=False
             )
         assert "DUPLICATE_NAME" in str(e.value)
+        assert "Path" in str(e.value)  # cursory check Path is returned
 
         # Now check warnings are shown when there are multiple validation
         # issues across local and central.
@@ -387,6 +388,9 @@ class TestValidation(BaseTest):
             "VALUE_LENGTH: Inconsistent value lengths for the prefix: ses"
             in str(w[3].message)
         )
+        assert "Path" not in str(
+            w[3].message
+        )  # no path in VALUE_LENGTH errors
 
     # -------------------------------------------------------------------------
     # Test validate names against project
@@ -468,6 +472,7 @@ class TestValidation(BaseTest):
             in str(e.value)
         )
 
+        breakpoint()
         with pytest.raises(NeuroBlueprintError) as e:
             validation.validate_names_against_project(
                 project.cfg,
@@ -518,6 +523,8 @@ class TestValidation(BaseTest):
             "Cannot check names for inconsistent value lengths because the subject value"
             in str(e.value)
         )
+        # Just a cursory check the path is included in the output
+        assert "Path" in str(e.value)
 
     @pytest.mark.parametrize("project", ["local", "full"], indirect=True)
     def test_validate_names_against_project_interactions(self, project):

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -247,7 +247,10 @@ class TestValidation(BaseTest):
         for bad_sub_name in ["sub-001_@DATE@", "sub-001_extra-key"]:
             with pytest.raises(NeuroBlueprintError) as e:
                 project.create_folders("rawdata", bad_sub_name, "ses-001")
-            assert "A sub already exists" in str(e.value)
+            try:
+                assert "A sub already exists" in str(e.value)
+            except:
+                breakpoint()
 
         project.create_folders("rawdata", "sub-001", "ses-001")
 
@@ -340,10 +343,13 @@ class TestValidation(BaseTest):
                 "rawdata", display_mode="error", local_only=False
             )
 
-        assert (
-            "A sub already exists with the same sub id as sub-002_id-11"
-            in str(e.value)
-        )
+        try:
+            assert (
+                "A sub already exists with the same sub id as sub-002_id-11"
+                in str(e.value)
+            )
+        except:
+            breakpoint()
 
         # Now check warnings are shown when there are multiple validation
         # issues across local and central.
@@ -425,10 +431,13 @@ class TestValidation(BaseTest):
                 project.cfg, "rawdata", ["sab-001"], local_only=True
             )
 
-        assert (
-            str(e.value)
-            == "The name: sab-001 do not begin with the required prefix: sub"
-        )
+        try:
+            assert (
+                str(e.value)
+                == "The name: sab-001 do not begin with the required prefix: sub"
+            )
+        except:
+            breakpoint()
 
         # Now check the bad names don't interfere with
         # inconsistent value lengths or duplicate names.
@@ -545,10 +554,13 @@ class TestValidation(BaseTest):
                 local_only=True,
                 display_mode="error",
             )
-        assert (
-            "same sub id as sub-1_id-11. "
-            "The existing folder is sub-1_id-abc." in str(e.value)
-        )
+        try:
+            assert (
+                "same sub id as sub-1_id-11. "
+                "The existing folder is sub-1_id-abc." in str(e.value)
+            )
+        except:
+            breakpoint()
 
         # Now check multiple different types of error are warned about
         sub_names = ["sub-002", "sub-1_id-11", "sub-3_id-c", "sub-4"]

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -188,9 +188,8 @@ class TestValidation(BaseTest):
         with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders("rawdata", "sub-001_id-125")
 
-        assert (
-            "A sub already "
-            "exists with the same sub id as sub-001_id-125" in str(e.value)
+        assert "The prefix for sub-001_id-125 duplicates the name" in str(
+            e.value
         )
 
         project.create_folders("rawdata", "sub-003")
@@ -204,9 +203,8 @@ class TestValidation(BaseTest):
                 "rawdata", "sub-001_id-123", "ses-002_date-1607"
             )
 
-        assert (
-            "A ses already exists with the same "
-            "ses id as ses-002_date-1607" in str(e.value)
+        assert "The prefix for ses-002_date-1607 duplicates the name" in str(
+            e.value
         )
 
         project.create_folders("rawdata", "sub-001_id-123", "ses-003")
@@ -247,10 +245,7 @@ class TestValidation(BaseTest):
         for bad_sub_name in ["sub-001_@DATE@", "sub-001_extra-key"]:
             with pytest.raises(NeuroBlueprintError) as e:
                 project.create_folders("rawdata", bad_sub_name, "ses-001")
-            try:
-                assert "A sub already exists" in str(e.value)
-            except:
-                breakpoint()
+            assert "duplicates the name" in str(e.value)
 
         project.create_folders("rawdata", "sub-001", "ses-001")
 
@@ -258,7 +253,7 @@ class TestValidation(BaseTest):
             project.create_folders(
                 "rawdata", "sub-001", "ses-001_extra-key", "behav"
             )
-        assert "A ses already exists with the same ses id as ses-001" in str(
+        assert "The prefix for ses-001_extra-key duplicates the name" in str(
             e.value
         )
 
@@ -266,13 +261,17 @@ class TestValidation(BaseTest):
             project.create_folders(
                 "rawdata", "sub-001_extra-key", "ses-001", "behav"
             )
-        assert "A sub already exists " in str(e.value)
+        assert "The prefix for sub-001_extra-key duplicates the name" in str(
+            e.value
+        )
 
         with pytest.raises(NeuroBlueprintError) as e:
             project.create_folders(
                 "rawdata", "sub-001_extra-key", "ses-001_@DATE@", "behav"
             )
-        assert "A sub already exists " in str(e.value)
+        assert "The prefix for sub-001_extra-key duplicates the name" in str(
+            e.value
+        )
 
         project.create_folders("rawdata", "sub-001", "ses-001", "behav")
 
@@ -284,8 +283,9 @@ class TestValidation(BaseTest):
             project.create_folders(
                 "rawdata", ["sub-001", "sub-002"], "ses-002_@DATE@", "ephys"
             )
-        assert "A ses already exists with the same ses id as ses-002" in str(
-            e.value
+        assert (
+            "The prefix for ses-002_date-20250218 duplicates the name"
+            in str(e.value)
         )
 
     # -------------------------------------------------------------------------
@@ -343,13 +343,9 @@ class TestValidation(BaseTest):
                 "rawdata", display_mode="error", local_only=False
             )
 
-        try:
-            assert (
-                "A sub already exists with the same sub id as sub-002_id-11"
-                in str(e.value)
-            )
-        except:
-            breakpoint()
+        assert "The prefix for sub-002_id-11 duplicates the name" in str(
+            e.value
+        )
 
         # Now check warnings are shown when there are multiple validation
         # issues across local and central.
@@ -365,8 +361,13 @@ class TestValidation(BaseTest):
         assert "Inconsistent value lengths for the key sub" in str(
             w[0].message
         )
-        assert "the same sub id as sub-002_id-11." in str(w[1].message)
-        assert "with the same sub id as sub-002" in str(w[2].message)
+        assert "The prefix for sub-002_id-11 duplicates the name" in str(
+            w[1].message
+        )
+
+        assert "The prefix for sub-002 duplicates the name" in str(
+            w[2].message
+        )
 
         # Finally, check that some bad sessions (ses-01) are caught.
         project.create_folders(
@@ -431,13 +432,10 @@ class TestValidation(BaseTest):
                 project.cfg, "rawdata", ["sab-001"], local_only=True
             )
 
-        try:
-            assert (
-                str(e.value)
-                == "The name: sab-001 do not begin with the required prefix: sub"
-            )
-        except:
-            breakpoint()
+        assert (
+            str(e.value)
+            == "The folder sab-001 does not begin with the required prefix. Path: None"  # TODO: only add path if there!!!
+        )
 
         # Now check the bad names don't interfere with
         # inconsistent value lengths or duplicate names.
@@ -465,9 +463,8 @@ class TestValidation(BaseTest):
             validation.validate_names_against_project(
                 project.cfg, "rawdata", ["sub-004_id-123"], local_only=True
             )
-        assert (
-            "A sub already exists with the same sub id as sub-004_id-123."
-            in str(e.value)
+        assert "The prefix for sub-004_id-123 duplicates the name" in str(
+            e.value
         )
 
         with pytest.raises(NeuroBlueprintError) as e:
@@ -478,9 +475,8 @@ class TestValidation(BaseTest):
                 ["ses-001_date-121212"],
                 local_only=True,
             )
-        assert (
-            "A ses already exists with the same ses id as ses-001_date-121212."
-            in str(e.value)
+        assert "The prefix for ses-001_date-121212 duplicates the name" in str(
+            e.value
         )
 
         # Finally make folders within the existing project that have
@@ -554,13 +550,7 @@ class TestValidation(BaseTest):
                 local_only=True,
                 display_mode="error",
             )
-        try:
-            assert (
-                "same sub id as sub-1_id-11. "
-                "The existing folder is sub-1_id-abc." in str(e.value)
-            )
-        except:
-            breakpoint()
+        assert "The prefix for sub-1_id-11 duplicates the name" in str(e.value)
 
         # Now check multiple different types of error are warned about
         sub_names = ["sub-002", "sub-1_id-11", "sub-3_id-c", "sub-4"]
@@ -583,13 +573,11 @@ class TestValidation(BaseTest):
         assert "Inconsistent value lengths for the key sub were found." in str(
             w[1].message
         )
-        assert (
-            "A sub already exists with the same sub id as sub-002. "
-            "The existing folder is sub-2_id-b." in str(w[2].message)
+        assert "The prefix for sub-002 duplicates the name" in str(
+            w[2].message
         )
-        assert (
-            "sub already exists with the same sub id as sub-1_id-11. "
-            "The existing folder is sub-1_id-abc." in str(w[3].message)
+        assert "The prefix for sub-1_id-11 duplicates the name" in str(
+            w[3].message
         )
 
         if project.is_local_project():
@@ -621,8 +609,8 @@ class TestValidation(BaseTest):
             )
 
         assert (
-            "same sub id as sub-4. "
-            "The existing folder is sub-4_date-2023." in str(e.value)
+            "The prefix for sub-4 duplicates the name : sub-4_date-2023"
+            in str(e.value)
         )
 
         # Now, make some sessions locally and on central. Check that
@@ -663,13 +651,11 @@ class TestValidation(BaseTest):
                 display_mode="warn",
             )
 
-        assert (
-            "the same ses id as ses-002_id-11. "
-            "The existing folder is ses-002." in str(w[0].message)
+        assert "The prefix for ses-002_id-11 duplicates the name" in str(
+            w[0].message
         )
-        assert (
-            "the same ses id as ses-003_id-random. "
-            "The existing folder is ses-003." in str(w[1].message)
+        assert "The prefix for ses-003_id-random duplicates the name" in str(
+            w[1].message
         )
 
     @pytest.mark.parametrize("project", ["local", "full"], indirect=True)

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -435,28 +435,22 @@ class TestTuiCreateFolders(TuiBase):
             await self.double_click(
                 pilot, "#create_folders_session_input", control=True
             )
-            try:
-                assert (
-                    pilot.app.screen.query_one(
-                        "#create_folders_session_input"
-                    ).value
-                    == "ses-...."
-                )
-            except:
-                breakpoint()
+            assert (
+                pilot.app.screen.query_one(
+                    "#create_folders_session_input"
+                ).value
+                == "ses-...."
+            )
 
             await self.double_click(
                 pilot, "#create_folders_subject_input", control=False
             )
-            try:
-                assert (
-                    pilot.app.screen.query_one(
-                        "#create_folders_subject_input"
-                    ).value
-                    == "sub-002"
-                )
-            except:
-                breakpoint()
+            assert (
+                pilot.app.screen.query_one(
+                    "#create_folders_subject_input"
+                ).value
+                == "sub-002"
+            )
 
             await self.fill_input(
                 pilot, "#create_folders_subject_input", "sub-001"
@@ -464,16 +458,12 @@ class TestTuiCreateFolders(TuiBase):
             await self.double_click(
                 pilot, "#create_folders_session_input", control=False
             )
-            try:
-                assert (
-                    pilot.app.screen.query_one(
-                        "#create_folders_session_input"
-                    ).value
-                    == "ses-0002"
-                )
-            except:
-                breakpoint()
-
+            assert (
+                pilot.app.screen.query_one(
+                    "#create_folders_session_input"
+                ).value
+                == "ses-0002"
+            )
             await pilot.pause()
 
     @pytest.mark.asyncio

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -246,15 +246,12 @@ class TestTuiCreateFolders(TuiBase):
             await self.fill_input(
                 pilot, "#create_folders_subject_input", "sub-001_@DATE@"
             )
-            try:
-                assert (
-                    "DUPLICATE_NAME: The prefix for sub-001_date-"
-                    in pilot.app.screen.query_one(
-                        "#create_folders_subject_input"
-                    ).tooltip
-                )
-            except:
-                breakpoint()
+            assert (
+                "DUPLICATE_NAME: The prefix for sub-001_date-"
+                in pilot.app.screen.query_one(
+                    "#create_folders_subject_input"
+                ).tooltip
+            )
 
             await pilot.pause()
 

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -201,7 +201,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).tooltip
-                == "Invalid character in subject or session value: abc"
+                == "BAD_VALUE: The value for prefix sub in name sub-abc is not an integer."
             )
 
             await self.fill_input(
@@ -215,9 +215,8 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_session_input"
                 ).tooltip
-                == "Invalid character in subject or session value: abc"
+                == "BAD_VALUE: The value for prefix sub in name sub-abc is not an integer."
             )
-
             await self.fill_input(
                 pilot, "#create_folders_subject_input", "sub-001"
             )
@@ -232,9 +231,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_session_input"
                 ).tooltip
-                == "There is more than one instance of ses in "
-                "ses-001_ses-001. NeuroBlueprint names must contain "
-                "only one instance of each key."
+                == "DUPLICATE_PREFIX: The name: ses-001_ses-001 of contains more than one instance of the prefix ses."
             )
 
             await self.fill_input(
@@ -250,7 +247,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot, "#create_folders_subject_input", "sub-001_@DATE@"
             )
             assert (
-                "A sub already exists with the same sub id as"
+                "DUPLICATE_NAME: The prefix for sub-001_date-20250226 duplicates the name: sub-001."
                 in pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).tooltip
@@ -292,8 +289,9 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#messagebox_message_label"
                 ).renderable
-                == "Invalid character in subject or session value: abc"
+                == "BAD_VALUE: The value for prefix sub in name sub-abc is not an integer."
             )
+
             await self.close_messagebox(pilot)
 
             assert not any(
@@ -362,12 +360,12 @@ class TestTuiCreateFolders(TuiBase):
             await self.fill_input(
                 pilot, "#create_folders_subject_input", "sub-0001"
             )
+
             assert (
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).tooltip
-                == "The name: sub-0001 does not match "
-                "the template: sub-\\d\\d\\d"
+                == "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             # It is expected that sub errors propagate to session input.
@@ -380,20 +378,19 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_session_input"
                 ).tooltip
-                == "The name: sub-0001 does not "
-                "match the template: sub-\\d\\d\\d"
+                == "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             # Try and make the folders, displaying a validation error.
             await self.scroll_to_click_pause(
                 pilot, "#create_folders_create_folders_button"
             )
-
             assert pilot.app.screen.query_one(
                 "#messagebox_message_label"
             ).renderable == (
-                "The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
+
             await self.close_messagebox(pilot)
 
             # Now make the correct folders respecting the name templates
@@ -410,7 +407,6 @@ class TestTuiCreateFolders(TuiBase):
             await self.fill_input(
                 pilot, "#create_folders_session_input", "ses-001"
             )
-
             assert (
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
@@ -421,7 +417,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_session_input"
                 ).tooltip
-                == "The name: ses-001 does not match the template: ses-...."
+                == "TEMPLATE: The name: ses-001 does not match the template: ses-...."
             )
 
             # Finally, double-click the input to suggest next
@@ -439,22 +435,28 @@ class TestTuiCreateFolders(TuiBase):
             await self.double_click(
                 pilot, "#create_folders_session_input", control=True
             )
-            assert (
-                pilot.app.screen.query_one(
-                    "#create_folders_session_input"
-                ).value
-                == "ses-...."
-            )
+            try:
+                assert (
+                    pilot.app.screen.query_one(
+                        "#create_folders_session_input"
+                    ).value
+                    == "ses-...."
+                )
+            except:
+                breakpoint()
 
             await self.double_click(
                 pilot, "#create_folders_subject_input", control=False
             )
-            assert (
-                pilot.app.screen.query_one(
-                    "#create_folders_subject_input"
-                ).value
-                == "sub-002"
-            )
+            try:
+                assert (
+                    pilot.app.screen.query_one(
+                        "#create_folders_subject_input"
+                    ).value
+                    == "sub-002"
+                )
+            except:
+                breakpoint()
 
             await self.fill_input(
                 pilot, "#create_folders_subject_input", "sub-001"
@@ -462,12 +464,16 @@ class TestTuiCreateFolders(TuiBase):
             await self.double_click(
                 pilot, "#create_folders_session_input", control=False
             )
-            assert (
-                pilot.app.screen.query_one(
-                    "#create_folders_session_input"
-                ).value
-                == "ses-0002"
-            )
+            try:
+                assert (
+                    pilot.app.screen.query_one(
+                        "#create_folders_session_input"
+                    ).value
+                    == "ses-0002"
+                )
+            except:
+                breakpoint()
+
             await pilot.pause()
 
     @pytest.mark.asyncio

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -246,12 +246,15 @@ class TestTuiCreateFolders(TuiBase):
             await self.fill_input(
                 pilot, "#create_folders_subject_input", "sub-001_@DATE@"
             )
-            assert (
-                "DUPLICATE_NAME: The prefix for sub-001_date-20250226 duplicates the name: sub-001."
-                in pilot.app.screen.query_one(
-                    "#create_folders_subject_input"
-                ).tooltip
-            )
+            try:
+                assert (
+                    "DUPLICATE_NAME: The prefix for sub-001_date-"
+                    in pilot.app.screen.query_one(
+                        "#create_folders_subject_input"
+                    ).tooltip
+                )
+            except:
+                breakpoint()
 
             await pilot.pause()
 

--- a/tests/tests_unit/test_validation_unit.py
+++ b/tests/tests_unit/test_validation_unit.py
@@ -264,3 +264,44 @@ class TestValidationUnit:
         output = validation.handle_path("message", Path("some/path"))
 
         assert output == "message Path: some/path"
+
+    @pytest.mark.parametrize("prefix", ["sub", "ses"])
+    def test_datetime_iso_format(self, prefix):
+
+        # Test dates
+        error_messages = validation.validate_list_of_names(
+            [
+                f"{prefix}-001_date-20240101",  # OK
+                f"{prefix}-002_date-123",  # wrong format
+                f"{prefix}-003_date-20241301",  # bad month
+                f"{prefix}-004_date-20241240",  # bad day
+            ],
+            prefix,
+        )
+        assert len(error_messages) == 3
+        assert all("DATETIME" in message for message in error_messages)
+
+        # Test Times
+        error_messages = validation.validate_list_of_names(
+            [
+                f"{prefix}-001_time-010101",  # OK
+                f"{prefix}-002_time-1122123",  # wrong format
+                f"{prefix}-003_time-250101",  # bad hour
+            ],
+            prefix,
+        )
+        assert len(error_messages) == 2
+        assert all("DATETIME" in message for message in error_messages)
+
+        # Test Datetime
+        error_messages = validation.validate_list_of_names(
+            [
+                f"{prefix}-001_datetime-20240101T010101",  # OK
+                f"{prefix}-002_datetime-123T123",  # wrong format
+                f"{prefix}-003_datetime-20241301T010101",  # bad date
+                f"{prefix}-004_datetime-20240101250101",  # bad time
+            ],
+            prefix,
+        )
+        assert len(error_messages) == 3
+        assert all("DATETIME" in message for message in error_messages)

--- a/tests/tests_unit/test_validation_unit.py
+++ b/tests/tests_unit/test_validation_unit.py
@@ -167,7 +167,11 @@ class TestValidationUnit:
         Ensure a list of sub / ses names that contain duplicate sub / ses
         ids (e.g. ["sub-001", "sub-001_@DATE@"]) leads to an error.
         """
-        names = [f"{prefix}-001", f"{prefix}-002", f"{prefix}-001_@DATE@"]
+        names = [
+            f"{prefix}-001",
+            f"{prefix}-002",
+            f"{prefix}-001_date-20250220",
+        ]
 
         with pytest.raises(BaseException) as e:
             formatting.check_and_format_names(names, prefix)

--- a/tests/tests_unit/test_validation_unit.py
+++ b/tests/tests_unit/test_validation_unit.py
@@ -253,3 +253,14 @@ class TestValidationUnit:
             fixed_datetime_regexp
             == r"ses-.?.?.?_datetime-\d\d\d\d\d\d\d\dT\d\d\d\d\d\d_some-.?.?tag"
         )
+
+    def test_handle_path(self):
+
+        output = validation.handle_path("message", None)
+        assert output == "message"
+
+        from pathlib import Path
+
+        output = validation.handle_path("message", Path("some/path"))
+
+        assert output == "message Path: some/path"


### PR DESCRIPTION
This PR extends and refactors the validation (`validation.py`):
- error messages are better standardized, each containing some key that describes the error (e.g. `DUPLICATE_NAME`) as well as a path to the folder causing the issue.
- `validation.py` is completely refactored, its still a little complex because of some annoying edge-cases but the logical all flows start-to-finish rather with recursion removed.
- public validation functions now return `error_messages` which contains a list of strings of all validation errors.
- A couple more validation cases caught.
- a `strict_mode` argument added. This will check all folders in the project and if they are not in a datatype folder ensures they are NeuroBlueprint. Currently, the validate will search for sub- and ses- prefixed names and check these only. Datatypes will not be validated. The problem is that NeuroBlueprint allows folders that are not NeuroBlueprint formatting for flexibility, so for example with datatype, we do not know if a folder is a bad datatype folder or just some other folder the user wants. So its not possible to validate. But in strict mode, we can validate everything. 
- docs and tests added


To test, this can be run with a file path `quick_validate_project` or to also get logs with `project.validate_project(...)`:
```
path_to_project = "path/to/project"
project_name = "some_name"

from datashuttle import quick_validate_project
from datashuttle import DataShuttle

# quick way
error_messages = quick_validate_project(path_to_project)

# datashuttle-project way (will output logs)

project = DataShuttle(project_name)
# first time: project.make_config_file(local_path=path_to_project)

error_messages = project.validate_project(..., strict_mode=...)

```

To check the docs (after `pip install -r docs/requirements.txt`)

```
`sphinx-build source build
```


and there is a new 'validation` page on the tutorials.

Unfortunately because this contains a lot of refactoring, the diff is quite big. The main changes are the refactoring in `validation.py` and some associated tests. It might be easiest just to look at the new `validation.py` file, unfortunately the diff is quite long sorry.

NOTE: tests are failing on linux / macos (just trying windows) but I cannot replicate locally on windows. Will check on macOS asap.