### PR TITLE
Rename `quick_validate_project` to `validate_project_from_path`

### DIFF
--- a/datashuttle/__init__.py
+++ b/datashuttle/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from datashuttle.datashuttle_class import DataShuttle
-from datashuttle.datashuttle_functions import quick_validate_project
+from datashuttle.datashuttle_functions import validate_project_from_path
 
 
 try:

--- a/datashuttle/datashuttle_functions.py
+++ b/datashuttle/datashuttle_functions.py
@@ -22,7 +22,7 @@ from datashuttle.utils import (
 )
 
 
-def quick_validate_project(
+def validate_project_from_path(
     project_path: str | Path,
     top_level_folder: Optional[TopLevelFolder] = "rawdata",
     display_mode: DisplayMode = "warn",

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -58,7 +58,7 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
             ),
             Button("Make New Project", id="mainwindow_new_project_button"),
             Button(
-                "Validate Project at Path",
+                "Validate Project From Path",
                 id="mainwindow_validate_from_project_path",
             ),
             Button("Settings", id="mainwindow_settings_button"),

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -20,7 +20,7 @@ from textual.widgets import (
     Select,
 )
 
-from datashuttle.datashuttle_functions import quick_validate_project
+from datashuttle.datashuttle_functions import validate_project_from_path
 from datashuttle.tui.custom_widgets import ClickableInput
 from datashuttle.tui.screens import modal_dialogs, validate_at_path
 from datashuttle.tui.tooltips import get_tooltip
@@ -192,7 +192,7 @@ class ValidateContent(Container):
                     )
                     return
 
-                output = quick_validate_project(
+                output = validate_project_from_path(
                     path_,
                     top_level_folder=top_level_folder,
                     strict_mode=strict_mode,

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -29,7 +29,7 @@ from datashuttle.tui.tooltips import get_tooltip
 class ValidateContent(Container):
     """A container containing widgets for project validation.
 
-    This is shared between the Validate Project from Path
+    This is shared between the Validate Project From Path
     and validation tab on the project manager. It takes a similar
     approach to ConfigsContent.
 

--- a/docs/source/pages/api_index.rst
+++ b/docs/source/pages/api_index.rst
@@ -7,4 +7,4 @@ API Reference
 
 .. autoclass:: DataShuttle
 
-.. autofunction:: quick_validate_project
+.. autofunction:: validate_project_from_path

--- a/docs/source/pages/get_started/quick-validate-project.md
+++ b/docs/source/pages/get_started/quick-validate-project.md
@@ -1,5 +1,5 @@
 :orphan:
-(quick-validate-projects)=
+(validate-project-from-path)=
 
 # Validate a project from a filepath
 
@@ -54,12 +54,12 @@ raise a validation issue.
 :sync: python
 
 To validate a project using the Python API, pass the path
-to the project to validate to ``quick_validate_project``:
+to the project to validate to ``validate_project_from_path``:
 
 ```python
-from datashuttle import quick_validate_project
+from datashuttle import validate_project_from_path
 
-quick_validate_project(
+validate_project_from_path(
     project_path="/mydrive/path/to/project/project_name",
     display_mode="error",
 )
@@ -69,7 +69,7 @@ quick_validate_project(
 In this case, `display_mode=error` will result in an error on the first encountered validation issue.
 Otherwise, `"warn"` will show a python warning for all detected issues, while `"print"` will print directly to the console.
 
-See the [](datashuttle.quick_validate_project) API documentation
+See the [](validate_project_from_path()) API documentation
 for full details of parameters, including the important argument ``strict_mode``
 that controls how validation is performed.
 

--- a/docs/source/pages/get_started/quick-validate-project.md
+++ b/docs/source/pages/get_started/quick-validate-project.md
@@ -14,7 +14,7 @@ to any problematic folders.
 :sync: gui
 
 To quickly validate a project, start the terminal user interface with
-``datashuttle launch`` and click ``Validate Project at Path``.
+``datashuttle launch`` and click ``Validate Project From Path``.
 
 The screen below will show. To validate an existing project,
 enter the full filepath to the project folder in the top input box

--- a/docs/source/pages/user_guides/validate.md
+++ b/docs/source/pages/user_guides/validate.md
@@ -6,7 +6,7 @@
 [NeuroBlueprint specification](https://neuroblueprint.neuroinformatics.dev/latest/specification.html).
 This will find and display a list of all formatting errors in the project.
 
-To quickly validate an existing project with only the project path, see [quick-validate-projects](quick-validate-projects).
+To quickly validate an existing project with only the project path, see how to [validate a project from a path](validate-project-from-path).
 
 Below we will cover how to validate a datashuttle-managed project
 (which will additionally [log](how-to-read-the-logs) the validation results).

--- a/tests/tests_integration/test_validation.py
+++ b/tests/tests_integration/test_validation.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 
-from datashuttle import quick_validate_project
+from datashuttle import validate_project_from_path
 from datashuttle.utils import formatting, validation
 from datashuttle.utils.custom_exceptions import NeuroBlueprintError
 
@@ -794,7 +794,7 @@ class TestValidation(BaseTest):
         os.makedirs(project.cfg["local_path"] / "derivatives" / "sub-02")
 
         with pytest.warns(UserWarning) as w:
-            quick_validate_project(
+            validate_project_from_path(
                 project.get_local_path(),
                 display_mode="warn",
                 top_level_folder=None,
@@ -812,7 +812,7 @@ class TestValidation(BaseTest):
             datashuttle.datashuttle_functions.validation, "validate_project"
         )
 
-        quick_validate_project(
+        validate_project_from_path(
             project.get_local_path(),
             display_mode="print",
             top_level_folder="derivatives",
@@ -829,7 +829,7 @@ class TestValidation(BaseTest):
         bad project path input.
         """
         with pytest.raises(FileNotFoundError) as e:
-            quick_validate_project(
+            validate_project_from_path(
                 project.get_local_path() / "does not exist",
                 display_mode="error",
             )

--- a/tests/tests_tui/test_tui_validate.py
+++ b/tests/tests_tui/test_tui_validate.py
@@ -160,7 +160,7 @@ class TestTuiValidate(TuiBase):
 
     @pytest.mark.asyncio
     async def test_validate_at_path_kwargs(self, setup_project_paths, mocker):
-        """Test kwargs are properly passed through from the TUI to `quick_validate_project`
+        """Test kwargs are properly passed through from the TUI to `validate_project_from_path`
         with mocker. Note that the 'Select' button / directorytree is not tested here,
         as the screen is tested elsewhere and it's non-critical feature here.
         """
@@ -179,7 +179,7 @@ class TestTuiValidate(TuiBase):
             # Spy the function and click 'validate' button
             spy_validate = mocker.spy(
                 datashuttle.tui.shared.validate_content,
-                "quick_validate_project",
+                "validate_project_from_path",
             )
 
             warnings.filterwarnings("ignore")


### PR DESCRIPTION
closes #579, this PR renames `quick_validate_project` function to `validate_project_from_path`. This is more descriptive and matches the TUI. It is a fairly straightforward find-and-replace. 

No tests need to be written. There is one documentation image that needs updating, but it also needs updating for other reasons and is handled in #591 