### PR TITLE
Skip ssh suggest next sub / ses test on CI.

### DIFF
--- a/tests/tests_transfers/ssh/test_ssh_suggest_next.py
+++ b/tests/tests_transfers/ssh/test_ssh_suggest_next.py
@@ -21,7 +21,7 @@ TEST_SSH = ssh_test_utils.docker_is_running()
 )
 @pytest.mark.skipif(
     os.getenv("CI") == "true",
-    reason="Skipped on CI as sproadically failing there.",
+    reason="Skipped on CI as sporadically failing there.",
 )
 class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     @pytest.fixture(


### PR DESCRIPTION
See #647 #679, cannot get this test to work on SSH on runners. There are similar tests for AWS/Google Drive and local filesystem, so not a huge deal that we skip on CI.