### PR TITLE
Use `Exception` instead of `BaseException`.

### DIFF
--- a/datashuttle/configs/load_configs.py
+++ b/datashuttle/configs/load_configs.py
@@ -55,7 +55,7 @@ def attempt_load_configs(
     try:
         new_cfg.load_from_file()
 
-    except BaseException:
+    except Exception:
         new_cfg = None
 
         utils.log_and_raise_error(

--- a/datashuttle/tui/app.py
+++ b/datashuttle/tui/app.py
@@ -193,7 +193,7 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
 
         try:
             showinfm.show_in_file_manager(path_.as_posix())
-        except BaseException:
+        except Exception:
             if path_.is_file():
                 # I don't see why this is not working as according to docs it
                 # should open the containing folder and select.
@@ -256,7 +256,7 @@ class TuiApp(App, inherit_bindings=False):  # type: ignore
             )
             self.screen.update_active_tab_tree()
 
-        except BaseException as e:
+        except Exception as e:
             self.show_modal_error_dialog(
                 f"Could not rename the file or folder."
                 f"Check the new name is valid, and correct "

--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -56,7 +56,7 @@ class Interface:
             self.project = project
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def setup_new_project(
@@ -82,7 +82,7 @@ class Interface:
 
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def set_configs_on_existing_project(
@@ -102,7 +102,7 @@ class Interface:
             self.project.update_config_file(**cfg_kwargs)
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def create_folders(
@@ -145,7 +145,7 @@ class Interface:
             )
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def validate_names(
@@ -192,7 +192,7 @@ class Interface:
                 "format_ses": format_ses,
             }
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def validate_project(
@@ -237,7 +237,7 @@ class Interface:
             )
             return True, results
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     # Transfer
@@ -268,7 +268,7 @@ class Interface:
 
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def transfer_top_level_only(
@@ -311,7 +311,7 @@ class Interface:
 
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def transfer_custom_selection(
@@ -362,7 +362,7 @@ class Interface:
 
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     # Name templates
@@ -394,7 +394,7 @@ class Interface:
             self.validation_templates = validation_templates
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def get_tui_settings(self) -> Dict:
@@ -467,7 +467,7 @@ class Interface:
                 include_central=include_central,
             )
             return True, next_sub
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def get_next_ses(
@@ -482,7 +482,7 @@ class Interface:
                 include_central=include_central,
             )
             return True, next_ses
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def get_ssh_hostkey(self) -> InterfaceOutput:
@@ -492,7 +492,7 @@ class Interface:
                 self.project.cfg["central_host_id"]
             )
             return True, key
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def save_hostkey_locally(self, key: paramiko.RSAKey) -> InterfaceOutput:
@@ -505,7 +505,7 @@ class Interface:
             )
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def setup_key_pair_and_rclone_config(
@@ -528,7 +528,7 @@ class Interface:
 
             return True, None
 
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     # Setup Google Drive
@@ -562,7 +562,7 @@ class Interface:
             )
 
             return True, None
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def get_rclone_message_for_gdrive_without_browser(
@@ -577,7 +577,7 @@ class Interface:
                 log=False,
             )
             return True, output
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)
 
     def terminate_gdrive_setup(self) -> None:
@@ -625,5 +625,5 @@ class Interface:
             )
             aws.raise_if_bucket_absent(self.project.cfg)
             return True, None
-        except BaseException as e:
+        except Exception as e:
             return False, str(e)

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -1210,7 +1210,7 @@ def strip_uncheckable_names(
                 prefix,
                 return_as_int=return_as_int,  # type: ignore
             )[0]
-        except BaseException:
+        except Exception:
             continue
 
         if path_:

--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -379,7 +379,7 @@ class TestLogging:
 
         configs["local_path"] = "~"
 
-        with pytest.raises(BaseException):
+        with pytest.raises(Exception):
             project.make_config_file(**configs)
 
         # Because an error was raised, the log will stay in the
@@ -446,7 +446,7 @@ class TestLogging:
         test_utils.delete_log_files(project.cfg.logging_path)
 
         # Check a validation error is logged.
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(Exception) as e:
             project.validate_project("rawdata", display_mode="error")
 
         log = test_utils.read_log_file(project.cfg.logging_path)
@@ -475,7 +475,7 @@ class TestLogging:
         project.create_folders("rawdata", "sub-001")
         test_utils.delete_log_files(project.cfg.logging_path)  #
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(Exception) as e:
             project.create_folders("rawdata", "sub-001_id-a")
 
         log = test_utils.read_log_file(project.cfg.logging_path)

--- a/tests/tests_integration/test_settings.py
+++ b/tests/tests_integration/test_settings.py
@@ -153,7 +153,7 @@ class TestPersistentSettings(BaseTest):
 
         project = test_utils.make_project(project.project_name)
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(Exception) as e:
             project.create_folders("rawdata", "sub-@@@")
 
         assert (

--- a/tests/tests_tui/test_tui_datatypes.py
+++ b/tests/tests_tui/test_tui_datatypes.py
@@ -135,7 +135,7 @@ class TestDatatypesTUI(TuiBase):
             )
 
             # Confirm also that narrow datatypes are not shown.
-            with pytest.raises(BaseException):
+            with pytest.raises(Exception):
                 pilot.app.screen.query_one(
                     f"#create_{narrow_datatype_names[0]}_checkbox"
                 )

--- a/tests/tests_tui/test_tui_settings.py
+++ b/tests/tests_tui/test_tui_settings.py
@@ -69,7 +69,7 @@ class TestTuiSettings(TuiBase):
                 is False
             )
 
-            with pytest.raises(BaseException) as e:
+            with pytest.raises(Exception) as e:
                 transfer_tab.query_one("#transfer_legend")
 
             assert "No nodes match" in str(e)

--- a/tests/tests_tui/test_tui_widgets_and_defaults.py
+++ b/tests/tests_tui/test_tui_widgets_and_defaults.py
@@ -267,7 +267,7 @@ class TestTuiWidgets(TuiBase):
                 "#configs_name_label",
                 "#configs_name_input",
             ]:
-                with pytest.raises(BaseException) as e:
+                with pytest.raises(Exception) as e:
                     configs_content.query_one(id)
                 assert "No nodes match" in str(e)
 

--- a/tests/tests_unit/test_unit.py
+++ b/tests/tests_unit/test_unit.py
@@ -168,7 +168,7 @@ class TestUnit:
             f"{prefix}-003",
         ]
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(Exception) as e:
             getters.get_max_sub_or_ses_num_and_value_length(
                 bad_num_values_names, prefix
             )

--- a/tests/tests_unit/test_validation_unit.py
+++ b/tests/tests_unit/test_validation_unit.py
@@ -146,7 +146,7 @@ class TestValidationUnit:
             [f"{prefix}-999", f"{prefix}-1000", f"{prefix}-1001"],
             [f"{prefix}-0099", f"{prefix}-100", f"{prefix}-0098"],
         ]:
-            with pytest.raises(BaseException) as e:
+            with pytest.raises(Exception) as e:
                 formatting.check_and_format_names(names, prefix)
 
             assert (
@@ -165,7 +165,7 @@ class TestValidationUnit:
             f"{prefix}-001_date-20250220",
         ]
 
-        with pytest.raises(BaseException) as e:
+        with pytest.raises(Exception) as e:
             formatting.check_and_format_names(names, prefix)
 
         assert (


### PR DESCRIPTION
`BaseException` is at the top of the exception hierarchy and catches exceptions we usually don’t want to handle, such as `SystemExit`.