### PR TITLE
Add workflow to run GDrive and AWS tests on forks.

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+
   schedule:
     # Cron runs on the 1st and 15th of every month.
     # This will only run on main by default.
@@ -20,6 +20,7 @@ jobs:
       - uses: neuroinformatics-unit/actions/lint@v2
 
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: [linting]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
@@ -74,22 +75,29 @@ jobs:
           sudo service mysql stop  # free up port 3306 for ssh tests
           pytest tests/tests_transfers/ssh
 
-      - name: Test Google Drive
+      - name: Test Google Drive and AWS
+        # AWS and GDrive tests require secrets, which are empty string by default on forked repositories.
+        # The below flag ensures that these tests do not run on forked repositories. To run, the
+        # ok-to-run-gdrive-aws label must be manually added, after checking no malicious code
+        # that extracts the secrets is found on the PR.
+        if: >
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          contains(
+            join(fromJSON('["' + join(github.event.pull_request.labels.*.name, '","') + '"]')),
+            'ok-to-run-gdrive-aws'
+          )
         env:
           GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
           GDRIVE_CLIENT_SECRET: ${{ secrets.GDRIVE_CLIENT_SECRET }}
           GDRIVE_ROOT_FOLDER_ID: ${{ secrets.GDRIVE_ROOT_FOLDER_ID }}
           GDRIVE_CONFIG_TOKEN: ${{ secrets.GDRIVE_CONFIG_TOKEN }}
-        run: |
-          pytest tests/tests_transfers/gdrive
-
-      - name: Test AWS
-        env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
+          pytest tests/tests_transfers/gdrive
           pytest tests/tests_transfers/aws
 
       - name: All Other Tests

--- a/.github/workflows/run_secure_tests_on_forked_pr.yml
+++ b/.github/workflows/run_secure_tests_on_forked_pr.yml
@@ -1,0 +1,54 @@
+# Secure Tests Workflow
+#
+# Runs the Google Drive and AWS transfer tests that need secrets.
+# GitHub doesn’t pass secrets to pull requests from forks, so this
+# workflow exists to let maintainers explicitly approve those runs.
+
+name: Secure tests (label gated)
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  run-secure-tests:
+    if: github.event.label.name == 'ok-to-run-gdrive-aws'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.12
+          channels: conda-forge
+          activate-environment: datashuttle-test
+
+      - name: Install deps
+        run: |
+          conda activate datashuttle-test
+          conda install -c conda-forge -y rclone
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Google Drive tests
+        env:
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
+          GDRIVE_CLIENT_SECRET: ${{ secrets.GDRIVE_CLIENT_SECRET }}
+          GDRIVE_ROOT_FOLDER_ID: ${{ secrets.GDRIVE_ROOT_FOLDER_ID }}
+          GDRIVE_CONFIG_TOKEN: ${{ secrets.GDRIVE_CONFIG_TOKEN }}
+        run: pytest tests/tests_transfers/gdrive
+
+      - name: AWS tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+        run: pytest tests/tests_transfers/aws

--- a/tests/tests_transfers/aws/aws_test_utils.py
+++ b/tests/tests_transfers/aws/aws_test_utils.py
@@ -53,4 +53,8 @@ def has_aws_environment_variables():
     ]:
         if key not in os.environ:
             return False
+
+        if os.environ[key].strip() == "":
+            return False
+
     return True

--- a/tests/tests_transfers/gdrive/gdrive_test_utils.py
+++ b/tests/tests_transfers/gdrive/gdrive_test_utils.py
@@ -67,4 +67,8 @@ def has_gdrive_environment_variables():
     ]:
         if key not in os.environ:
             return False
+
+        if os.environ[key].strip() == "":
+            return False
+
     return True


### PR DESCRIPTION
This PR prototypes a method of allowing PRs from forked repositories to run the tests for AWS and GDrive which require GitHub secrets. CI running on forked repositories does not have access to secrets, which return as a empty string. This PR uses splits the AWS and Google Drive tests such that they can be run using the `pull_request_target` directive which runs code from a PR with base environment privileges, which has access to secrets.

 `pull_request_target` is controversial because without some guardrails, this can run code with base privileges from an unchcked PR. The solution here is to manually review, and then add a label that confirms the code is safe. Once the label is set, the workflow will run the PR code with base permissions. This seems a fairly robust solution and is quite common.

However, after reading [this article](https://www.sysdig.com/blog/insecure-github-actions-found-in-mitre-splunk-and-other-open-source-repositories) I think it is probably safest not to mess with `pull_request_target`. The article is generally interesting, and includes:

```
If you still choose to use pull_request_target after reading this article, ensure you fully understand the associated risks and implement strong safety checks. One mitigation to consider is configuring the workflow to run only when a specific label is assigned to the pull request, effectively requiring manual vetting by maintainers with write access to the repository. Since external contributors can’t assign labels, this ensures pull requests trigger the workflow after a manual review.

However, this method is not foolproof. It is vulnerable to a race condition, where an attacker could push new commits to the pull request after the label has been added but before the workflow starts. For this reason, label-based gating should be treated as a temporary workaround, rather than a permanent solution. Implementing one of the stronger mitigations mentioned earlier is highly recommended.
```

But the only other recommendations they make is to use `read` only permission, and:

```
This brings us to our first and most important recommendation: Don’t use it unless you fully understand how to secure it properly. If you do need to use this trigger, ensure the workflow is thoroughly hardened to prevent potential security vulnerabilities, such as those identified in this blog.
```

TBH I don't think the benefits of this outweigh the potential costs and maintenance headache. At present, PRs from forked repositories will not run full AWS or Google Drive tests. These will run when the PR is merged into main branch (and on the weekly tests). This will be sufficient to catch any issues, the main tests should always complete before version release. It's not ideal but lesser of two evils.
