### PR TITLE
feat: Allow Google Drive as remove storage

### DIFF
--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -39,7 +39,9 @@ def get_canonical_configs() -> dict:
     canonical_configs = {
         "local_path": Union[str, Path],
         "central_path": Optional[Union[str, Path]],
-        "connection_method": Optional[Literal["ssh", "local_filesystem"]],
+        "connection_method": Optional[
+            Literal["ssh", "local_filesystem", "google_drive"]
+        ],
         "central_host_id": Optional[str],
         "central_host_username": Optional[str],
     }

--- a/datashuttle/configs/canonical_configs.py
+++ b/datashuttle/configs/canonical_configs.py
@@ -44,6 +44,7 @@ def get_canonical_configs() -> dict:
         ],
         "central_host_id": Optional[str],
         "central_host_username": Optional[str],
+        "google_drive_folder_id": Optional[str],
     }
 
     return canonical_configs
@@ -150,15 +151,25 @@ def raise_on_bad_local_only_project_configs(config_dict: Configs) -> None:
     should be set and not the other. Either both are set ('full' project) or
     neither are ('local only' project). Check this assumption here.
     """
-    params_are_none = local_only_configs_are_none(config_dict)
+    cloud_method = cloud_config_method(config_dict)
 
-    if any(params_are_none):
-        if not all(params_are_none):
-            utils.log_and_raise_error(
-                "Either both `central_path` and `connection_method` must be set, "
-                "or must both be `None` (for local-project mode).",
-                ConfigError,
-            )
+    if not cloud_method:
+        params_are_none = local_only_configs_are_none(config_dict)
+
+        if any(params_are_none):
+            if not all(params_are_none):
+                utils.log_and_raise_error(
+                    "Either both `central_path` and `connection_method` must be set, "
+                    "or must both be `None` (for local-project mode).",
+                    ConfigError,
+                )
+
+
+def cloud_config_method(config_dict: Configs) -> bool:
+    """
+    Check if the config is set to Google Drive or AWS.
+    """
+    return config_dict["connection_method"] in ["google_drive", "aws"]
 
 
 def local_only_configs_are_none(config_dict: Configs) -> list[bool]:

--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -903,6 +903,7 @@ class DataShuttle:
         connection_method: str | None = None,
         central_host_id: Optional[str] = None,
         central_host_username: Optional[str] = None,
+        google_drive_folder_id: Optional[str] = None,
     ) -> None:
         """
         Initialise the configurations for datashuttle to use on the
@@ -967,6 +968,7 @@ class DataShuttle:
                 "connection_method": connection_method,
                 "central_host_id": central_host_id,
                 "central_host_username": central_host_username,
+                "google_drive_folder_id": google_drive_folder_id,
             },
         )
 
@@ -1456,6 +1458,12 @@ class DataShuttle:
             self.cfg,
             self.cfg.get_rclone_config_name("ssh"),
             self.cfg.ssh_key_path,
+            log=log,
+        )
+
+    def _setup_rclone_central_google_drive_config(self, log: bool) -> None:
+        rclone.setup_rclone_clone_for_google_drive(
+            self.cfg.get_rclone_config_name("google_drive"),
             log=log,
         )
 

--- a/datashuttle/tui/configs.py
+++ b/datashuttle/tui/configs.py
@@ -109,6 +109,9 @@ class ConfigsContent(Container):
                 ),
                 RadioButton("SSH", id="configs_ssh_radiobutton"),
                 RadioButton(
+                    "Google Drive", id="configs_google_drive_radiobutton"
+                ),
+                RadioButton(
                     "No connection (local only)",
                     id="configs_local_only_radiobutton",
                 ),
@@ -215,6 +218,7 @@ class ConfigsContent(Container):
             "#configs_connect_method_label",
             "#configs_local_filesystem_radiobutton",
             "#configs_ssh_radiobutton",
+            "#configs_google_drive_radiobutton",
             "#configs_local_only_radiobutton",
             "#configs_central_host_username_input",
             "#configs_central_host_id_input",

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -58,6 +58,9 @@
 SetupSshScreen {
     align: center middle;
 }
+SetupGoogleDriveScreen {
+    align: center middle;
+}
 SettingsScreen {
     align: center middle;
 }
@@ -77,6 +80,17 @@ GetHelpScreen {
 #setup_ssh_screen_container {
     border: thick $panel-darken-3;
 }
+#setup_google_drive_screen_container {
+    height: 75%;
+    width: 80%;
+    align: center middle;
+    border: thick $panel-lighten-1;
+}
+
+#setup_google_drive_screen_container {
+    border: thick $panel-darken-3;
+}
+
 #messagebox_buttons_horizontal {
     align: center middle;
 }
@@ -165,6 +179,9 @@ MessageBox:light > #messagebox_top_container {
 
 #configs_setup_ssh_connection_button {
     margin: 2 1 0 0;
+}
+#configs_setup_google_drive_connection_button {
+    margin: 2;
 }
 #configs_go_to_project_screen_button {
     margin: 2 1 0 0;

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -460,3 +460,12 @@ class Interface:
 
         except BaseException as e:
             return False, str(e)
+
+    def setup_key_pair_and_google_drive_config(self) -> InterfaceOutput:
+        try:
+            self.project._setup_rclone_central_google_drive_config(log=False)
+
+            return True, None
+
+        except BaseException as e:
+            return False, str(e)

--- a/datashuttle/tui/screens/setup_google_drive.py
+++ b/datashuttle/tui/screens/setup_google_drive.py
@@ -64,3 +64,39 @@ class SetupGoogleDriveScreen(ModalScreen):
         """
         if event.button.id == "setup_google_drive_cancel_button":
             self.dismiss()
+
+        if event.button.id == "setup_google_drive_ok_button":
+            if self.stage == 0:
+                self.ask_user_to_authenticate()
+            elif self.stage == 1:
+                self.dismiss()
+
+    def ask_user_to_authenticate(self) -> None:
+        """
+        Prompts the user to authenticate their Google Drive account.
+
+        This method will guide the user through the process of authenticating
+        their Google Drive account, which is necessary for accessing and
+        managing files stored in Google Drive through the application.
+
+        Returns:
+            None
+        """
+
+        success, output = (
+            self.interface.setup_key_pair_and_google_drive_config()
+        )
+        if success:
+            message = "Connection successful! You can now access your Google Drive files."
+            self.query_one("#setup_google_drive_ok_button").label = "Finish"
+            self.query_one("#setup_google_drive_cancel_button").disabled = True
+            self.stage += 1
+
+        else:
+            message = (
+                f"Google Drive setup failed. Check your browser and try again."
+                f"\n\n Traceback: {output}"
+            )
+            self.stage += 1
+
+        self.query_one("#messagebox_message_label").update(message)

--- a/datashuttle/tui/screens/setup_google_drive.py
+++ b/datashuttle/tui/screens/setup_google_drive.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+    from datashuttle.tui.interface import Interface
+
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import (
+    Button,
+    Static,
+)
+
+
+class SetupGoogleDriveScreen(ModalScreen):
+    """
+    This dialog windows handles the TUI equivalent of API's
+    setup_google_drive(). This asks to
+    confirm the central hostkey, and takes password to setup
+    SSH key pair.
+
+    This is the one instance in which it is not possible for
+    the TUI to nearly wrap the API, because the logic flow is
+    broken up requiring user input (accept hostkey and input password).
+    """
+
+    def __init__(self, interface: Interface) -> None:
+        super(SetupGoogleDriveScreen, self).__init__()
+
+        self.interface = interface
+        self.stage = 0
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Horizontal(
+                Static(
+                    "Ready to setup setup Google Drive. "
+                    "Press OK to proceed.",
+                    id="messagebox_message_label",
+                ),
+                id="messagebox_message_container",
+            ),
+            Horizontal(
+                Button("OK", id="setup_google_drive_ok_button"),
+                Button("Cancel", id="setup_google_drive_cancel_button"),
+                id="messagebox_buttons_horizontal",
+            ),
+            id="setup_google_drive_screen_container",
+        )
+
+    def on_mount(self) -> None:
+        pass
+
+    def on_button_pressed(self, event: Button.pressed) -> None:
+        """
+        When each stage is successfully progressed by clicking the "ok" button,
+        `self.stage` is iterated by 1. For saving and excepting hostkey,
+        if there is a problem (error or user declines) the 'OK' button
+        is frozen so it is not possible to proceed. For accepting password
+        input, multiple attempts are allowed.
+        """
+        if event.button.id == "setup_google_drive_cancel_button":
+            self.dismiss()

--- a/datashuttle/tui/tooltips.py
+++ b/datashuttle/tui/tooltips.py
@@ -33,6 +33,13 @@ def get_tooltip(id: str) -> str:
     elif id == "#configs_ssh_radiobutton":
         tooltip = "Use SSH when planning to connect with the central data storage via SSH protocol."
 
+    # Google Drive radiobutton
+    elif id == "#configs_google_drive_radiobutton":
+        tooltip = (
+            "Use Google Drive when the central data storage "
+            "is a Google Drive folder."
+        )
+
     # No connection (local only) radiobutton
     elif id == "#configs_local_only_radiobutton":
         tooltip = "No connection to a central project is made.\nTransfer functionality will not be available."

--- a/datashuttle/tui/tooltips.py
+++ b/datashuttle/tui/tooltips.py
@@ -52,6 +52,10 @@ def get_tooltip(id: str) -> str:
     elif id == "#configs_central_host_username_input":
         tooltip = "The account username through which to access the server."
 
+    # central folder id input
+    elif id == "#configs_google_drive_folder_id_input":
+        tooltip = "The ID of the project folder on Google Drive"
+
     # central path input
     elif id == "config_central_path_input_mode-ssh":
         tooltip = (

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -113,7 +113,7 @@ def setup_rclone_clone_for_google_drive(
     log: bool = True,
 ):
     call_rclone(
-        f"config create " f"{rclone_config_name} " f"drive",
+        f"config create " f"{rclone_config_name} " f"drive ",
         pipe_std=True,
     )
     if log:

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -108,6 +108,18 @@ def setup_rclone_config_for_ssh(
         log_rclone_config_output()
 
 
+def setup_rclone_clone_for_google_drive(
+    rclone_config_name: str,
+    log: bool = True,
+):
+    call_rclone(
+        f"config create " f"{rclone_config_name} " f"drive",
+        pipe_std=True,
+    )
+    if log:
+        log_rclone_config_output()
+
+
 def log_rclone_config_output():
     output = call_rclone("config file", pipe_std=True)
     utils.log(


### PR DESCRIPTION
This _draft pull request_ is an early approach for the development of Google Drive (and AWS S3 in the future) integration to be used as a remote storage in the future. Since I am currently in the process of understanding the code base and architecture of the project, some mistakes might be found. Also, I have noticed there is already another implementation that can be found in [this pull request](https://github.com/neuroinformatics-unit/datashuttle/pull/497), so I am not sure if further effort in this issue is required. If not, I will aim another issue. Regardless, I'd like to open the discussion if the implementation is following the correct project standards and it's on the right track :). 

The following have been already implemented:

- [x] TUI extension: Added a new radio box for the Google Drive option
- [x] Rclone drive config setup: Rclone is authenticating with the Google Drive account and creating a config 

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR is needed because it introduces an initial implementation of data synchronization using Google Drive via RClone. Since many researchers lack access to centralized lab storage, this provides a practical alternative for transferring data between laptops and acquisition machines. Although it's still a draft and limited to Google Drive for now, it is necessary to open the discussion about the direction of the implementation and ensure that the approach aligns with the needs of the community before expanding support to other cloud storage options like AWS.

**What does this PR do?**

This PR introduces an initial implementation of data synchronization using Google Drive via RClone. As a draft PR, it focuses on setting up the basic functionality for Google Drive sync and serves as a starting point for discussions on the overall implementation approach.

## References

[Add support for Amazon AWS and Google Drive](https://github.com/neuroinformatics-unit/datashuttle/issues/407)

## How has this PR been tested?

This PR has been tested manually using TUI and Python API. Unit tests have not yet been implemented.

## Does this PR require an update to the documentation?

In the future, the new integrations will require updates to the documentation. However, since this is an early draft, documentation updates are not yet necessary but should be considered as the implementation progresses.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
