### PR TITLE
refactor: reduce subprocess shell=True usage with Windows fallback

### DIFF
--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -33,33 +33,33 @@ def call_rclone(command: str, pipe_std: bool = False) -> CompletedProcess:
     subprocess.CompletedProcess with `stdout` and `stderr` attributes.
 
     """
-    cmd=["rclone "]+shlex.split(command)
-    
+    cmd = ["rclone "] + shlex.split(command)
+
     try:
         if pipe_std:
-            output=subprocess.run(
+            output = subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
         else:
-            output=subprocess.run(
+            output = subprocess.run(
                 cmd,
                 shell=False,
             )
     except FileNotFoundError:
         if platform.system() == "Windows":
-            full_cmd="rclone "+ command
+            full_cmd = "rclone " + command
             if pipe_std:
-                output=subprocess.run(
+                output = subprocess.run(
                     full_cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     shell=True,
                 )
             else:
-                output=subprocess.run(
+                output = subprocess.run(
                     full_cmd,
                     shell=True,
                 )


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other (documentation reorganization)

**Why is this PR needed?**

Some subprocess calls in the rclone utilities relied on shell=True, which has security and portability implications and can behave inconsistently across platforms, especially on Windows. Issue #639 recommends reducing the use of shell=True where possible and handling platform-specific requirements explicitly.

**What does this PR do?**

- Refactors rclone-related subprocess calls to prefer argument-list execution (shell=False)

- Adds explicit Windows-only fallbacks to shell=True where PATH resolution requires a shell

- Preserves existing behavior while improving safety and clarity

- Does not introduce any user-facing or API changes

## References

- #639 

## How has this PR been tested?

- Ran pytest locally on Windows.

- Test collection and unit tests run successfully.

- Integration and TUI tests requiring rclone fail locally due to missing rclone installation and Textual environment differences on           Windows.

- No test behavior was modified; CI is expected to validate rclone-dependent tests.

## Is this a breaking change?

No.
This PR does not break any existing functionality and only refactors internal subprocess execution.

## Does this PR require an update to the documentation?

No.
There are no user-facing changes that require documentation updates.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with pre-commit (not applicable for docs-only changes)
