### PR TITLE
Add v* in workflow tags to solve issue 440

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v**'
+      - 'v*'
   pull_request:
   schedule:
     # Weekly cron job at 12:00 AM UTC on Mondays.

--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v**'
   pull_request:
   schedule:
     # Weekly cron job at 12:00 AM UTC on Mondays.

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v**'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     tags:
-      - 'v**'
+      - 'v*'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION

Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ yes] Bug fix
- [ no] Addition of a new feature
- [ no] Other

**Why is this PR needed?**
Closes: #440 
It is quite a common mistake to forget the leading v when creating a new version tag. So , I have solved this issue (#440) by adding 'v**' in tags of workflow. 

**What does this PR do?**
If the "v" is omitted, the system might not recognize the version correctly, potentially causing issues during the build or deployment process. Some CI/CD pipelines or build scripts are set to enforce this naming convention, meaning if the version tag doesn't start with a "v", the build might fail. However, some systems might still allow the build to proceed without it, leading to inconsistencies.

## References
Issue #440 

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
- by running pre-commit run -a
- by manually testing the workflow.

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?
- no

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?
-no

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [ yes] The code has been tested locally
- [yes ] Tests have been added to cover all new functionality
- [ yes] The documentation has been updated to reflect any changes
- [ yes] The code has been formatted with [pre-commit](https://pre-commit.com/)
