### PR TITLE
Add line on how to close the terminal in docs.

### DIFF
--- a/docs/source/pages/how_tos/choose-a-terminal.md
+++ b/docs/source/pages/how_tos/choose-a-terminal.md
@@ -81,3 +81,5 @@ with rendering errors.
 
 Once you've chosen a terminal, get started with
 **datashuttle** with our [Getting Started Tutorial](tutorial-getting-started).
+
+To quit **datashuttle** in the terminal, press `CTRL+C`.


### PR DESCRIPTION
This PR adds a quick line to the documentation explaining how to quit `datashuttle` in the terminal (CTRL+C).  I put it here as there is no other page dedicated only to the TUI. However, in future docs refactor #207 TUI vs. Python API might be split a bit more and it can be moved to somewhere more sensible.