### PR TITLE
Reduce CI usage.

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
+  pull_request: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Cron runs on the 1st and 15th of every month.
     # This will only run on main by default.


### PR DESCRIPTION
This PR makes some small changes to reduce the CI usage, which has become heavy. I added `fail-fast` but the default is for this to be `true` anyway, so it does nothing but at least makes it explicit. 

The other changes are to:
- only run on `macos-latest` in the PR
- run the scheduled tests (which include all OS and python version) to run every 2 weeks after than weekly. 
- do not run tests on draft PRs

However, the majority of CI reduction will be made by reducing how long the tests take to run, #607 