### PR TITLE
Bug-fix: Duplicate SSH Setup Message in TUI

### DIFF
--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -42,7 +42,7 @@ class SetupSshScreen(ModalScreen):
         yield Container(
             Horizontal(
                 Static(
-                    "Ready to setup setup SSH. " "Press OK to proceed.",
+                    "Ready to setup SSH. " "Press OK to proceed.",
                     id="messagebox_message_label",
                 ),
                 id="messagebox_message_container",

--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -42,7 +42,7 @@ class SetupSshScreen(ModalScreen):
         yield Container(
             Horizontal(
                 Static(
-                    "Ready to setup SSH. " "Press OK to proceed.",
+                    "Ready to setup SSH. Press OK to proceed.",
                     id="messagebox_message_label",
                 ),
                 id="messagebox_message_container",


### PR DESCRIPTION

## Description
 When selecting SSH as the connection method in `datashuttle`, the TUI incorrectly displays the setup message twice
 
 ```
"Ready to setup setup SSH."
"Press OK to proceed."
```


## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
