### PR TITLE
Pin textual version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
-    "textual",
+    "textual<=1.0.0",
     "show-in-file-manager",
     "gitpython",
     "typeguard"


### PR DESCRIPTION
#467 is due to a textual update. Textual is still updating [very quickly](https://pypi.org/project/textual/#history), I'd hoped to avoid pinning a version but I think this is the only sustainable solution for now. We can periodically review and test new textual versions.