### PR TITLE
Introduce artifact ci and add developer docs

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -21,9 +21,6 @@ jobs:
     steps:
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
         with:
-          python-version: 3.12
-          use-make: false
-          fetch-tags: false
           use-artifactci: lazy
 
   deploy_sphinx_docs:

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -19,7 +19,12 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+        with:
+          python-version: 3.12
+          use-make: false
+          fetch-tags: false
+          use-artifactci: lazy
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/docs/source/pages/community/contributing.md
+++ b/docs/source/pages/community/contributing.md
@@ -166,3 +166,13 @@ To edit a page, please:
 
 If you aren't sure where the changes should be made, please
 [get in touch!](https://neuroinformatics.zulipchat.com/#narrow/stream/405999-DataShuttle)
+
+
+### Previewing the documentation in continuous integration
+
+We use [artifact.ci](https://artifact.ci/) to preview the documentation that is built as part of our GitHub Actions workflow. To do so:
+1. Go to the "Checks" tab in the GitHub PR.
+2. Click on the "Docs" section on the left.
+3. If the "Build Sphinx Docs" action is successful, a summary section will appear under the block diagram with a link to preview the built documentation.
+4. Click on the link and wait for the files to be uploaded (it may take a while the first time). You may be asked to sign in to GitHub.
+5. Once the upload is complete, look for `docs/build/html/index.html` under the "Detected Entrypoints" section.


### PR DESCRIPTION
This PR allows previewing the documentation from a PR, following [the same in movement](https://github.com/neuroinformatics-unit/movement/pull/631/files).