### PR TITLE
Remove macos 13 runners, add intel.

### DIFF
--- a/.github/workflows/conda_install_check.yml
+++ b/.github/workflows/conda_install_check.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-15-intel]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     defaults:


### PR DESCRIPTION
This PR removes the deprecated macOS 13 runners from the conda-install test which runs on cronjob weekly.