### PR TITLE
Partially revert lsjson

### DIFF
--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -660,7 +660,7 @@ def search_local_filesystem(
         elif item.is_file():
             all_filenames.append(to_append)
 
-    return all_folder_names, all_filenames
+    return sorted(all_folder_names), sorted(all_filenames)
 
 
 def search_central_via_connection(

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -722,4 +722,4 @@ def search_central_via_connection(
         else:
             all_filenames.append(to_append)
 
-    return all_folder_names, all_filenames
+    return sorted(all_folder_names), sorted(all_filenames)

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -642,8 +642,9 @@ def search_local_filesystem(
     ----------
     search_path
         The path to search (relative to the local or remote drive). For example,
-        for "local_filesystem" this is the path on the local machine. For "ssh", this
-        is the path on the machine that has been connected to.
+        for "local_filesystem" this is the path on the local machine. For any other
+        connection to central, this is the path on the central storage that has been
+        connected to.
 
     search_prefix
         The search string e.g. "sub-*".
@@ -683,10 +684,13 @@ def search_central_via_connection(
         datashuttle Configs class.
     search_path
         The path to search (relative to the local or remote drive). For example,
-        for "local_filesystem" this is the path on the local machine. For "ssh", this
-        is the path on the machine that has been connected to.
+        for "local_filesystem" this is the path on the local machine. For any other
+        connection to central, this is the path on the central storage that has been
+        connected to.
+
     search_prefix
         The search string e.g. "sub-*".
+
     return_full_path
         If `True`, return the full filepath, otherwise return only the folder/file name.
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -571,11 +571,12 @@ def search_for_folders(
     verbose: bool = True,
     return_full_path: bool = False,
 ) -> Tuple[List[Any], List[Any]]:
-    """Determine the method used to search for search prefix folders in the search path.
+    """Search for files and folders in the search path.
 
-    If local filesystem, use a bespoke function because it is faster. `rclone`
-    can be used to search local filesystem, but it is slow because a new process
-    must be created. These functions are tested against each-other.
+    If searching the local filesystem, use a separate function that does not call `rclone`,
+    which is faster as a new process does not have to be created. This slowness
+    is mostly a problem on Windows. This does mean there are two duplicate functions,
+    these are tested against each-other in unit tests.
 
     Parameters
     ----------
@@ -643,8 +644,10 @@ def search_local_filesystem(
         The path to search (relative to the local or remote drive). For example,
         for "local_filesystem" this is the path on the local machine. For "ssh", this
         is the path on the machine that has been connected to.
+
     search_prefix
         The search string e.g. "sub-*".
+
     return_full_path
         If `True`, return the full filepath, otherwise return only the folder/file name.
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -695,17 +695,17 @@ def search_central_via_connection(
         pipe_std=True,
     )
 
+    all_folder_names: list = []
+    all_filenames: list = []
+
     if output.returncode != 0:
-        utils.log_and_raise_error(
+        utils.log_and_message(
             f"Error searching files at {search_path.as_posix()}\n"
-            f"{output.stderr.decode('utf-8') if output.stderr else ''}",
-            RuntimeError,
+            f"{output.stderr.decode('utf-8') if output.stderr else ''}"
         )
+        return all_folder_names, all_filenames
 
     files_and_folders = json.loads(output.stdout)
-
-    all_folder_names = []
-    all_filenames = []
 
     for file_or_folder in files_and_folders:
         name = file_or_folder["Name"]

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -7,6 +6,7 @@ from datashuttle.utils.folders import (
     search_central_via_connection,
     search_local_filesystem,
 )
+from datashuttle.utils.rclone import call_rclone
 
 from .. import test_utils
 from ..base import BaseTest
@@ -65,9 +65,7 @@ class TestSubSesSearches(BaseTest):
             lambda connection_method: "local",
         )
 
-        subprocess.run(
-            "rclone config create local local nounc true", shell=True
-        )
+        call_rclone("config create local local nounc true")
 
         # Perform a range of checks across folders and files
         # and check the outputs of both approaches match.

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from .. import test_utils
 from ..base import BaseTest
 
@@ -9,47 +11,35 @@ from ..base import BaseTest
 
 
 class TestSubSesSearches(BaseTest):
-    def test_local_vs_central_search_methods(self, project, monkeypatch):
+    # TODO: return full path
+    @pytest.mark.parametrize("return_full_path", [True, False])
+    def test_local_vs_central_search_methods(
+        self, project, monkeypatch, return_full_path
+    ):
         """ """
         central_path = project.get_central_path()
 
+        # fmt: off
         paths_to_make = []
         for i in range(1, 4):
             paths_to_make.append(Path(f"rawdata/sub-00{i}/ses-001/behav"))
-            paths_to_make.append(
-                Path(f"rawdata/sub-00{i}/ses-002_date-20250402/behav")
-            )
-            paths_to_make.append(
-                Path(f"rawdata/sub-00{i}/ses-002_date-20250402/anat")
-            )
+            paths_to_make.append(Path(f"rawdata/sub-00{i}/ses-002_date-20250402/behav"))
+            paths_to_make.append(Path(f"rawdata/sub-00{i}/ses-002_date-20250402/anat"))
 
-        paths_to_make.append(
-            Path("rawdata/sub-003_condition-test/ses-001_hello-world/ephys")
-        )
-        paths_to_make.append(
-            Path("rawdata/sub-004_condition-test/ses-002_hello-world/funcimg")
-        )
+        paths_to_make.append(Path("rawdata/sub-003_condition-test/ses-001_hello-world/ephys"))
+        paths_to_make.append(Path("rawdata/sub-004_condition-test/ses-002_hello-world/funcimg"))
 
         for path_ in paths_to_make:
             (central_path / path_).mkdir(parents=True)
-            breakpoint()
-            test_utils.write_file(
-                central_path / path_ / f"{path_.name}.md",
-                contents="hello_world",
-            )
-            test_utils.write_file(
-                central_path / path_.parent / f"{path_.parent.name}.md",
-                contents="hello_world",
-            )
-            test_utils.write_file(
-                central_path
-                / path_.parent.parent
-                / f"{path_.parent.parent.name}.md",
-                contents="hello_world",
-            )
+            test_utils.write_file(central_path / path_ / f"{path_.name}_file.md", contents="hello_world",)
+            test_utils.write_file(central_path / path_.parent / f"{path_.name}.md", contents="hello_world",)
+            test_utils.write_file(central_path / path_.parent.parent / f"{path_.parent.name}.md", contents="hello_world",)
+            test_utils.write_file(central_path / path_.parent.parent.parent / f"{path_.parent.parent.name}.md", contents="hello_world",)
+        # fmt: on
 
         from datashuttle.utils.folders import (
             search_central_via_connection,
+            search_local_filesystem,
         )
 
         # -- monkeypatch cfg.get_rclone_config to return dummy config
@@ -66,11 +56,38 @@ class TestSubSesSearches(BaseTest):
             shell=True,
         )
 
-        hello, world = search_central_via_connection(
-            project.cfg,
-            central_path / "rawdata",
-            "sub-*",
-            return_full_path=True,
-        )
+        for search_path, search_str in (
+            (central_path / "rawdata", "*"),
+            (central_path / "rawdata", "sub-*"),
+            (central_path / "rawdata" / "sub-003_condition-test", "ses-*"),
+            (central_path / "rawdata/sub-001/ses-002_date-20250402", "behav"),
+            (
+                central_path / "rawdata/sub-001/ses-002_date-20250402/behav",
+                "behav_file.md",
+            ),  # ses-002_date-20250402
+            (
+                central_path / "rawdata/sub-001/ses-002_date-20250402/behav",
+                "*",
+            ),
+            (central_path / "rawdata/sub-002", "*"),
+            (central_path / "rawdata/sub-002/ses-002_date-20250402", "*"),
+            (central_path / "rawdata", "sub-003*"),
+        ):
+            central_method_folders, central_method_files = (
+                search_central_via_connection(
+                    project.cfg,
+                    search_path,
+                    search_str,
+                    return_full_path=return_full_path,
+                )
+            )
+            local_method_folders, local_method_files = search_local_filesystem(
+                search_path, search_str, return_full_path=return_full_path
+            )
 
-        breakpoint()
+            assert central_method_folders == local_method_folders, (
+                f"Failed folders, search_str: {search_str}, search_path: {search_path}"
+            )
+            assert central_method_files == local_method_files, (
+                f"Failed files, search_str: {search_str}, search_path: {search_path}"
+            )

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from .. import test_utils
+from ..base import BaseTest
+
+# -----------------------------------------------------------------------------
+# Inconsistent sub or ses value lengths
+# -----------------------------------------------------------------------------
+
+
+class TestSubSesSearches(BaseTest):
+    def test_local_vs_central_search_methods(self, project, monkeypatch):
+        """ """
+        central_path = project.get_central_path()
+
+        paths_to_make = []
+        for i in range(1, 4):
+            paths_to_make.append(Path(f"rawdata/sub-00{i}/ses-001/behav"))
+            paths_to_make.append(
+                Path(f"rawdata/sub-00{i}/ses-002_date-20250402/behav")
+            )
+            paths_to_make.append(
+                Path(f"rawdata/sub-00{i}/ses-002_date-20250402/anat")
+            )
+
+        paths_to_make.append(
+            Path("rawdata/sub-003_condition-test/ses-001_hello-world/ephys")
+        )
+        paths_to_make.append(
+            Path("rawdata/sub-004_condition-test/ses-002_hello-world/funcimg")
+        )
+
+        for path_ in paths_to_make:
+            (central_path / path_).mkdir(parents=True)
+            breakpoint()
+            test_utils.write_file(
+                central_path / path_ / f"{path_.name}.md",
+                contents="hello_world",
+            )
+            test_utils.write_file(
+                central_path / path_.parent / f"{path_.parent.name}.md",
+                contents="hello_world",
+            )
+            test_utils.write_file(
+                central_path
+                / path_.parent.parent
+                / f"{path_.parent.parent.name}.md",
+                contents="hello_world",
+            )
+
+        from datashuttle.utils.folders import (
+            search_central_via_connection,
+        )
+
+        # -- monkeypatch cfg.get_rclone_config to return dummy config
+        monkeypatch.setattr(
+            project.cfg,
+            "get_rclone_config_name",
+            lambda connection_method: "local",
+        )
+
+        import subprocess
+
+        subprocess.run(
+            ["rclone", "config", "create", "local", "local", "nounc", "true"],
+            shell=True,
+        )
+
+        hello, world = search_central_via_connection(
+            project.cfg,
+            central_path / "rawdata",
+            "sub-*",
+            return_full_path=True,
+        )
+
+        breakpoint()

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -1,6 +1,12 @@
+import subprocess
 from pathlib import Path
 
 import pytest
+
+from datashuttle.utils.folders import (
+    search_central_via_connection,
+    search_local_filesystem,
+)
 
 from .. import test_utils
 from ..base import BaseTest
@@ -11,14 +17,26 @@ from ..base import BaseTest
 
 
 class TestSubSesSearches(BaseTest):
-    # TODO: return full path
     @pytest.mark.parametrize("return_full_path", [True, False])
     def test_local_vs_central_search_methods(
         self, project, monkeypatch, return_full_path
     ):
-        """ """
+        """
+        Test the `search_local_filesystem` and `search_central_via_connection`
+        functions. These functions perform the same function but `search_local_filesystem`
+        is used for local filesystem for speed. Here we check the outputs of these
+        functions match.
+
+        These functions are individually tested in many places, primarily in
+        transfer tests. Local filesystem transfer tests are very extensive,
+        because they are quicker, while central connection tests are less
+        thorough. We test the outputs of these two functions directly
+        under a range of test cases to ensure they are matched under many conditions.
+
+        """
         central_path = project.get_central_path()
 
+        # Create a set of folders and files
         # fmt: off
         paths_to_make = []
         for i in range(1, 4):
@@ -37,42 +55,36 @@ class TestSubSesSearches(BaseTest):
             test_utils.write_file(central_path / path_.parent.parent.parent / f"{path_.parent.parent.name}.md", contents="hello_world",)
         # fmt: on
 
-        from datashuttle.utils.folders import (
-            search_central_via_connection,
-            search_local_filesystem,
-        )
-
-        # -- monkeypatch cfg.get_rclone_config to return dummy config
+        # Monkeycatch `get_rclone_config_name` to return `local` and set `local`
+        # as a rclone config entry associated with the local filesystem. By this
+        # method we can hijack `search_central_via_connection` to run locally
+        # (though it is set up in practice to run via ssh, gdrive or aws).
         monkeypatch.setattr(
             project.cfg,
             "get_rclone_config_name",
             lambda connection_method: "local",
         )
 
-        import subprocess
-
         subprocess.run(
             ["rclone", "config", "create", "local", "local", "nounc", "true"],
             shell=True,
         )
 
+        # Perform a range of checks across folders and files
+        # and check the outputs of both approaches match.
+        # fmt: off
         for search_path, search_str in (
             (central_path / "rawdata", "*"),
             (central_path / "rawdata", "sub-*"),
             (central_path / "rawdata" / "sub-003_condition-test", "ses-*"),
             (central_path / "rawdata/sub-001/ses-002_date-20250402", "behav"),
-            (
-                central_path / "rawdata/sub-001/ses-002_date-20250402/behav",
-                "behav_file.md",
-            ),  # ses-002_date-20250402
-            (
-                central_path / "rawdata/sub-001/ses-002_date-20250402/behav",
-                "*",
-            ),
+            (central_path / "rawdata/sub-001/ses-002_date-20250402/behav", "behav_file.md",),
+            (central_path / "rawdata/sub-001/ses-002_date-20250402/behav", "*",),
             (central_path / "rawdata/sub-002", "*"),
             (central_path / "rawdata/sub-002/ses-002_date-20250402", "*"),
             (central_path / "rawdata", "sub-003*"),
         ):
+        # fmt: on
             central_method_folders, central_method_files = (
                 search_central_via_connection(
                     project.cfg,

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -23,7 +23,7 @@ class TestSubSesSearches(BaseTest):
     ):
         """
         Test the `search_local_filesystem` and `search_central_via_connection`
-        functions. These functions perform the same function but `search_local_filesystem`
+        functions. These functions should have the same outputs but `search_local_filesystem`
         is used for local filesystem for speed. Here we check the outputs of these
         functions match.
 
@@ -36,7 +36,7 @@ class TestSubSesSearches(BaseTest):
         """
         central_path = project.get_central_path()
 
-        # Create a set of folders and files
+        # Create a project of folders and files
         # fmt: off
         paths_to_make = []
         for i in range(1, 4):
@@ -84,6 +84,7 @@ class TestSubSesSearches(BaseTest):
             (central_path / "rawdata", "sub-003*"),
         ):
         # fmt: on
+
             central_method_folders, central_method_files = (
                 search_central_via_connection(
                     project.cfg,

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -66,8 +66,7 @@ class TestSubSesSearches(BaseTest):
         )
 
         subprocess.run(
-            ["rclone", "config", "create", "local", "local", "nounc", "true"],
-            shell=True,
+            "rclone config create local local nounc true", shell=True
         )
 
         # Perform a range of checks across folders and files


### PR DESCRIPTION
This PR partially reverts #551 by using local filesystem searches when possible for speed improvement (avoiding process creation which is slow on Windows).

It essentially creates a duplicate function, `search_local_filesystem` that should have the same output as `search_central_via_connection` but does not call `rclone`. This is faster as a new process does not need to be made with `subprocess.run()`. This slowness is particularly noticeable during live-validation on the create-folders screen, it is so bad that is makes the user experience very poor. On Linux, it is less of an issue.

This solution is not at all ideal, we now have two functions doing the same thing. When all searches were done through `search_central_via_connection`, it meant that all local filesystem tests implicitly tested the behaviour ssh, aws, google drive tests. There are many more local filesystem transfer tests because these are much quicker to run. Therefore, this duplication is reducing test coverage. The solution is just to add a few more explicit tests to ssh, aws and google drive #577 and in this PR, perform a set of tests to check that the outputs of these functions are the same under many conditions.

I thought another potential solution in #551 is to create a process on `datashuttle` with POpen and hold it for the lifetime of the class, and call it when needed. However, as far as I can tell this is not how POpen works. It will also be a high burden and possible source of bugs to manage the lifetime of the process on the datashuttle class. So I think this is a better solution, although not ideal.