### PR TITLE
Fix directorytree focus issue

### DIFF
--- a/datashuttle/tui/custom_widgets.py
+++ b/datashuttle/tui/custom_widgets.py
@@ -155,7 +155,6 @@ class CustomDirectoryTree(DirectoryTree):
         """
         if not self.has_focus:  # type: ignore
             self.focus()
-            self.has_focus = True
 
     def filter_paths(self, paths: Iterable[Path]) -> Iterable[Path]:
         """Filter out all hidden folders and files from CustomDirectoryTree display.


### PR DESCRIPTION
This PR fixes an issue (mentioned in #618) that required clicking on the directory tree widget (e.g. a particular folder) before it was possible to use the keyboard shortcut. Now the widget grabs focus on mouse move so clicking the widget to give it focus is not necessary.

To test this PR, going to the directory tree and pressing `CTRL+O` while holding the mouse over a folder should open it in the finder. You shouldn't need to click on the widget before doing this for it to work.