### PR TITLE
Added support for custom tags in template input with regex conversion

### DIFF
--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1179,6 +1179,21 @@ class DataShuttle:
         settings = self._load_persistent_settings()
         return settings["name_templates"]
 
+    def convert_custom_tags_to_regex(self, template: str) -> str:
+        """
+        Convert custom tags in the template to their corresponding regex patterns.
+        """
+        CUSTOM_TAGS = {
+            "<ANY_DIGIT>": r"\d",  # Matches a single digit (0-9)
+            "<ANY_CHAR>": r".?",  # Matches any single character
+            "<ANY_STRING>": r".*",  # Matches any sequence of characters
+        }
+
+        for tag, regex in CUSTOM_TAGS.items():
+            template = template.replace(tag, regex)
+
+        return template
+
     def set_name_templates(self, new_name_templates: Dict) -> None:
         """
         Update the persistent settings with new name templates.
@@ -1194,6 +1209,16 @@ class DataShuttle:
             where "sub" or "ses" can be a regexp that subject and session
             names respectively are validated against.
         """
+        if "sub" in new_name_templates and new_name_templates["sub"]:
+            new_name_templates["sub"] = self.convert_custom_tags_to_regex(
+                new_name_templates["sub"]
+            )
+
+        if "ses" in new_name_templates and new_name_templates["ses"]:
+            new_name_templates["ses"] = self.convert_custom_tags_to_regex(
+                new_name_templates["ses"]
+            )
+
         self._update_persistent_setting("name_templates", new_name_templates)
 
     # -------------------------------------------------------------------------

--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -169,10 +169,7 @@ class CreateFoldersSettingsScreen(ModalScreen):
         """
         CUSTOM_TAGS = {
             "<ANY_DIGIT>": r"\d",  # Matches a single digit (0-9)
-            "<ANY_LETTER>": r"[a-zA-Z]",  # Matches a single letter (uppercase or lowercase)
-            "<ANY_WORD>": r"\w+",  # Matches a whole word (letters, numbers, underscores)
-            "<DATE_YYYYMMDD>": r"\d{4}-\d{2}-\d{2}",  # Matches a date format YYYY-MM-DD
-            "<ANY_CHAR>": r".",  # Matches any single character
+            "<ANY_CHAR>": r".?",  # Matches any single character
             "<ANY_STRING>": r".*",  # Matches any sequence of characters
         }
 

--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -163,6 +163,24 @@ class CreateFoldersSettingsScreen(ModalScreen):
         ).value
         self.query_one("#template_inner_container").disabled = not is_on
 
+    def convert_custom_tags_to_regex(self, template: str) -> str:
+        """
+        Convert custom tags in the template to their corresponding regex patterns.
+        """
+        CUSTOM_TAGS = {
+            "<ANY_DIGIT>": r"\d",  # Matches a single digit (0-9)
+            "<ANY_LETTER>": r"[a-zA-Z]",  # Matches a single letter (uppercase or lowercase)
+            "<ANY_WORD>": r"\w+",  # Matches a whole word (letters, numbers, underscores)
+            "<DATE_YYYYMMDD>": r"\d{4}-\d{2}-\d{2}",  # Matches a date format YYYY-MM-DD
+            "<ANY_CHAR>": r".",  # Matches any single character
+            "<ANY_STRING>": r".*",  # Matches any sequence of characters
+        }
+
+        for tag, regex in CUSTOM_TAGS.items():
+            template = template.replace(tag, regex)
+
+        return template
+
     def fill_input_from_template(self) -> None:
         """
         Fill the `name_templates` Input, that is shared
@@ -176,7 +194,8 @@ class CreateFoldersSettingsScreen(ModalScreen):
             input.value = ""
             input.placeholder = f"{self.input_mode}-"
         else:
-            input.value = value
+            converted_regex = self.convert_custom_tags_to_regex(value)
+            input.value = converted_regex
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """

--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -163,21 +163,6 @@ class CreateFoldersSettingsScreen(ModalScreen):
         ).value
         self.query_one("#template_inner_container").disabled = not is_on
 
-    def convert_custom_tags_to_regex(self, template: str) -> str:
-        """
-        Convert custom tags in the template to their corresponding regex patterns.
-        """
-        CUSTOM_TAGS = {
-            "<ANY_DIGIT>": r"\d",  # Matches a single digit (0-9)
-            "<ANY_CHAR>": r".?",  # Matches any single character
-            "<ANY_STRING>": r".*",  # Matches any sequence of characters
-        }
-
-        for tag, regex in CUSTOM_TAGS.items():
-            template = template.replace(tag, regex)
-
-        return template
-
     def fill_input_from_template(self) -> None:
         """
         Fill the `name_templates` Input, that is shared
@@ -191,8 +176,7 @@ class CreateFoldersSettingsScreen(ModalScreen):
             input.value = ""
             input.placeholder = f"{self.input_mode}-"
         else:
-            converted_regex = self.convert_custom_tags_to_regex(value)
-            input.value = converted_regex
+            input.value = value
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """


### PR DESCRIPTION
## Description

**What is this PR**
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR adds support for custom tags in template inputs following the first suggested option in the issue (#351), allowing users to define and use predefined placeholders (`<ANY_DIGIT>`, `<ANY_STRING>` and `ANY_CHAR`) that automatically convert into corresponding regex patterns. This improves flexibility when defining naming conventions.

**What does this PR do?**
- Implements a `convert_custom_tags_to_regex` function to replace custom tags with regex patterns.
- Integrates this function into `set_name_templates` to ensure correct transformation of input values.
- Ensured that users can enter name templates in regex format without encountering any errors.

## References
closes #351

## How has this PR been tested?
Tested Locally


https://github.com/user-attachments/assets/4d1fa3e9-036c-492e-9c1e-f715cb5f10d6


## Is this a breaking change?
No

## Does this PR require an update to the documentation?

Yes, documentation need to be updated when this addition works fine.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
