### PR TITLE
[Fix #438] Disallow empty project names

### DIFF
--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -424,10 +424,15 @@ class ConfigsContent(Container):
         project_name = self.interface.project.cfg.project_name
         # Add validation before proceeding
         if not project_name.strip():
-            self.notify("Project name cannot be empty. Please enter a valid name.", severity="error")
-            print("Project creation blocked due to empty name!")  # Debugging print
+            self.notify(
+                "Project name cannot be empty. Please enter a valid name.",
+                severity="error",
+            )
+            print(
+                "Project creation blocked due to empty name!"
+            )  # Debugging print
             return
-        
+
         for key, value in cfg_kwargs.items():
             saved_val = self.interface.get_configs()[key]
             if key in ["central_path", "local_path"]:
@@ -453,11 +458,15 @@ class ConfigsContent(Container):
         project_name = self.query_one("#configs_name_input").value
         # Add validation before proceeding
         if not project_name.strip():
-            self.notify("Project name cannot be empty. Please enter a valid name.", severity="error")
-            print("Project creation blocked due to empty name!")  # Debugging print
+            self.notify(
+                "Project name cannot be empty. Please enter a valid name.",
+                severity="error",
+            )
+            print(
+                "Project creation blocked due to empty name!"
+            )  # Debugging print
             return
-        
-        
+
         cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
 
         interface = Interface()

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -422,7 +422,12 @@ class ConfigsContent(Container):
         cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
 
         project_name = self.interface.project.cfg.project_name
-
+        # Add validation before proceeding
+        if not project_name.strip():
+            self.notify("Project name cannot be empty. Please enter a valid name.", severity="error")
+            print("Project creation blocked due to empty name!")  # Debugging print
+            return
+        
         for key, value in cfg_kwargs.items():
             saved_val = self.interface.get_configs()[key]
             if key in ["central_path", "local_path"]:
@@ -446,6 +451,13 @@ class ConfigsContent(Container):
         with the new project.
         """
         project_name = self.query_one("#configs_name_input").value
+        # Add validation before proceeding
+        if not project_name.strip():
+            self.notify("Project name cannot be empty. Please enter a valid name.", severity="error")
+            print("Project creation blocked due to empty name!")  # Debugging print
+            return
+        
+        
         cfg_kwargs = self.get_datashuttle_inputs_from_widgets()
 
         interface = Interface()


### PR DESCRIPTION
## Description
Fixes issue #438 : Disallow empty file name in TUI project setup

## What is this PR

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

## Why is this PR needed?

Currently, the TUI allows users to create a project with an empty name, which can lead to unexpected behavior. 
This PR introduces a validation step to ensure that project names cannot be empty. If an empty name is detected, an error message is displayed, preventing project creation.

## What does this PR do?

1. Added a check in the project creation logic to verify if the name is empty.
2. Updated the UI to display a clear error message when this occurs.

_Demonstration of the changes:_
https://github.com/user-attachments/assets/6b3fa0ec-e25b-4fae-a423-67d59b126062

## References
Fix for issue #438 

## How has this PR been tested?

1. Tried creating a project with a valid name → Works as expected.
2. Tried creating a project with an empty name → Error is shown.

## Does this PR require an update to the documentation?
Yes, minor update required to specify project name validation in the documentation.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
