### PR TITLE
Keep default drive for SelectDirectoryTreeScreen as home.

### DIFF
--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -219,9 +219,7 @@ class SelectDirectoryTreeScreen(ModalScreen):
 
     """
 
-    def __init__(
-        self, mainwindow: TuiApp, path_: Optional[Path] = None
-    ) -> None:
+    def __init__(self, mainwindow: TuiApp) -> None:
         """Initialise SelectDirectoryTreeScreen.
 
         Parameters
@@ -236,11 +234,13 @@ class SelectDirectoryTreeScreen(ModalScreen):
         super(SelectDirectoryTreeScreen, self).__init__()
         self.mainwindow = mainwindow
 
-        if path_ is None:
-            path_ = Path().home()
-        self.path_ = path_
+        self.path_ = Path().home()
 
         self.click_info = ClickInfo()
+
+        # Flag as the Select triggers `on_select_change` during set up
+        # which results setting tree back to default drive not home.
+        self.skip_first_select_trigger = True
 
     def compose(self) -> ComposeResult:
         """Add widgets to the SelectDirectoryTreeScreen."""
@@ -305,10 +305,13 @@ class SelectDirectoryTreeScreen(ModalScreen):
 
     def on_select_changed(self, event: Select.Changed) -> None:
         """Update the directory tree when the drive is changed."""
-        self.path_ = Path(event.value)
-        self.query_one(
-            "#select_directory_tree_directory_tree"
-        ).path = self.path_
+        if self.skip_first_select_trigger:
+            self.skip_first_select_trigger = False
+        else:
+            self.path_ = Path(event.value)
+            self.query_one(
+                "#select_directory_tree_directory_tree"
+            ).path = self.path_
 
     @require_double_click
     def on_directory_tree_directory_selected(

--- a/tests/tests_tui/test_tui_selectdirectorytree.py
+++ b/tests/tests_tui/test_tui_selectdirectorytree.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from datashuttle.tui.app import TuiApp
@@ -47,9 +49,7 @@ class TestSelectTree(TuiBase):
                 "#select_directory_tree_drive_select"
             )
 
-            select.value = "Drive1"
-            await pilot.pause()
-            assert str(tree.path) == "Drive1"
+            assert tree.path == Path().home()
 
             select.value = "Drive2"
             await pilot.pause()


### PR DESCRIPTION
This PR closes #550 by ensuring that the default path on the DirectoryTree in the select path window (used for new project and validate screen) is the home path. The problem is that the drive select (e.g. select C:\, D:\) was automatically triggered (I think when it is composed) calling `on_select_changed` which reset the directory tree to the drive. 

I couldn't find a way around this except to use a flag, which isn't ideal but it works. Now the default home path is used and only reset to the drive base when the select is changed. Also, I removed the `path_` argument for `SelectDirectoryTree` because it was never used.

Docs do not need changing and a test is updated.