### PR TITLE
Add "Projects List" Button on Project Manager Screen

### DIFF
--- a/datashuttle/tui/css/tui_style.tcss
+++ b/datashuttle/tui/css/tui_style.tcss
@@ -30,6 +30,16 @@ Button:light:hover {
     layer: top;
 }
 
+
+/* Projects List Button --------------------------------------------------------------------- */
+
+#projects-list{
+    dock: right;
+    height: 3;
+    layer: top;
+    margin-right: 16;
+}
+
 /* Header --------------------------------------------------------------------------- */
 
 Header {

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -54,6 +54,7 @@ class ProjectManagerScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header()
         yield Button("Main Menu", id="all_main_menu_buttons")
+        yield Button("Projects List", id="projects-list")
         with TabbedContent(
             id="tabscreen_tabbed_content", initial="tabscreen_create_tab"
         ):

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -17,7 +17,7 @@ from textual.widgets import (
 )
 
 from datashuttle.tui.configs import ConfigsContent
-from datashuttle.tui.screens import modal_dialogs
+from datashuttle.tui.screens import modal_dialogs, project_selector
 from datashuttle.tui.tabs import create_folders, logging, transfer
 
 
@@ -92,6 +92,10 @@ class ProjectManagerScreen(Screen):
         """
         if event.button.id == "all_main_menu_buttons":
             self.dismiss()
+        elif event.button.id == "projects-list":
+            self.app.push_screen(
+                project_selector.ProjectSelectorScreen(self.app)
+            )
 
     def on_tabbed_content_tab_activated(
         self, event: TabbedContent.TabActivated


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, there is no direct way to navigate back to the Projects List from the Project Manager screen. Users have to go through the Main Menu and then select Existing Projects to access the list again, which adds unnecessary steps. This PR improves navigation by providing a quicker way to return to the Projects List.

**What does this PR do?**
- Adds a "Projects List" button next to the Main Menu button on the Project Manager screen.
- Clicking this button takes users directly to the Projects List without needing to go through the Main Menu.
- Improves user experience by making navigation more intuitive and efficient.

## References
fixes #488 

## How has this PR been tested?

I have tested locally. I am attaching the video of the updated functionality


https://github.com/user-attachments/assets/1becf8a1-c898-4c6a-a874-be6c0d01688a


## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Not required

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
