### PR TITLE
Add concurrency.

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -13,6 +13,11 @@ on:
     # This will only run on main by default.
     - cron: "0 0 1,15 * *"
 
+# Cancel in-progress runs if a new run is triggered, except for main branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel in-progress runs if a new run is triggered, except for main branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build_sphinx_docs:
     name: Build Sphinx Docs


### PR DESCRIPTION
CI from past commits on a PR are not cancelled when a new commit is pushed.