### PR TITLE
Handle empty string case.

### DIFF
--- a/datashuttle/configs/load_configs.py
+++ b/datashuttle/configs/load_configs.py
@@ -89,7 +89,13 @@ def convert_str_and_pathlib_paths(
     for path_key in canonical_configs.keys_str_on_file_but_path_in_class():
         value = config_dict[path_key]
 
-        if value:
+        if value is not None:
+            if value == "":
+                utils.log_and_raise_error(
+                    f"{path_key} cannot be an empty string.",
+                    ValueError,
+                )
+
             if direction == "str_to_path":
                 config_dict[path_key] = Path(value)
 


### PR DESCRIPTION
This PR fixes an issue that occurs when an empty string is passed as a local or central path. The string was not being converted to path as the value can be a string, Path or `None` and only `if value` was checked, so the empty string case was being treated as `None`, then not being converted to Path, leading to an error elsewhere.