### PR TITLE
Improve error message on bad datatype combination.

### DIFF
--- a/datashuttle/utils/data_transfer.py
+++ b/datashuttle/utils/data_transfer.py
@@ -397,8 +397,8 @@ class TransferData:
             [name in ["all", "all_datatype"] for name in self.datatype]
         ):
             utils.log_and_raise_error(
-                "'datatype' must only include 'all' "
-                "or 'all_datatype' if these options are used.",
+                "If either `all` or `all_datatype` is selected for datatype, "
+                "it must be the only selected option.",
                 ValueError,
             )
 


### PR DESCRIPTION
addresses #537 (but does not fully close) by improving the error message. #537 highlights that the `all` and single datatypes can be selected in the custom transfer screen at the same time. The resulting error message is confusing.

@alessandrofelder do you think this (error message below) is clearer? I tried to change the checkboxes themselves such that only one of these options at a time can be selected. It's possible, but becomes a little complex in terms of the code and making clear to the user why boxes are automatically becoming checked / unchecked.I think an error alone is workable 🤔, if the message is very clear.

<img width="1163" height="787" alt="image" src="https://github.com/user-attachments/assets/f06ad3a9-eeec-4972-b136-34069367a569" />
