### PR TITLE
Handle bad project names

### DIFF
--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1427,6 +1427,10 @@ class DataShuttle:
                 "The project name must contain alphanumeric characters only.",
                 ValueError,
             )
+        if project_name == "":
+            utils.log_and_raise_error(
+                "The project name cannot be empty.", NeuroBlueprintError
+            )
 
     def _log_successful_config_change(self, message: bool = False) -> None:
         """

--- a/datashuttle/tui/screens/project_selector.py
+++ b/datashuttle/tui/screens/project_selector.py
@@ -49,14 +49,18 @@ class ProjectSelectorScreen(Screen):
         yield Header(id="project_select_header")
         yield Button("Main Menu", id="all_main_menu_buttons")
         yield Container(
-            *[Button(name, id=name) for name in self.project_names],
+            *[
+                Button(name, id=self.name_to_id(name))
+                for name in self.project_names
+            ],
             id="project_select_top_container",
         )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id in self.project_names:
 
-            project_name = event.button.id
+        project_name = self.id_to_name(event.button.id)
+
+        if project_name in self.project_names:
 
             interface = Interface()
             success, output = interface.select_existing_project(project_name)
@@ -68,3 +72,18 @@ class ProjectSelectorScreen(Screen):
 
         elif event.button.id == "all_main_menu_buttons":
             self.dismiss(False)
+
+    @staticmethod
+    def name_to_id(name: str):
+        """
+        Textual ids cannot start with a number, so ensure
+        all ids are prefixed with text instead of the project name.
+        """
+        return f"safety_prefix_{name}"
+
+    @staticmethod
+    def id_to_name(id: str):
+        """
+        See `name_id_id()`
+        """
+        return id.replace("safety_prefix_", "")

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -6,7 +6,10 @@ from base import BaseTest
 
 from datashuttle import DataShuttle
 from datashuttle.utils import getters
-from datashuttle.utils.custom_exceptions import ConfigError
+from datashuttle.utils.custom_exceptions import (
+    ConfigError,
+    NeuroBlueprintError,
+)
 
 
 class TestConfigs(BaseTest):
@@ -49,6 +52,15 @@ class TestConfigs(BaseTest):
             == "Configuration file has not been initialized. "
             "Use make_config_file() to setup before continuing."
         )
+
+    def test_empty_project_name(self):
+        """
+        Empty project names ("") are not allowed.
+        """
+        with pytest.raises(NeuroBlueprintError) as e:
+            DataShuttle("")
+
+        assert str(e.value) == "The project name cannot be empty."
 
     @pytest.mark.parametrize(
         "bad_pattern",

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -53,10 +53,12 @@ class TestConfigs(BaseTest):
             "Use make_config_file() to setup before continuing."
         )
 
-    def test_empty_project_name(self):
+    def test_empty_project_name(self, tmp_path):
         """
         Empty project names ("") are not allowed.
         """
+        os.chdir(tmp_path)  # avoids messy backup folder creation
+
         with pytest.raises(NeuroBlueprintError) as e:
             DataShuttle("")
 

--- a/tests/tests_tui/test_tui_configs.py
+++ b/tests/tests_tui/test_tui_configs.py
@@ -370,6 +370,44 @@ class TestTuiConfigs(TuiBase):
             await pilot.pause()
 
     # -------------------------------------------------------------------------
+    # Test project name is number
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_project_name_is_number(self):
+        """
+        Make a project that has a number name, and check the project screen
+        can be loaded.
+        """
+        app = TuiApp()
+        async with app.run_test(size=self.tui_size()) as pilot:
+
+            # Set up a project with a numerical project name
+            project_name = "123"
+
+            await self.scroll_to_click_pause(
+                pilot, "#mainwindow_new_project_button"
+            )
+
+            await self.fill_input(pilot, "#configs_name_input", project_name)
+            await self.fill_input(pilot, "#configs_local_path_input", "a")
+            await self.fill_input(pilot, "#configs_central_path_input", "b")
+            await self.scroll_to_click_pause(
+                pilot, "#configs_save_configs_button"
+            )
+
+            # Go back to main menu and load the project screen
+            await self.close_messagebox(pilot)
+
+            await self.scroll_to_click_pause(pilot, "#all_main_menu_buttons")
+
+            await self.check_and_click_onto_existing_project(
+                pilot, project_name
+            )
+
+            await pilot.pause()
+
+    # -------------------------------------------------------------------------
     # Helpers
     # -------------------------------------------------------------------------
 

--- a/tests/tests_tui/tui_base.py
+++ b/tests/tests_tui/tui_base.py
@@ -188,7 +188,7 @@ class TuiBase:
         assert len(pilot.app.screen.project_names) == 1
         assert project_name in pilot.app.screen.project_names
 
-        await pilot.click(f"#{project_name}")
+        await pilot.click(f"#safety_prefix_{project_name}")
         await pilot.pause()
 
         assert isinstance(pilot.app.screen, ProjectManagerScreen)


### PR DESCRIPTION
This PR handles two types of project names that were causing problems:

1) empty project names #472 
2) project names with numbers in #512 

This raises an error if the project name is empty, and for the TUI adds a prefix to the id created from the project name to ensure numbers don't crash (as ids cannot start with a number).

Tests are added for these cases, no documentation is required.