### PR TITLE
Move rlcone error.

### DIFF
--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -127,8 +127,6 @@ class DataShuttle:
 
         if self.cfg:
             self._set_attributes_after_config_load()
-        else:
-            rclone.prompt_rclone_download_if_does_not_exist()
 
     def _set_attributes_after_config_load(self) -> None:
         """

--- a/datashuttle/utils/decorators.py
+++ b/datashuttle/utils/decorators.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
+from datashuttle.utils import rclone, utils
 from datashuttle.utils.custom_exceptions import ConfigError
-from datashuttle.utils.utils import log_and_raise_error
 
 
 def requires_ssh_configs(func):
@@ -16,7 +16,7 @@ def requires_ssh_configs(func):
             not args[0].cfg["central_host_id"]
             or not args[0].cfg["central_host_username"]
         ):
-            log_and_raise_error(
+            utils.log_and_raise_error(
                 "Cannot setup SSH connection, 'central_host_id' "
                 "or 'central_host_username' is not set in "
                 "the configuration file.",
@@ -38,7 +38,10 @@ def check_configs_set(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if args[0].cfg is None:
-            log_and_raise_error(
+
+            rclone.raise_prompt_rclone_download_if_does_not_exist()
+
+            utils.log_and_raise_error(
                 "Must set configs with make_config_file() "
                 "before using this function.",
                 ConfigError,
@@ -61,7 +64,7 @@ def check_is_not_local_project(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if args[0].is_local_project():
-            log_and_raise_error(
+            utils.log_and_raise_error(
                 "This function cannot be used for a local-project. "
                 "Set connection configurations using `update_config_file` "
                 "to use this functionality.",

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -127,7 +127,7 @@ def check_rclone_with_default_call() -> bool:
     return True if output.returncode == 0 else False
 
 
-def prompt_rclone_download_if_does_not_exist() -> None:
+def raise_prompt_rclone_download_if_does_not_exist() -> None:
     """
     Check that rclone is installed. If it does not
     (e.g. first time using datashuttle) then download.


### PR DESCRIPTION
EDIT:
on further consideration this is quite complex, as rclone configs are setup up-front. So this would only work in local-only mode, and it is fiddly. As rlcone config is not too onerous it just means the package is not pip-installable, and users that do not transfer are unecessarily downloading a package.  It's not ideal but will leave this for now, because changing this is quite deep in the codebase and will require a lot of thinking / checking.

The implementation here is not good, it would be necessary to make a new decorator @requires_rclone.


There is a check that `rclone` is installed, which raises if it is not installed. Previously this was in the `DataShuttle`  class `__init__`, however now people will want to use datashuttle for validation / creating folders in local mode and will not need transfer. Therefore, this PR moves the check to the configs-check decorator used before transfer.



The install documentation can be changed, and this will be done on #499 to avoid merge conflicts. No tests are requred.