### PR TITLE
Fix for issue #449

### DIFF
--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -868,9 +868,22 @@ class DataShuttle:
 
         if verified:
             ssh.setup_ssh_key(self.cfg, log=True)
+            # Directly use the central path removed input
+            if not self._check_write_permissions(self.cfg["central_path"]): # 449
+                raise PermissionError(
+                    f"Cannot write to the central path: {self.cfg['central_path']}"
+                )
             self._setup_rclone_central_ssh_config(log=True)
 
         ds_logger.close_log_filehandler()
+
+
+    def _check_write_permissions(self, path) -> bool: # 449
+            """
+            Check if the user has write permissions on the central path.
+            """
+            return ssh.check_write_permissions(self.cfg, path, log=False)
+
 
     @requires_ssh_configs
     @check_is_not_local_project

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -320,3 +322,61 @@ def get_list_of_folder_names_over_sftp(
             utils.log_and_message(f"No file found at {search_path.as_posix()}")
 
     return all_folder_names, all_filenames
+
+
+# 449
+@dataclass
+class SSHCommandResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+def run_ssh_command(
+    cfg: Configs,
+    command: str,
+    password: Optional[str] = None,
+    log: bool = True,
+) -> SSHCommandResult:
+    """
+    Run a command on the remote server over SSH and return a result object.
+    """
+    client = paramiko.SSHClient()
+    try:
+        connect_client_with_logging(
+            client, cfg, password, message_on_sucessful_connection=log
+        )
+        stdin, stdout, stderr = client.exec_command(command)
+        stdout_output = stdout.read().decode("utf-8").strip()
+        stderr_output = stderr.read().decode("utf-8").strip()
+        return_code = stdout.channel.recv_exit_status()
+
+        if log:
+            utils.log(f"Command executed: {command}")
+            utils.log(f"STDOUT: {stdout_output}")
+            utils.log(f"STDERR: {stderr_output}")
+            utils.log(f"Return code: {return_code}")
+
+        return SSHCommandResult(stdout_output, stderr_output, return_code)
+    except Exception as e:
+        if log:
+            utils.log_and_raise_error(
+                f"Failed to execute command over SSH: {str(e)}", Exception
+            )
+        raise
+    finally:
+        client.close()
+
+# 449
+def check_write_permissions(cfg: Configs, path: str, log: bool = True) -> bool:
+    """
+    Check if the user has write permissions on the specified path on the remote server.
+    """
+    try:
+        command = f"touch {path}/test_write_permission.txt && rm {path}/test_write_permission.txt"
+        result = run_ssh_command(cfg, command, log=log)
+        return result.returncode == 0
+    except Exception as e:
+        if log:
+            utils.log(f"Write permission check failed: {e}")
+        return False


### PR DESCRIPTION
@JoeZiminski  “””This is a nice idea, but taking an input here would freeze the application when run through the TUI. At this stage we can trust the user has input the path correctly at the config stage (if they have not, they will realize after a permission error below). Here I would delete the input code and use self.cfg["central_path"] directly in self._check_write_permissions “”” Following this, in datasshuttle_class.py removed input prompt . Then “””This is cool, I think this function can go into ssh.py and be merged with run_ssh_command. It is nice to encapsulate the code for writing commands over SSH but as we do this [elsewhere](https://github.com/neuroinformatics-unit/datashuttle/blob/166f8620199b6392df43d0889a8b5e34b263d3a0/datashuttle/utils/ssh.py#L66) in a way that would make it difficult to use run_ssh_command. For now we can use client.exec_command more flexibly from within other functions and refactor to centralise under a single function at a later time””” I refactored this to move the check_write_permission function to ssh.py . Now, I am trying to focus on further narrow it down to establish complete connection early and combining check_write_permission with run_ssh_command . Where login will be set to off.