### PR TITLE
docs: add developer conventions documentation

### DIFF
--- a/docs/source/developer/index.md
+++ b/docs/source/developer/index.md
@@ -1,75 +1,47 @@
-## Developer conventions (work in progress)
+## Developer conventions
 
-This page describes developer-facing conventions and testing behavior used in
-the `datashuttle` codebase.
+This page documents existing developer-facing conventions used in the
+`datashuttle` codebase. It is intended as a reference for contributors working
+on internal implementation details and established coding conventions.
 
-The conventions documented here are **soft conventions** rather than strict
-rules. They reflect existing practices in the codebase and are intended to help
-contributors understand expectations and avoid common pitfalls.
-
-This documentation is a work in progress and will evolve over time.
-
-  ---
-
-## Testing conventions
-
-### TUI tests
-
-When writing TUI tests, `await pilot.pause()` should be called at the end of the test. This ensures the interface has fully settled before the test exits and helps avoid flaky test behaviour.
+The conventions described here reflect current practices in the codebase.
+They are not strict rules, but following them helps improve consistency,
+readability, and maintainability.
 
 ---
 
-### Cloud connection tests (SSH, Google Drive, AWS)
+## Terminal user interface (TUI) conventions
 
-Tests related to cloud-based connection methods have the following behavior:
+When working on the terminal user interface (TUI), contributors should be
+mindful of interaction timing and state transitions.
 
-Tests for AWS and Google Drive do not run on forks.
-
-These tests are expected to pass only after a pull request is merged.
-
-Contributors should not attempt to fix these failures within forked CI runs.
-
-These tests rely on rclone configuration, credentials, and infrastructure that are not available in forked environments.
+TUI-related code often involves asynchronous updates and delayed rendering.
+Designing interactions defensively and allowing sufficient time for UI state
+to settle helps avoid fragile behaviour and improves test reliability.
 
 ---
 
-### Backward compatibility tests
+## Code organization
 
-The test suite includes backward compatibility checks to ensure older configuration formats and workflows continue to function correctly.
+As a general convention in the codebase, caller functions are typically defined
+above the functions they call. This pattern is not strictly enforced, but
+following it improves readability and makes control flow easier to follow.
 
-When modifying configuration-related code, contributors should be mindful of these tests and expect failures if compatibility is broken.
-
----
-
-### Code organization
-
-As a general convention in the codebase, caller functions are typically defined above the functions they call. This is not strictly enforced but following this pattern improves readability and consistency.
+Related functionality should be grouped logically, with structure driven by
+responsibility rather than file size.
 
 ---
 
-### Environment and configuration notes
-Some parts of the codebase depend on external tools and system configuration.
+## Environment and configuration considerations
 
-Certain workflows rely on external tools such as rclone.
+Some parts of the `datashuttle` codebase depend on external tools and
+system-level configuration.
 
-Some tests require credentials or infrastructure not available in all environments.
+For example:
 
-Environment-based configuration (for example, .env files) may be adopted in the future and should be documented here if introduced.
+- Certain workflows rely on external tools such as `rclone`
+- Some functionality depends on credentials or environment-specific setup
+- Behaviour may vary slightly across operating systems or environments
 
----
-
-### Scope and future work
-
-This page serves as an initial location for developer-oriented documentation.
-
-Planned or potential future additions include:
-
-A high-level architecture overview
-
-Detailed documentation of data transfer and rclone interactions
-
-TUI design patterns and conventions
-
-Expanded testing strategy documentation
-
-Contributions and improvements to this documentation are welcome.
+When introducing new dependencies or environment assumptions, these should be
+documented clearly and kept consistent with existing patterns in the codebase.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

The datashuttle codebase follows several soft developer conventions that have
been mentioned across issues and reviews but were not documented in one place.
This made it harder for new contributors to understand testing expectations and
code structure conventions.

**What does this PR do?**

This PR adds an initial developer documentation page that records existing
developer conventions, including:
- TUI testing requirements
- Behavior of cloud connection tests (SSH, Google Drive, AWS)
- Backward compatibility testing expectations
- Code organization conventions

The documentation is intentionally lightweight and marked as work in progress.

## References

- Closes #533

## How has this PR been tested?

This PR adds documentation only and does not modify code or tests.

## Is this a breaking change?

No. This PR does not change any runtime behavior or APIs.

## Does this PR require an update to the documentation?

Yes. This PR **adds** developer-facing documentation.

## Checklist:

- [x] The documentation has been updated to reflect the changes
