### PR TITLE
Add exit button

### DIFF
--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -12,8 +12,7 @@ import pyperclip
 import showinfm
 import yaml
 from textual.app import App, ComposeResult
-from textual.binding import Binding
-from textual.containers import Container, Horizontal
+from textual.containers import Container
 from textual.widgets import Button, Label
 
 from datashuttle.configs import canonical_folders
@@ -41,10 +40,6 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
     CSS_PATH = list(Path(tui_path / "css").glob("*.tcss"))
     ENABLE_COMMAND_PALETTE = False
 
-    BINDINGS = [
-        Binding("ctrl+c", "app.quit", "Exit app", priority=True),
-    ]
-
     def compose(self) -> ComposeResult:
         """Set up widgets for the main window."""
         yield Container(
@@ -60,10 +55,7 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
             ),
             Button("Settings", id="mainwindow_settings_button"),
             Button("Get Help", id="mainwindow_get_help_button"),
-            Horizontal(
-                Button("Exit", id="mainwindow_exit_button"),
-                id="mainwindow_horizontal",
-            ),
+            Button("Exit", id="mainwindow_exit_button"),
             id="mainwindow_contents_container",
         )
 
@@ -113,6 +105,9 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
 
         elif event.button.id == "mainwindow_validate_from_project_path":
             self.push_screen(validate_at_path.ValidateScreen(self))
+
+        elif event.button.id == "mainwindow_exit_button":
+            self.app.exit()
 
     def load_project_page(self, interface: Interface) -> None:
         """Load the project manager page.

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -12,6 +12,7 @@ import pyperclip
 import showinfm
 import yaml
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Container
 from textual.widgets import Button, Label
 
@@ -39,6 +40,20 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
     tui_path = Path(__file__).parent
     CSS_PATH = list(Path(tui_path / "css").glob("*.tcss"))
     ENABLE_COMMAND_PALETTE = False
+
+    BINDINGS = [
+        Binding("escape", "app.quit", "Exit app", priority=True),
+        Binding("ctrl+c", "show_copy_help", "Show copy help", priority=True),
+    ]
+
+    def action_show_copy_help(self) -> None:
+        """Display a notification (for CTRL+C)."""
+        self.notify(
+            "Use CTRL+Q to copy from Inputs and DirectoryTrees.\n"
+            "Use ESC or the 'Exit' button to quit the application.\n"
+            "CTRL+Q can be used to copy after highlighting text with the mouse while pressing 'shift'.",
+            timeout=6,
+        )
 
     def compose(self) -> ComposeResult:
         """Set up widgets for the main window."""

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -42,9 +42,11 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
     ENABLE_COMMAND_PALETTE = False
 
     BINDINGS = [
-        Binding("escape", "app.quit", "Exit app", priority=True),
+        Binding("escape", "exit_app", "Exit app", priority=True),
         Binding("ctrl+c", "show_copy_help", "Show copy help", priority=True),
     ]
+
+    exit_accept_or_decline_popup = False
 
     def compose(self) -> ComposeResult:
         """Set up widgets for the main window."""
@@ -123,6 +125,27 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
             "CTRL+C can be used to copy after highlighting text with the mouse while pressing 'shift'.",
             timeout=6,
         )
+
+    def action_exit_app(self) -> None:
+        """Show pop up to confirm closing the application."""
+        if self.exit_accept_or_decline_popup:
+            return
+
+        def exit_function(exit: bool) -> None:
+            self.exit_accept_or_decline_popup = False
+            if exit:
+                self.exit()
+
+        self.exit_accept_or_decline_popup = (
+            modal_dialogs.AcceptOrDeclineMessageBox(
+                self,
+                "Press 'Exit' to confirm closing datashuttle.",
+                "Exit",
+                "Cancel",
+            )
+        )
+
+        self.push_screen(self.exit_accept_or_decline_popup, exit_function)
 
     def load_project_page(self, interface: Interface) -> None:
         """Load the project manager page.

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -120,7 +120,7 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
         self.notify(
             "Use CTRL+Q to copy from Inputs and DirectoryTrees.\n"
             "Use ESC or the 'Exit' button to quit the application.\n"
-            "CTRL+Q can be used to copy after highlighting text with the mouse while pressing 'shift'.",
+            "CTRL+C can be used to copy after highlighting text with the mouse while pressing 'shift'.",
             timeout=6,
         )
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -13,11 +13,8 @@ import showinfm
 import yaml
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Container
-from textual.widgets import (
-    Button,
-    Label,
-)
+from textual.containers import Container, Horizontal
+from textual.widgets import Button, Label
 
 from datashuttle.configs import canonical_folders
 from datashuttle.tui.screens import (
@@ -63,6 +60,10 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
             ),
             Button("Settings", id="mainwindow_settings_button"),
             Button("Get Help", id="mainwindow_get_help_button"),
+            Horizontal(
+                Button("Exit", id="mainwindow_exit_button"),
+                id="mainwindow_horizontal",
+            ),
             id="mainwindow_contents_container",
         )
 

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -46,15 +46,6 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
         Binding("ctrl+c", "show_copy_help", "Show copy help", priority=True),
     ]
 
-    def action_show_copy_help(self) -> None:
-        """Display a notification (for CTRL+C)."""
-        self.notify(
-            "Use CTRL+Q to copy from Inputs and DirectoryTrees.\n"
-            "Use ESC or the 'Exit' button to quit the application.\n"
-            "CTRL+Q can be used to copy after highlighting text with the mouse while pressing 'shift'.",
-            timeout=6,
-        )
-
     def compose(self) -> ComposeResult:
         """Set up widgets for the main window."""
         yield Container(
@@ -123,6 +114,15 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
 
         elif event.button.id == "mainwindow_exit_button":
             self.app.exit()
+
+    def action_show_copy_help(self) -> None:
+        """Display a notification (for CTRL+C)."""
+        self.notify(
+            "Use CTRL+Q to copy from Inputs and DirectoryTrees.\n"
+            "Use ESC or the 'Exit' button to quit the application.\n"
+            "CTRL+Q can be used to copy after highlighting text with the mouse while pressing 'shift'.",
+            timeout=6,
+        )
 
     def load_project_page(self, interface: Interface) -> None:
         """Load the project manager page.

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -20,10 +20,26 @@
     margin: 2 0 2 0;
 }
 
+#mainwindow_contents_container > Button#mainwindow_exit_button {
+    height: auto;
+    margin: 0 0 0 0;
+    width: 50%;
+    align: center middle;
+    content-align: center middle;
+}
+
+#mainwindow_horizontal {
+    width: auto;
+    align: center middle;
+    content-align: center middle;
+    margin: 0 0 1 0;
+}
+
 /* Project Select ------------------------------------------------------------------- */
 
 #project_select_top_container {
-    align: center top;
+    width: 50%;
+    align: center middle;
     margin: 3 2 0 0;
     content-align: center middle;
     height: auto;
@@ -31,8 +47,6 @@
 
 #project_select_top_container > Button {
     width: 50%;
-    align: center middle;
-    content-align: left middle;
     margin: 0 0 1 0;
 }
 

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -521,3 +521,39 @@ RenameFileOrFolderScreen {
 #rename_screen_cancel_button {
     align: center middle;
  }
+
+/* Accept or Decline Modal Popup ------------------------------------------------------------ */
+
+AcceptOrDeclineMessageBox {
+    align: center middle;
+    content-align: center middle;
+}
+
+#accept_or_decline_messagebox_container {
+    align: center middle;
+    content-align: center middle;
+    height: 12;
+    width: 65;
+    border: tall $panel-lighten-1;
+    background: $primary-background;
+ }
+
+ AcceptOrDeclineMessageBox:light > #accept_or_decline_messagebox_container {
+    border: tall $panel-darken-3;
+    background: $boost;
+ }
+
+#accept_or_decline_messagebox_label {
+    align: center middle;
+    text-align: center;
+    width: 100%;
+    margin: 0 0 1 2;
+ }
+
+#accept_or_decline_messagebox_accept_button {
+    align: center middle;
+}
+
+#accept_or_decline_messagebox_decline_button {
+    align: center middle;
+ }

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -4,12 +4,14 @@
 #mainwindow_contents_container {
     align: center top;
     padding: 1 0 0 0;
+    width: 100%
 }
+
 #mainwindow_contents_container > Button {
     width: 50%;
-    content-align: center middle;
-    margin: 0 0 1 0;
+    margin: 1 0 0 0;
 }
+
 #mainwindow_banner_label {
     border: hkey $primary;
     content-align: center middle;
@@ -18,21 +20,6 @@
     width: 50%;
     height: 5;
     margin: 2 0 2 0;
-}
-
-#mainwindow_contents_container > Button#mainwindow_exit_button {
-    height: auto;
-    margin: 0 0 0 0;
-    width: 50%;
-    align: center middle;
-    content-align: center middle;
-}
-
-#mainwindow_horizontal {
-    width: auto;
-    align: center middle;
-    content-align: center middle;
-    margin: 0 0 1 0;
 }
 
 /* Project Select ------------------------------------------------------------------- */

--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -4,14 +4,12 @@
 #mainwindow_contents_container {
     align: center top;
     padding: 1 0 0 0;
-    width: 100%
 }
-
 #mainwindow_contents_container > Button {
     width: 50%;
-    margin: 1 0 0 0;
+    content-align: center middle;
+    margin: 0 0 1 0;
 }
-
 #mainwindow_banner_label {
     border: hkey $primary;
     content-align: center middle;
@@ -25,8 +23,7 @@
 /* Project Select ------------------------------------------------------------------- */
 
 #project_select_top_container {
-    width: 50%;
-    align: center middle;
+    align: center top;
     margin: 3 2 0 0;
     content-align: center middle;
     height: auto;
@@ -34,6 +31,8 @@
 
 #project_select_top_container > Button {
     width: 50%;
+    align: center middle;
+    content-align: left middle;
     margin: 0 0 1 0;
 }
 

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -98,6 +98,67 @@ class MessageBox(ModalScreen):
         self.dismiss(True)
 
 
+class AcceptOrDeclineMessageBox(ModalScreen):
+    """Display generic pop up window to ask user to accept or decline."""
+
+    def __init__(
+        self,
+        mainwindow: TuiApp,
+        message: str,
+        accept_button_label: str,
+        decline_button_label: str,
+    ) -> None:
+        """Initialise the accept or decline pop up window.
+
+        Parameters
+        ----------
+        mainwindow
+            Textual main app screen.
+
+        message
+            Message to show above the accept / decline button.
+
+        accept_button_label
+            Label to display on the 'accept' button.
+
+        decline_button_label
+                    Label to display on the 'decline' button.
+
+        """
+        super(AcceptOrDeclineMessageBox, self).__init__()
+
+        self.mainwindow = mainwindow
+        self.message = message
+        self.accept_button_label = accept_button_label
+        self.decline_button_label = decline_button_label
+
+    def compose(self) -> ComposeResult:
+        """Add widgets to the RenameFileOrFolderScreen."""
+        yield Container(
+            Label(self.message, id="accept_or_decline_messagebox_label"),
+            Horizontal(
+                Button(
+                    self.accept_button_label,
+                    id="accept_or_decline_messagebox_accept_button",
+                ),
+                Button(
+                    self.decline_button_label,
+                    id="accept_or_decline_messagebox_decline_button",
+                ),
+                id="rename_screen_horizontal",
+            ),
+            id="accept_or_decline_messagebox_container",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button pressed on the RenameFileOrFolderScreen."""
+        if event.button.id == "accept_or_decline_messagebox_accept_button":
+            self.dismiss(True)
+
+        elif event.button.id == "accept_or_decline_messagebox_decline_button":
+            self.dismiss(False)
+
+
 class ConfirmAndAwaitTransferPopup(ModalScreen):
     """A popup screen for confirming, awaiting and finishing a Transfer.
 

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -155,8 +155,6 @@ class ValidateContent(Container):
                 "#validate_strict_mode_checkbox"
             ).value
 
-            #            assert False, f"strict mode: {strict_mode}"
-
             if self.interface:
                 if self.interface.project.is_local_project():
                     include_central = False

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -325,11 +325,14 @@ class CreateFoldersTab(TreeAndInputTab):
             If `True`, search central project as well to generate the suggestion.
 
         """
-        assert self.interface.project.cfg["connection_method"] in [
-            None,
-            "local_filesystem",
-            "ssh",
-        ]
+        try:
+            assert self.interface.project.cfg["connection_method"] in [
+                None,
+                "local_filesystem",
+                "ssh",
+            ]
+        except:
+            assert False, f"{self.interface.project.cfg['connection_method']}"
 
         if (
             include_central

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -325,14 +325,11 @@ class CreateFoldersTab(TreeAndInputTab):
             If `True`, search central project as well to generate the suggestion.
 
         """
-        try:
-            assert self.interface.project.cfg["connection_method"] in [
-                None,
-                "local_filesystem",
-                "ssh",
-            ]
-        except:
-            assert False, f"{self.interface.project.cfg['connection_method']}"
+        assert self.interface.project.cfg["connection_method"] in [
+            None,
+            "local_filesystem",
+            "ssh",
+        ]
 
         if (
             include_central

--- a/docs/source/pages/user_guides/choose-a-terminal.md
+++ b/docs/source/pages/user_guides/choose-a-terminal.md
@@ -82,4 +82,4 @@ with rendering errors.
 Once you've chosen a terminal, get started with
 ``datashuttle`` with our [Getting Started Tutorial](getting-started-walkthrough).
 
-To quit ``datashuttle`` in the terminal, press `CTRL+C`.
+To quit ``datashuttle`` in the terminal, press `CTRL+Q`.

--- a/tests/tests_tui/test_tui_directorytree.py
+++ b/tests/tests_tui/test_tui_directorytree.py
@@ -134,7 +134,7 @@ class TestTuiCreateDirectoryTree(TuiBase):
                 pilot,
                 "#create_folders_directorytree",
                 hover_line=2,
-                press_string="ctrl+c",
+                press_string="ctrl+q",
             )
 
             pasted_path = pyperclip.paste()
@@ -178,7 +178,7 @@ class TestTuiCreateDirectoryTree(TuiBase):
                 pilot,
                 "#create_folders_directorytree",
                 hover_line=2,
-                press_string="ctrl+c",
+                press_string="ctrl+q",
             )
 
             # Check that the error message is displayed.

--- a/tests/tests_tui/test_tui_directorytree.py
+++ b/tests/tests_tui/test_tui_directorytree.py
@@ -114,7 +114,7 @@ class TestTuiCreateDirectoryTree(TuiBase):
     async def test_create_folders_directorytree_clipboard(
         self, setup_project_paths
     ):
-        """Check that pressing CTRL+Q on the directorytree copies the
+        """Check that pressing CTRL+C on the directorytree copies the
         hovered folder to the clipboard (using pyperclip).
         """
         tmp_config_path, tmp_path, project_name = setup_project_paths.values()
@@ -134,7 +134,7 @@ class TestTuiCreateDirectoryTree(TuiBase):
                 pilot,
                 "#create_folders_directorytree",
                 hover_line=2,
-                press_string="ctrl+q",
+                press_string="ctrl+c",
             )
 
             pasted_path = pyperclip.paste()
@@ -178,7 +178,7 @@ class TestTuiCreateDirectoryTree(TuiBase):
                 pilot,
                 "#create_folders_directorytree",
                 hover_line=2,
-                press_string="ctrl+q",
+                press_string="ctrl+c",
             )
 
             # Check that the error message is displayed.


### PR DESCRIPTION
This PR closes #545 by adding an 'Exit' button to the main window. I tried to use `CTRL+C` for copy directly, but forgot that in some cases this still quits the application on Windows. I think under certain conditions the `textual` event loop is in a strange / awaiting state and the CTRL+C is not caught, defaulting to windows behavior which is to exit the application (also encountered in #458).

As such, `CTRL+Q` is maintained for copy. However now, `CTRL+C` does not exit the application, but causes a popup with the following information:

```
      self.notify(
          "Use CTRL+Q to copy from Inputs and DirectoryTrees.\n"
          "Use ESC or the 'Exit' button to quit the application.\n"
          "CTRL+C can be used to copy after highlighting text with the mouse while pressing 'shift'.",
          timeout=6,
      )
```

This is because I think it might be annoying if you were trying to copy for the application to exit. It also lets the user know about a cool trick that if you select while holding shift, you can copy any text (found by @cs7-shrey). 
