### PR TITLE
Enable the 'save' button on configs when widget input is changed

### DIFF
--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -207,9 +207,6 @@ class ConfigsContent(Container):
             id = "#configs_name_input"
             self.query_one(id).tooltip = get_tooltip(id)
 
-            # Register event handler for project name input
-            self.query_one(id).changed_callback = self.on_input_changed
-
             # Assumes 'local_filesystem' is default if no project set.
             assert (
                 self.query_one("#configs_local_filesystem_radiobutton").value
@@ -233,23 +230,6 @@ class ConfigsContent(Container):
         ]:
             self.query_one(id).tooltip = get_tooltip(id)
 
-        # Register change handlers for input fields
-        for input_id in [
-            "#configs_local_path_input",
-            "#configs_central_path_input",
-            "#configs_central_host_id_input",
-            "#configs_central_host_username_input",
-        ]:
-            self.query_one(input_id).changed_callback = self.on_input_changed
-
-    def on_input_changed(self, widget: ClickableInput) -> None:
-        """
-        Handler for input changes to enable the save button
-        when widgets are modified.
-        """
-        self.has_unsaved_changes = True
-        self.query_one("#configs_save_configs_button").disabled = False
-
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         """
         Update the displayed SSH widgets when the `connection_method`
@@ -261,9 +241,6 @@ class ConfigsContent(Container):
         When mode is `No connection`, the `central_path` is cleared and
         disabled.
         """
-        # Mark changes so save button is enabled
-        self.has_unsaved_changes = True
-        self.query_one("#configs_save_configs_button").disabled = False
 
         label = str(event.pressed.label)
         assert label in [
@@ -371,10 +348,6 @@ class ConfigsContent(Container):
             else:
                 self.setup_configs_for_an_existing_project()
 
-            # After saving, disable the save button again
-            self.has_unsaved_changes = False
-            self.query_one("#configs_save_configs_button").disabled = True
-
         elif event.button.id == "configs_setup_ssh_connection_button":
             self.setup_ssh_connection()
 
@@ -428,10 +401,6 @@ class ConfigsContent(Container):
             self.query_one("#configs_central_path_input").value = (
                 path_.as_posix()
             )
-
-        # Enable the save button since we've changed a path
-        self.has_unsaved_changes = True
-        self.query_one("#configs_save_configs_button").disabled = False
 
     def setup_ssh_connection(self) -> None:
         """


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**
- [ yes] Addition of a new feature
Issue #330 solved. Moreover, this is my first PR in any open source organisation. Please do guide me and correct me if something went wrong from my side. 


**Why is this PR needed?**
This PR is needed because I have tried to solve the issue #330 which is there in your repository

**What does this PR do?**
I have implemented the 'Save'  button as disabled until a widget has something entered in, and then become active in config tab.


## References
#330 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.
- I have run pre-commit run -a to test it. 
- I have also done datashuttle launch and tried to manually test the feature

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.
- No.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.
- No, I don't think it requires document updation

## Checklist:

- [yes ] The code has been tested locally
- [no ] Tests have been added to cover all new functionality
- [ no] The documentation has been updated to reflect any changes
- [ yes] The code has been formatted with [pre-commit](https://pre-commit.com/)
