### PR TITLE
Skip AWS and GDRIVE tests when environment variables not set.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -710,3 +710,27 @@ def monkeypatch_get_datashuttle_path(tmp_config_path, _monkeypatch):
         "datashuttle.configs.canonical_folders.get_datashuttle_path",
         mock_get_datashuttle_path,
     )
+
+
+def has_gdrive_environment_variables():
+    for key in [
+        "GDRIVE_CLIENT_ID"
+        "GDRIVE_ROOT_FOLDER_ID"
+        "GDRIVE_CONFIG_TOKEN"
+        "GDRIVE_CLIENT_SECRET"
+    ]:
+        if key not in os.environ:
+            return False
+    return True
+
+
+def has_aws_environment_variables():
+    for key in [
+        "AWS_BUCKET_NAME",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_REGION",
+        "AWS_SECRET_ACCESS_KEY",
+    ]:
+        if key not in os.environ:
+            return False
+    return True

--- a/tests/tests_transfers/aws/test_aws_transfer.py
+++ b/tests/tests_transfers/aws/test_aws_transfer.py
@@ -2,10 +2,15 @@ import pytest
 
 from datashuttle.utils import rclone
 
+from ... import test_utils
 from ..base_transfer import BaseTransfer
 from . import aws_test_utils
 
 
+@pytest.mark.skipif(
+    not test_utils.has_aws_environment_variables(),
+    reason="AWS set up environment variables must be set.",
+)
 class TestAwsTransfer(BaseTransfer):
     @pytest.fixture(
         scope="class",

--- a/tests/tests_transfers/gdrive/test_gdrive_transfer.py
+++ b/tests/tests_transfers/gdrive/test_gdrive_transfer.py
@@ -2,10 +2,15 @@ import pytest
 
 from datashuttle.utils import rclone
 
+from ... import test_utils
 from ..base_transfer import BaseTransfer
 from . import gdrive_test_utils
 
 
+@pytest.mark.skipif(
+    not test_utils.has_gdrive_environment_variables(),
+    reason="Google Drive set up environment variables must be set.",
+)
 class TestGdriveTransfer(BaseTransfer):
     @pytest.fixture(
         scope="class",


### PR DESCRIPTION
Currently AWS or GDrive tests fail when run locally if environment variables required for set up are not set. Now, these tests are just skipped.