### PR TITLE
Set DATASHUTTLE_GDRIVE_ROOT_FOLDER_ID in workflow

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -24,6 +24,8 @@ jobs:
     needs: [linting]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    env:
+      DATASHUTTLE_GDRIVE_ROOT_FOLDER_ID: test-root-folder-id
 
     defaults:
       run:


### PR DESCRIPTION
## Description

### What is this PR?
- ✅ Bug fix (CI config)

### Why is this PR needed?
The GitHub Actions workflow fails because `DATASHUTTLE_GDRIVE_ROOT_FOLDER_ID` is missing during CI.  
This PR adds a placeholder value so CI can run successfully.

### What does this PR do?
Adds a default placeholder value (`test-root-folder-id`) for `DATASHUTTLE_GDRIVE_ROOT_FOLDER_ID` in the test workflow.  
This is **test-only** and does **not** affect real Google Drive configuration.

## References
Fixes CI failure related to missing Google Drive environment variable.

## How has this PR been tested?
Ensured CI pipeline runs successfully with the placeholder value.

## Is this a breaking change?
- ❌ No

## Does this PR require a documentation update?
- ❌ No

## Checklist
- ✅ CI passes after change  
- ✅ No new tests required (config-only change)  
- ✅ No docs affected  
- ✅ Code formatting unchanged  
