### PR TITLE
docs: add local testing instructions to contributing guide

### DIFF
--- a/docs/source/pages/community/contributing.md
+++ b/docs/source/pages/community/contributing.md
@@ -159,7 +159,7 @@ contact the development team if you require local testing of Google Drive or AWS
 
 ## Contributing documentation
 
-To ensure ease of use, every part of all software must be documented as
+To ensure ease of use, all parts of `datashuttle` must be documented as
 thoroughly as possible, and all new features should be fully documented. If you
 notice any areas where the documentation can be improved, please don't hesitate
 to make a contribution.


### PR DESCRIPTION
Adds repository-specific instructions for running tests locally, including
pytest usage and notes on tests that require external infrastructure.

This addresses feedback from the JOSS review.

Closes #661
