### PR TITLE
Pin fancylog.

### DIFF
--- a/.github/workflows/code_test_and_deploy.yml
+++ b/.github/workflows/code_test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
               || '["ubuntu-latest","windows-latest","macos-latest"]') }}
         python-version: ${{ fromJson(github.event_name == 'schedule'
               && '["3.9","3.10","3.11","3.12","3.13"]'
-              || '["3.10", "3.11","3.12","3.13"]') }}
+              || '["3.9","3.13"]') }}
 
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "psutil",
     # Skip the fancylog version which logs env packages
     # by default, which is slow due to subprocess calls.
-    "fancylog >= 0.7.0"
+    "fancylog >= 0.7.0; python_version >= '3.11'",
+    "fancylog < 0.5.0; python_version < '3.11'",
 ]
 
 classifiers = [


### PR DESCRIPTION
Further to #635 this PR pins fancylog to avoid the release in which package versions was logged by default, that included a subprocess call. This slowed down tests a lot. Tests are now running at their usual duration.

TODO: reverse CI changes before merging