### PR TITLE
Correct `mainwindow` typehints

### DIFF
--- a/datashuttle/tui/custom_widgets.py
+++ b/datashuttle/tui/custom_widgets.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from textual import events
     from textual.validation import Validator
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.tui.interface import Interface
 
 from dataclasses import dataclass
@@ -51,7 +51,7 @@ class ClickableInput(Input):
 
     def __init__(
         self,
-        mainwindow: App,
+        mainwindow: TuiApp,
         placeholder: str,
         id: Optional[str] = None,
         validate_on: Optional[List[str]] = None,
@@ -98,7 +98,7 @@ class CustomDirectoryTree(DirectoryTree):
         node_path: Optional[Path]
 
     def __init__(
-        self, mainwindow: App, path: Path, id: Optional[str] = None
+        self, mainwindow: TuiApp, path: Path, id: Optional[str] = None
     ) -> None:
         super(CustomDirectoryTree, self).__init__(path=path, id=id)
 

--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
 
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.tui.interface import Interface
 
 import webbrowser
@@ -54,7 +54,7 @@ class CreateFoldersSettingsScreen(ModalScreen):
 
     TITLE = "Create Folders Settings"
 
-    def __init__(self, mainwindow: App, interface: Interface) -> None:
+    def __init__(self, mainwindow: TuiApp, interface: Interface) -> None:
         super(CreateFoldersSettingsScreen, self).__init__()
 
         self.mainwindow = mainwindow

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
     from textual.worker import Worker
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.utils.custom_types import InterfaceOutput
 
 from pathlib import Path
@@ -147,7 +147,7 @@ class SelectDirectoryTreeScreen(ModalScreen):
     Parameters
     ----------
 
-    mainwindow : App
+    mainwindow : TuiApp
         Textual main app screen
 
     path_ : Optional[Path]
@@ -155,7 +155,9 @@ class SelectDirectoryTreeScreen(ModalScreen):
         if `None` set to the system user home.
     """
 
-    def __init__(self, mainwindow: App, path_: Optional[Path] = None) -> None:
+    def __init__(
+        self, mainwindow: TuiApp, path_: Optional[Path] = None
+    ) -> None:
         super(SelectDirectoryTreeScreen, self).__init__()
         self.mainwindow = mainwindow
 
@@ -198,7 +200,7 @@ class SelectDirectoryTreeScreen(ModalScreen):
 class RenameFileOrFolderScreen(ModalScreen):
     """ """
 
-    def __init__(self, mainwindow: App, path_: Path) -> None:
+    def __init__(self, mainwindow: TuiApp, path_: Path) -> None:
         super(RenameFileOrFolderScreen, self).__init__()
 
         self.mainwindow = mainwindow

--- a/datashuttle/tui/screens/new_project.py
+++ b/datashuttle/tui/screens/new_project.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
 
 from textual.screen import Screen
 from textual.widgets import Button, Header
@@ -36,7 +36,7 @@ class NewProjectScreen(Screen):
 
     TITLE = "Make New Project"
 
-    def __init__(self, mainwindow: App) -> None:
+    def __init__(self, mainwindow: TuiApp) -> None:
         super(NewProjectScreen, self).__init__()
 
         self.mainwindow = mainwindow

--- a/datashuttle/tui/screens/project_manager.py
+++ b/datashuttle/tui/screens/project_manager.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.tui.interface import Interface
 
 from textual.screen import Screen
@@ -42,7 +42,7 @@ class ProjectManagerScreen(Screen):
     See ConfigsContent for more information.
     """
 
-    def __init__(self, mainwindow: App, interface: Interface, id) -> None:
+    def __init__(self, mainwindow: TuiApp, interface: Interface, id) -> None:
         super(ProjectManagerScreen, self).__init__(id=id)
 
         self.mainwindow = mainwindow

--- a/datashuttle/tui/screens/project_selector.py
+++ b/datashuttle/tui/screens/project_selector.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
 
 from textual.containers import Container
 from textual.screen import Screen
@@ -37,7 +37,7 @@ class ProjectSelectorScreen(Screen):
 
     TITLE = "Select Project"
 
-    def __init__(self, mainwindow: App) -> None:
+    def __init__(self, mainwindow: TuiApp) -> None:
         super(ProjectSelectorScreen, self).__init__()
 
         self.project_names = [

--- a/datashuttle/tui/screens/settings.py
+++ b/datashuttle/tui/screens/settings.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
 
 from textual.containers import Container
 from textual.screen import ModalScreen
@@ -27,7 +27,7 @@ class SettingsScreen(ModalScreen):
     of the main datashuttle API.
     """
 
-    def __init__(self, mainwindow: App) -> None:
+    def __init__(self, mainwindow: TuiApp) -> None:
         super(SettingsScreen, self).__init__()
 
         self.mainwindow = mainwindow

--- a/datashuttle/tui/screens/validate_at_path.py
+++ b/datashuttle/tui/screens/validate_at_path.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
 
 from textual.screen import Screen
 from textual.widgets import Button, Header
@@ -23,7 +23,7 @@ class ValidateScreen(Screen):
 
     TITLE = "Validate Project"
 
-    def __init__(self, mainwindow: App) -> None:
+    def __init__(self, mainwindow: TuiApp) -> None:
         super(ValidateScreen, self).__init__()
 
         self.mainwindow = mainwindow

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import platform
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -155,7 +155,7 @@ class ValidateContent(Container):
                 )
                 if not success:
                     self.parent_class.mainwindow.show_modal_error_dialog(
-                        output
+                        cast(str, output)
                     )
                 else:
                     self.write_results_to_richlog(output)

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
     from textual.app import ComposeResult
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.tui.interface import Interface
     from datashuttle.utils.custom_types import Prefix
 
@@ -39,7 +39,7 @@ class CreateFoldersTab(TreeAndInputTab):
     Create new project files formatted according to the NeuroBlueprint specification.
     """
 
-    def __init__(self, mainwindow: App, interface: Interface) -> None:
+    def __init__(self, mainwindow: TuiApp, interface: Interface) -> None:
         super(CreateFoldersTab, self).__init__(
             "Create", id="tabscreen_create_tab"
         )

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
     from textual.worker import Worker
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.tui.custom_widgets import CustomDirectoryTree
     from datashuttle.tui.interface import Interface
     from datashuttle.utils.custom_types import InterfaceOutput
@@ -54,7 +54,7 @@ class TransferTab(TreeAndInputTab):
 
     title : str
 
-    mainwindow : App
+    mainwindow : TuiApp
 
     interface : Interface
         TUI-datashuttle interface object
@@ -79,7 +79,7 @@ class TransferTab(TreeAndInputTab):
     def __init__(
         self,
         title: str,
-        mainwindow: App,
+        mainwindow: TuiApp,
         interface: Interface,
         id: Optional[str] = None,
     ) -> None:

--- a/datashuttle/tui/tabs/transfer_status_tree.py
+++ b/datashuttle/tui/tabs/transfer_status_tree.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from rich.style import Style
     from textual.widgets._directory_tree import DirEntry
 
-    from datashuttle.tui.app import App
+    from datashuttle.tui.app import TuiApp
     from datashuttle.tui.interface import Interface
 
 import os
@@ -38,7 +38,10 @@ class TransferStatusTree(CustomDirectoryTree):
     """
 
     def __init__(
-        self, mainwindow: App, interface: Interface, id: Optional[str] = None
+        self,
+        mainwindow: TuiApp,
+        interface: Interface,
+        id: Optional[str] = None,
     ):
 
         self.interface = interface


### PR DESCRIPTION
## Description
This PR changes the typehint of `mainwindow` from `App` to `TuiApp` for better type checking and code completion in IDEs.

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
To correct typehints of the `mainwindow` parameter used in the codebase.

## How has this PR been tested?
Tested with pre-commit.

## Is this a breaking change?
No


## Does this PR require an update to the documentation?
No


## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
