### PR TITLE
Remove superfluous warnings from tests.

### DIFF
--- a/datashuttle/tui/screens/create_folder_settings.py
+++ b/datashuttle/tui/screens/create_folder_settings.py
@@ -75,7 +75,7 @@ class CreateFoldersSettingsScreen(ModalScreen):
         sub_on = True if self.input_mode == "sub" else False
         ses_on = not sub_on
 
-        explanation = """
+        explanation = r"""
         A 'Template' can be set check subject or session names are
         formatted in a specific way.
 

--- a/datashuttle/utils/getters.py
+++ b/datashuttle/utils/getters.py
@@ -233,7 +233,7 @@ def get_num_value_digits_from_project(
 def get_num_value_digits_from_regexp(
     prefix: Prefix, name_template_regexp: str
 ) -> Union[Literal[False], int]:
-    """
+    r"""
     Given a name template regexp, find the number of values for the
     sub or ses key. These will be fixed with "\d" (digit) or ".?" (wildcard).
     If there is length-unspecific wildcard (.*) in the sub key, then skip.

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -310,7 +310,7 @@ def get_path_and_name(path_or_name: Path | str) -> Tuple[Optional[Path], str]:
 
 
 def replace_tags_in_regexp(regexp: str) -> str:
-    """
+    r"""
     Before validation, all tags in the names are converted to
     their final values (e.g. @DATE@ -> _date-<date>). We also want to
     allow template to be formatted like `sub-\d\d_@DATE@` as it

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -321,8 +321,8 @@ def replace_tags_in_regexp(regexp: str) -> str:
     Note `replace_date_time_tags_in_name()` operates in place on a list.
     """
     regexp_list = [regexp]
-    date_regexp = "\d\d\d\d\d\d\d\d"
-    time_regexp = "\d\d\d\d\d\d"
+    date_regexp = r"\d\d\d\d\d\d\d\d"
+    time_regexp = r"\d\d\d\d\d\d"
 
     formatting.replace_date_time_tags_in_name(
         regexp_list,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,15 +34,11 @@ def setup_project_default_configs(
     """
     delete_project_if_it_exists(project_name)
 
-    warnings.filterwarnings("ignore")
-
-    project = DataShuttle(project_name)
+    project = make_project(project_name)
 
     default_configs = get_test_config_arguments_dict(
         tmp_path, project_name, set_as_defaults=True
     )
-
-    #  make_project_paths(default_configs)
 
     project.make_config_file(**default_configs)
 
@@ -51,8 +47,6 @@ def setup_project_default_configs(
         project.cfg.get_rclone_config_name("ssh"),
         project.cfg.ssh_key_path,
     )
-
-    warnings.filterwarnings("default")
 
     if local_path:
         os.makedirs(local_path, exist_ok=True)
@@ -147,7 +141,7 @@ def setup_project_fixture(tmp_path, test_project_name, project_type="full"):
             ),
         )
     elif project_type == "local":
-        project = DataShuttle(test_project_name)
+        project = make_project(test_project_name)
         project.make_config_file(
             local_path=make_test_path(tmp_path, "local", test_project_name)
         )
@@ -699,3 +693,10 @@ def get_task_by_name(name):
 async def await_task_by_name_if_present(name: str) -> None:
     if task := get_task_by_name(name):
         await task
+
+
+def make_project(project_name):
+    warnings.filterwarnings("ignore")
+    project = DataShuttle(project_name)
+    warnings.filterwarnings("default")
+    return project

--- a/tests/tests_integration/base.py
+++ b/tests/tests_integration/base.py
@@ -3,8 +3,6 @@ import warnings
 import pytest
 import test_utils
 
-from datashuttle import DataShuttle
-
 TEST_PROJECT_NAME = "test_project"
 
 
@@ -19,7 +17,7 @@ class BaseTest:
         test_utils.delete_project_if_it_exists(TEST_PROJECT_NAME)
 
         warnings.filterwarnings("ignore")
-        no_cfg_project = DataShuttle(TEST_PROJECT_NAME)
+        no_cfg_project = test_utils.make_project(TEST_PROJECT_NAME)
         warnings.filterwarnings("default")
 
         yield no_cfg_project
@@ -51,7 +49,7 @@ class BaseTest:
             )
         elif project_type == "local":
             test_utils.delete_project_if_it_exists(TEST_PROJECT_NAME)
-            project = DataShuttle(TEST_PROJECT_NAME)
+            project = test_utils.make_project(TEST_PROJECT_NAME)
             project.make_config_file(local_path=tmp_path / TEST_PROJECT_NAME)
 
         else:

--- a/tests/tests_integration/test_configs.py
+++ b/tests/tests_integration/test_configs.py
@@ -71,6 +71,8 @@ class TestConfigs(BaseTest):
 
         Note pathlib strips "./" so not checked.
         """
+        os.chdir(tmp_path)
+
         if bad_pattern != ".":
             bad_pattern = f"{bad_pattern}/{project.project_name}"
         good_pattern = f"{tmp_path}/my/path/{project.project_name}"
@@ -236,7 +238,7 @@ class TestConfigs(BaseTest):
             patch_get_datashuttle_path,
         )
 
-        project_1 = DataShuttle("project_1")
+        project_1 = test_utils.make_project("project_1")
         project_1.make_config_file(
             tmp_path / "project_1",
             tmp_path / "project_1",
@@ -247,7 +249,7 @@ class TestConfigs(BaseTest):
         # have a config file.
         os.mkdir(tmp_path / "projects" / "project_2")
 
-        project_2 = DataShuttle("project_3")
+        project_2 = test_utils.make_project("project_3")
         project_2.make_config_file(
             tmp_path / "project_3",
             tmp_path / "project_3",
@@ -276,6 +278,6 @@ class TestConfigs(BaseTest):
 
         del project  # del project is almost certainly unnecessary
 
-        project = DataShuttle(project_name)
+        project = test_utils.make_project(project_name)
 
         test_utils.check_configs(project, kwargs[0])

--- a/tests/tests_integration/test_filesystem_transfer.py
+++ b/tests/tests_integration/test_filesystem_transfer.py
@@ -336,7 +336,7 @@ class TestFileTransfer(BaseTest):
                     (base_local / "rawdata" / sub / "ses*").as_posix()
                 )
 
-                datetime_regexp = "datetime-\d{8}T\d{6}"
+                datetime_regexp = r"datetime-\d{8}T\d{6}"
 
                 assert re.fullmatch(
                     "ses-001_" + datetime_regexp, sessions_in_path[0]

--- a/tests/tests_integration/test_local_only_mode.py
+++ b/tests/tests_integration/test_local_only_mode.py
@@ -4,7 +4,6 @@ import pytest
 import test_utils
 from base import BaseTest
 
-from datashuttle import DataShuttle
 from datashuttle.utils.custom_exceptions import (
     ConfigError,
 )
@@ -21,7 +20,7 @@ class TestLocalOnlyProject(BaseTest):
         """
         local_path = tmp_path / "test_local"
 
-        project = DataShuttle("this_project_is_not_torn_down")
+        project = test_utils.make_project("this_project_is_not_torn_down")
 
         with pytest.raises(ConfigError) as e:
             project.make_config_file(

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 import test_utils
 
-from datashuttle import DataShuttle
 from datashuttle.configs import canonical_configs
 from datashuttle.configs.canonical_tags import tags
 from datashuttle.utils import ds_logger
@@ -154,7 +153,7 @@ class TestLogging:
 
     def test_logs_make_config_file(self, clean_project_name, tmp_path):
         """"""
-        project = DataShuttle(clean_project_name)
+        project = test_utils.make_project(clean_project_name)
 
         project.make_config_file(
             tmp_path / clean_project_name,
@@ -358,7 +357,7 @@ class TestLogging:
         logs are moved to the passed `local_path` when
         `make_config_file()` is passed.
         """
-        project = DataShuttle(clean_project_name)
+        project = test_utils.make_project(clean_project_name)
 
         configs = test_utils.get_test_config_arguments_dict(
             tmp_path, clean_project_name
@@ -389,7 +388,7 @@ class TestLogging:
         begins, this test checks the `_temp_log_path`
         is cleared correctly.
         """
-        project = DataShuttle(clean_project_name)
+        project = test_utils.make_project(clean_project_name)
 
         configs = test_utils.get_test_config_arguments_dict(
             tmp_path, clean_project_name

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -65,8 +65,8 @@ class TestPersistentSettings(BaseTest):
 
         assert (
             str(e.value)
-            == "TEMPLATE: The name: sub-3_id-abC_random-helloworld "
-            "does not match the template: sub-\\d_id-.?.?_random-.*"
+            == r"TEMPLATE: The name: sub-3_id-abC_random-helloworld "
+            r"does not match the template: sub-\\d_id-.?.?_random-.*"
         )
 
         # Good sub name (should not raise)
@@ -78,8 +78,8 @@ class TestPersistentSettings(BaseTest):
 
         assert (
             str(e.value)
-            == "TEMPLATE: The name: ses-33_id-xyz_ranDUM-helloworld "
-            "does not match the template: ses-\\d\\d_id-.?.?.?_random-.*"
+            == r"TEMPLATE: The name: ses-33_id-xyz_ranDUM-helloworld "
+            r"does not match the template: ses-\\d\\d_id-.?.?.?_random-.*"
         )
 
         # Good ses name (should not raise)

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -65,8 +65,8 @@ class TestPersistentSettings(BaseTest):
 
         assert (
             str(e.value)
-            == r"TEMPLATE: The name: sub-3_id-abC_random-helloworld "
-            r"does not match the template: sub-\\d_id-.?.?_random-.*"
+            == "TEMPLATE: The name: sub-3_id-abC_random-helloworld "
+            "does not match the template: sub-\\d_id-.?.?_random-.*"
         )
 
         # Good sub name (should not raise)
@@ -78,8 +78,8 @@ class TestPersistentSettings(BaseTest):
 
         assert (
             str(e.value)
-            == r"TEMPLATE: The name: ses-33_id-xyz_ranDUM-helloworld "
-            r"does not match the template: ses-\\d\\d_id-.?.?.?_random-.*"
+            == "TEMPLATE: The name: ses-33_id-xyz_ranDUM-helloworld "
+            "does not match the template: ses-\\d\\d_id-.?.?.?_random-.*"
         )
 
         # Good ses name (should not raise)

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -32,8 +32,8 @@ class TestPersistentSettings(BaseTest):
         assert name_templates["ses"] is None
 
         # Set some new settings and check they become persistent
-        sub_regexp = "sub-\d_id-.?.?_random-.*"
-        ses_regexp = "ses-\d\d_id-.?.?.?_random-.*"
+        sub_regexp = r"sub-\d_id-.?.?_random-.*"
+        ses_regexp = r"ses-\d\d_id-.?.?.?_random-.*"
 
         new_name_templates = {
             "on": True,

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -2,9 +2,9 @@ import os
 import shutil
 
 import pytest
+import test_utils
 from base import BaseTest
 
-from datashuttle import DataShuttle
 from datashuttle.configs import canonical_configs
 from datashuttle.utils import validation
 from datashuttle.utils.custom_exceptions import NeuroBlueprintError
@@ -32,8 +32,8 @@ class TestPersistentSettings(BaseTest):
         assert name_templates["ses"] is None
 
         # Set some new settings and check they become persistent
-        sub_regexp = r"sub-\d_id-.?.?_random-.*"
-        ses_regexp = r"ses-\d\d_id-.?.?.?_random-.*"
+        sub_regexp = "sub-\d_id-.?.?_random-.*"
+        ses_regexp = "ses-\d\d_id-.?.?.?_random-.*"
 
         new_name_templates = {
             "on": True,
@@ -43,7 +43,7 @@ class TestPersistentSettings(BaseTest):
 
         project.set_name_templates(new_name_templates)
 
-        project_reload = DataShuttle(project.project_name)
+        project_reload = test_utils.make_project(project.project_name)
 
         reload_name_templates = project_reload.get_name_templates()
 
@@ -138,7 +138,7 @@ class TestPersistentSettings(BaseTest):
         project._update_persistent_setting("tui", new_tui_settings)
 
         # Reload and check
-        project = DataShuttle(project.project_name)
+        project = test_utils.make_project(project.project_name)
 
         reloaded_settings = project._load_persistent_settings()
         assert reloaded_settings["tui"] == new_tui_settings
@@ -155,7 +155,7 @@ class TestPersistentSettings(BaseTest):
         # should not raise
         project.create_folders("rawdata", "sub-@@@", bypass_validation=True)
 
-        project = DataShuttle(project.project_name)
+        project = test_utils.make_project(project.project_name)
 
         with pytest.raises(BaseException) as e:
             project.create_folders("rawdata", "sub-@@@")

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -717,8 +717,8 @@ class TestValidation(BaseTest):
         """
         name_templates = {
             "on": True,
-            "sub": "sub-\d\d_@DATE@",
-            "ses": "ses-\d\d\d@DATETIME@",
+            "sub": r"sub-\d\d_@DATE@",
+            "ses": r"ses-\d\d\d@DATETIME@",
         }
 
         project.set_name_templates(name_templates)
@@ -745,7 +745,7 @@ class TestValidation(BaseTest):
         assert "TEMPLATE: The name: ses-001_datex-20241212" in str(e.value)
 
         # Do a quick test for time
-        name_templates["sub"] = "sub-\d\d_@TIME@"
+        name_templates["sub"] = r"sub-\d\d_@TIME@"
         project.set_name_templates(name_templates)
 
         # use time tag, should not raise
@@ -765,8 +765,8 @@ class TestValidation(BaseTest):
         """
         name_templates = {
             "on": True,
-            "sub": "sub-\d\d_id-\d.?",
-            "ses": "ses-\d\d_id-\d.?",
+            "sub": r"sub-\d\d_id-\d.?",
+            "ses": r"ses-\d\d_id-\d.?",
         }
         project.set_name_templates(name_templates)
 

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -760,9 +760,8 @@ class TestValidation(BaseTest):
         assert "TEMPLATE: The name: ses-001_datex-20241212" in str(e.value)
 
     def test_name_templates_validate_project(self, project):
-        """
-        TODO
-        """
+
+        # set up name templates
         name_templates = {
             "on": True,
             "sub": r"sub-\d\d_id-\d.?",
@@ -770,12 +769,14 @@ class TestValidation(BaseTest):
         }
         project.set_name_templates(name_templates)
 
+        # Create names that match, check this does not error
         project.create_folders(
             "rawdata", "sub-01_id-2b", "ses-01_id-1a", bypass_validation=True
         )
 
         project.validate_project("rawdata", "error", include_central=False)
 
+        # Create names that don't match, check they error
         project.create_folders(
             "rawdata", "sub-02_id-a1", "ses-02_id-aa", bypass_validation=True
         )
@@ -784,11 +785,11 @@ class TestValidation(BaseTest):
             project.validate_project("rawdata", "warn", include_central=False)
 
         assert (
-            r"TEMPLATE: The name: sub-02_id-a1 does not match the template: sub-\\d\\d_id-\\d.?"
+            "TEMPLATE: The name: sub-02_id-a1 does not match the template: sub-\\d\\d_id-\\d.?"
             in str(w[0].message)
         )
         assert (
-            r"TEMPLATE: The name: ses-02_id-aa does not match the template: ses-\\d\\d_id-\\d.?"
+            "TEMPLATE: The name: ses-02_id-aa does not match the template: ses-\\d\\d_id-\\d.?"
             in str(w[1].message)
         )
 

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -784,11 +784,11 @@ class TestValidation(BaseTest):
             project.validate_project("rawdata", "warn", include_central=False)
 
         assert (
-            "TEMPLATE: The name: sub-02_id-a1 does not match the template: sub-\\d\\d_id-\\d.?"
+            r"TEMPLATE: The name: sub-02_id-a1 does not match the template: sub-\\d\\d_id-\\d.?"
             in str(w[0].message)
         )
         assert (
-            "TEMPLATE: The name: ses-02_id-aa does not match the template: ses-\\d\\d_id-\\d.?"
+            r"TEMPLATE: The name: ses-02_id-aa does not match the template: ses-\\d\\d_id-\\d.?"
             in str(w[1].message)
         )
 

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -1,5 +1,6 @@
 import os.path
 import shutil
+import warnings
 
 import pytest
 from base import BaseTest
@@ -408,9 +409,12 @@ class TestValidation(BaseTest):
                 "rawdata", "sub-001", bad_names, bypass_validation=True
             )
 
+        warnings.filterwarnings("ignore")
         error_messages = project.validate_project(
             "rawdata", "warn", include_central=False
         )
+        warnings.filterwarnings("default")
+
         concat_error = "".join(error_messages)
 
         assert "DATETIME" in concat_error
@@ -426,9 +430,11 @@ class TestValidation(BaseTest):
             "rawdata", sub_name, ses_name, bypass_validation=True
         )
 
+        warnings.filterwarnings("ignore")
         error_messages = project.validate_project(
             "rawdata", "warn", include_central=False
         )
+        warnings.filterwarnings("default")
 
         sub_path = error_messages[0].split("Path: ")[-1]
         ses_path = error_messages[1].split("Path: ")[-1]

--- a/tests/tests_regression/test_backwards_compatibility.py
+++ b/tests/tests_regression/test_backwards_compatibility.py
@@ -5,8 +5,6 @@ from pathlib import Path
 import pytest
 import test_utils
 
-from datashuttle import DataShuttle
-
 TEST_PROJECT_NAME = "test_project"
 
 
@@ -20,7 +18,7 @@ class TestBackwardsCompatibility:
         """
         test_utils.delete_project_if_it_exists(TEST_PROJECT_NAME)
 
-        project = DataShuttle(TEST_PROJECT_NAME)
+        project = test_utils.make_project(TEST_PROJECT_NAME)
 
         yield project
 
@@ -104,7 +102,7 @@ class TestBackwardsCompatibility:
 
         # In the current version of datashuttle, get the settings. These are
         # thus correct for the most recent datashuttle version.
-        project = DataShuttle(TEST_PROJECT_NAME)
+        project = test_utils.make_project(TEST_PROJECT_NAME)
         project.make_config_file("cur_ver", "cur_ver", "local_filesystem")
 
         current_ver_configs = project.get_configs()
@@ -117,7 +115,7 @@ class TestBackwardsCompatibility:
         shutil.copy(old_version_path / "config.yaml", config_path)
         shutil.copy(old_version_path / "persistent_settings.yaml", config_path)
 
-        project = DataShuttle(TEST_PROJECT_NAME)
+        project = test_utils.make_project(TEST_PROJECT_NAME)
 
         reloaded_ver_configs = project.get_configs()
         reloaded_ver_persistent_settings = project._load_persistent_settings()

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -110,11 +110,11 @@ class TestTuiCreateFolders(TuiBase):
             sub_1_regexp = r"sub\-001_date\-\d{8}"
             sub_2_regexp = r"sub\-002_date\-\d{8}"
             sub_tooltip_regexp = (
-                "Formatted names: \['"
+                r"Formatted names: \['"
                 + sub_1_regexp
                 + "', '"
                 + sub_2_regexp
-                + "'\]"
+                + r"'\]"
             )
             sub_tooltip = pilot.app.screen.query_one(
                 "#create_folders_subject_input"
@@ -131,13 +131,13 @@ class TestTuiCreateFolders(TuiBase):
             ses_2_regexp = r"ses\-002_date\-\d{8}"
             ses_3_regexp = r"ses\-003_date\-\d{8}"
             ses_tooltip_regexp = (
-                "Formatted names: \['"
+                r"Formatted names: \['"
                 + ses_1_regexp
                 + "', '"
                 + ses_2_regexp
                 + "', '"
                 + ses_3_regexp
-                + "'\]"
+                + r"'\]"
             )
             ses_tooltip = pilot.app.screen.query_one(
                 "#create_folders_session_input"

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -388,7 +388,7 @@ class TestTuiCreateFolders(TuiBase):
             assert pilot.app.screen.query_one(
                 "#messagebox_message_label"
             ).renderable == (
-                r"TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             await self.close_messagebox(pilot)
@@ -429,7 +429,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).value
-                == r"sub-\\d\\d\\d"
+                == "sub-\\d\\d\\d"
             )
 
             await self.double_click(

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -365,7 +365,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).tooltip
-                == r"TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                == "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             # It is expected that sub errors propagate to session input.
@@ -378,7 +378,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_session_input"
                 ).tooltip
-                == r"TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                == "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             # Try and make the folders, displaying a validation error.

--- a/tests/tests_tui/test_tui_create_folders.py
+++ b/tests/tests_tui/test_tui_create_folders.py
@@ -107,8 +107,8 @@ class TestTuiCreateFolders(TuiBase):
                 "sub-001_@DATE@, sub-002_@DATE@",
             )
 
-            sub_1_regexp = "sub\-001_date\-\d{8}"
-            sub_2_regexp = "sub\-002_date\-\d{8}"
+            sub_1_regexp = r"sub\-001_date\-\d{8}"
+            sub_2_regexp = r"sub\-002_date\-\d{8}"
             sub_tooltip_regexp = (
                 "Formatted names: \['"
                 + sub_1_regexp
@@ -127,9 +127,9 @@ class TestTuiCreateFolders(TuiBase):
                 pilot, "#create_folders_session_input", "ses-001@TO@003_@DATE@"
             )
 
-            ses_1_regexp = "ses\-001_date\-\d{8}"
-            ses_2_regexp = "ses\-002_date\-\d{8}"
-            ses_3_regexp = "ses\-003_date\-\d{8}"
+            ses_1_regexp = r"ses\-001_date\-\d{8}"
+            ses_2_regexp = r"ses\-002_date\-\d{8}"
+            ses_3_regexp = r"ses\-003_date\-\d{8}"
             ses_tooltip_regexp = (
                 "Formatted names: \['"
                 + ses_1_regexp
@@ -354,7 +354,7 @@ class TestTuiCreateFolders(TuiBase):
             # Set some name template and check the tooltips
             # indicate mismatches correctly
             pilot.app.screen.interface.project.set_name_templates(
-                {"on": True, "sub": "sub-\d\d\d", "ses": "ses-...."}
+                {"on": True, "sub": r"sub-\d\d\d", "ses": "ses-...."}
             )
 
             await self.fill_input(
@@ -365,7 +365,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).tooltip
-                == "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                == r"TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             # It is expected that sub errors propagate to session input.
@@ -378,7 +378,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_session_input"
                 ).tooltip
-                == "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                == r"TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             # Try and make the folders, displaying a validation error.
@@ -388,7 +388,7 @@ class TestTuiCreateFolders(TuiBase):
             assert pilot.app.screen.query_one(
                 "#messagebox_message_label"
             ).renderable == (
-                "TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
+                r"TEMPLATE: The name: sub-0001 does not match the template: sub-\\d\\d\\d"
             )
 
             await self.close_messagebox(pilot)
@@ -429,7 +429,7 @@ class TestTuiCreateFolders(TuiBase):
                 pilot.app.screen.query_one(
                     "#create_folders_subject_input"
                 ).value
-                == "sub-\\d\\d\\d"
+                == r"sub-\\d\\d\\d"
             )
 
             await self.double_click(

--- a/tests/tests_tui/test_tui_logging.py
+++ b/tests/tests_tui/test_tui_logging.py
@@ -1,7 +1,7 @@
 import pytest
+import test_utils
 from tui_base import TuiBase
 
-from datashuttle import DataShuttle
 from datashuttle.tui.app import TuiApp
 from datashuttle.tui.tabs.logging import RichLogScreen
 
@@ -21,7 +21,7 @@ class TestTuiLogging(TuiBase):
         async with app.run_test(size=self.tui_size()) as pilot:
 
             # Update configs and create folders to make some logs
-            project = DataShuttle(project_name)
+            project = test_utils.make_project(project_name)
 
             # Sometimes in CI environment there is already an
             # update-config-file log here. Not sure why, it's not

--- a/tests/tests_tui/test_tui_validate.py
+++ b/tests/tests_tui/test_tui_validate.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import textual
 from tui_base import TuiBase
@@ -187,9 +189,11 @@ class TestTuiValidate(TuiBase):
                 "quick_validate_project",
             )
 
+            warnings.filter("ignore")
             await self.scroll_to_click_pause(
                 pilot, "#validate_validate_button"
             )
+            warnings.filter("default")
 
             # Check args are passed through to function as expected
             args_, kwargs_ = spy_validate.call_args_list[0]

--- a/tests/tests_tui/test_tui_validate.py
+++ b/tests/tests_tui/test_tui_validate.py
@@ -189,11 +189,11 @@ class TestTuiValidate(TuiBase):
                 "quick_validate_project",
             )
 
-            warnings.filter("ignore")
+            warnings.filterwarnings("ignore")
             await self.scroll_to_click_pause(
                 pilot, "#validate_validate_button"
             )
-            warnings.filter("default")
+            warnings.filterwarnings("default")
 
             # Check args are passed through to function as expected
             args_, kwargs_ = spy_validate.call_args_list[0]

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -509,8 +509,8 @@ class TestTuiWidgets(TuiBase):
         """
         tmp_config_path, tmp_path, project_name = setup_project_paths.values()
 
-        sub_regexp = "sub-\d\d\d"
-        ses_regexp = "ses-00\d_????"
+        sub_regexp = r"sub-\d\d\d"
+        ses_regexp = r"ses-00\d_????"
 
         app = TuiApp()
         async with app.run_test(size=self.tui_size()) as pilot:

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -2,9 +2,9 @@ import platform
 from typing import Union
 
 import pytest
+import test_utils
 from tui_base import TuiBase
 
-from datashuttle import DataShuttle
 from datashuttle.configs import canonical_configs
 from datashuttle.tui.app import TuiApp
 from datashuttle.tui.screens.create_folder_settings import (
@@ -509,8 +509,8 @@ class TestTuiWidgets(TuiBase):
         """
         tmp_config_path, tmp_path, project_name = setup_project_paths.values()
 
-        sub_regexp = r"sub-\d\d\d"
-        ses_regexp = r"ses-00\d_????"
+        sub_regexp = "sub-\d\d\d"
+        ses_regexp = "ses-00\d_????"
 
         app = TuiApp()
         async with app.run_test(size=self.tui_size()) as pilot:
@@ -1420,7 +1420,7 @@ class TestTuiWidgets(TuiBase):
 
         assert pilot.app.screen.interface.tui_settings["dry_run"] is value
 
-        project = DataShuttle(project_name)
+        project = test_utils.make_project(project_name)
         persistent_settings = project._load_persistent_settings()
         assert persistent_settings["tui"]["dry_run"] is value
 
@@ -1445,7 +1445,7 @@ class TestTuiWidgets(TuiBase):
             == format_val
         )
 
-        project = DataShuttle(project_name)
+        project = test_utils.make_project(project_name)
         persistent_settings = project._load_persistent_settings()
         assert (
             persistent_settings["tui"]["overwrite_existing_files"]

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -18,7 +18,7 @@ class TestUnit:
         "key", [tags("date"), tags("time"), tags("datetime")]
     )
     def test_datetime_string_replacement(self, key, underscore_position):
-        """
+        r"""
         Test the function that replaces @DATE, @TIME@ or @DATETIME@
         keywords with the date / time / datetime. Also, it will
         pre/append underscores to the tags if they are not


### PR DESCRIPTION
The PR add some `warnings.filter("ignore")` to tests and adds `r` string prefix to avoid unecessary warnings in tests. I will merge this without review because it is a very simple addition and exclusively on tests, which are passing.

