### PR TITLE
Add Python 3.13 support.

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -34,7 +34,7 @@ jobs:
         # the weekly cron job.
         os: [ ubuntu-latest, windows-latest, macos-14, macos-13]
         # Test all Python versions for cron job, and only first/last for other triggers
-        python-version: ${{ fromJson(github.event_name == 'schedule' && '["3.9", "3.10", "3.11", "3.12"]' || '["3.9", "3.12"]') }}
+        python-version: ${{ fromJson(github.event_name == 'schedule' && '["3.9", "3.10", "3.11", "3.12", "3.13"]' || '["3.9", "3.13"]') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License",
 ]


### PR DESCRIPTION
Update `pyproject.toml` and CI tests to support Python 3.13.

Currently the conda-tests are not changed because a release needs to be made on the Python side to trigger a conda release. Then, a follow-up PR will add the conda release tests.