### PR TITLE
[ENH] Fix log directory creation issue in _start_log

### DIFF
--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1359,6 +1359,8 @@ class DataShuttle:
         else:
             path_to_save = self.cfg.logging_path
 
+        os.makedirs(path_to_save, exist_ok=True)
+
         ds_logger.start(path_to_save, command_name, variables, verbose)
 
     def _move_logs_from_temp_folder(self) -> None:


### PR DESCRIPTION
## Description
This PR ensures that `datashuttle` can recover, if the `.datashuttle` folder (where logs are stored) is deleted. Previously, the software would throw an error and become unusable. Now, the necessary log directory is automatically recreated when missing, improving package stability.

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

When the following code is executed, the error shown in the figure occurs. This PR will fixes this error by automatically creating new folder if it not exist.
```python
from datashuttle import DataShuttle
project = DataShuttle("new_project")
# delete folder here
project.create_folders("rawdata", "sub-001")
```
![Screenshot 2025-03-14 150905](https://github.com/user-attachments/assets/fcf13c28-e808-4a60-a2a5-6d0888054ce8)


## References

fixes #435

## How has this PR been tested?

I have tested this on my local machine, and it worked properly. The following is the result:

![Screenshot 2025-03-14 155009](https://github.com/user-attachments/assets/54f6041d-45f3-4d23-a0b5-2ae4ba29c24d)



## Is this a breaking change?

No, this PR is not a breaking change.

## Does this PR require an update to the documentation?

Not required

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
