### PR TITLE
Fix docs builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,10 @@
-fancylog
+-e .
 linkify-it-py
 myst-parser
 nbsphinx
 numpydoc
-
-paramiko
 pydata-sphinx-theme
-PyYAML
-requests
-rich
 setuptools_scm
-simplejson
 sphinx
 sphinx-design
 sphinx_autodoc_typehints


### PR DESCRIPTION
For some reason, the docs started failing to build. Completely mystifying why this just started happening, but tidying up the docs requirements files (including adding the `-e .`) fixed it.