### PR TITLE
ci: run mypy on tests and add initial typing for ssh and tui tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
-exclude = [
-    "tests/"
-]
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/tests_transfers/ssh/base_ssh.py
+++ b/tests/tests_transfers/ssh/base_ssh.py
@@ -4,6 +4,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -25,7 +26,7 @@ class BaseSSHTransfer(BaseTransfer):
     @pytest.fixture(
         scope="class",
     )
-    def setup_ssh_container_fixture(self):
+    def setup_ssh_container_fixture(self) -> Iterator[None]:
         """
         Set up the Dockerfile container for SSH tests and
         delete it on teardown.
@@ -56,8 +57,8 @@ class BaseSSHTransfer(BaseTransfer):
             capture_output=True,
         )
         assert build_output.returncode == 0, (
-            f"docker build failed with: STDOUT-{build_output.stdout} "
-            f"STDERR-{build_output.stderr}"
+            f"docker build failed with: STDOUT-{build_output.stdout!r} "
+            f"STDERR-{build_output.stderr!r}"
         )
 
         run_output = subprocess.run(
@@ -67,8 +68,8 @@ class BaseSSHTransfer(BaseTransfer):
         )
 
         assert run_output.returncode == 0, (
-            f"docker run failed with: STDOUT-{run_output.stdout} "
-            f"STDERR-{run_output.stderr}"
+            f"docker run failed with: STDOUT-{run_output.stdout!r} "
+            f"STDERR-{run_output.stderr!r}"
         )
 
         yield

--- a/tests/tests_transfers/ssh/ssh_test_utils.py
+++ b/tests/tests_transfers/ssh/ssh_test_utils.py
@@ -2,13 +2,14 @@ import builtins
 import copy
 import subprocess
 import sys
+from typing import Any
 
 from datashuttle.utils import rclone, ssh, utils
 
 
 def setup_project_for_ssh(
-    project,
-):
+    project: Any,
+)-> None:
     """
     Set up the project configs to use
     SSH connection to central. The settings
@@ -44,7 +45,7 @@ def setup_ssh_connection(project, setup_ssh_key_pair=True):
     utils.get_connection_secret_from_user = lambda *args, **kwargs: "password"  # type: ignore
 
     orig_isatty = copy.deepcopy(sys.stdin.isatty)
-    sys.stdin.isatty = lambda: True
+    sys.stdin.isatty = lambda: True 
 
     # Run setup
     verified = ssh.verify_ssh_central_host_api(
@@ -68,7 +69,7 @@ def setup_ssh_connection(project, setup_ssh_key_pair=True):
     return verified
 
 
-def docker_is_running():
+def docker_is_running()-> bool:
     if not is_docker_installed():
         return False
 
@@ -76,11 +77,11 @@ def docker_is_running():
     return is_running
 
 
-def is_docker_installed():
+def is_docker_installed()-> bool:
     return check_sys_command_returns_0("docker -v")
 
 
-def check_sys_command_returns_0(command):
+def check_sys_command_returns_0(command: str)-> bool:
     return (
         subprocess.run(
             command,

--- a/tests/tests_transfers/ssh/ssh_test_utils.py
+++ b/tests/tests_transfers/ssh/ssh_test_utils.py
@@ -9,7 +9,7 @@ from datashuttle.utils import rclone, ssh, utils
 
 def setup_project_for_ssh(
     project: Any,
-)-> None:
+) -> None:
     """
     Set up the project configs to use
     SSH connection to central. The settings
@@ -45,7 +45,7 @@ def setup_ssh_connection(project, setup_ssh_key_pair=True):
     utils.get_connection_secret_from_user = lambda *args, **kwargs: "password"  # type: ignore
 
     orig_isatty = copy.deepcopy(sys.stdin.isatty)
-    sys.stdin.isatty = lambda: True 
+    sys.stdin.isatty = lambda: True
 
     # Run setup
     verified = ssh.verify_ssh_central_host_api(
@@ -69,7 +69,7 @@ def setup_ssh_connection(project, setup_ssh_key_pair=True):
     return verified
 
 
-def docker_is_running()-> bool:
+def docker_is_running() -> bool:
     if not is_docker_installed():
         return False
 
@@ -77,11 +77,11 @@ def docker_is_running()-> bool:
     return is_running
 
 
-def is_docker_installed()-> bool:
+def is_docker_installed() -> bool:
     return check_sys_command_returns_0("docker -v")
 
 
-def check_sys_command_returns_0(command: str)-> bool:
+def check_sys_command_returns_0(command: str) -> bool:
     return (
         subprocess.run(
             command,

--- a/tests/tests_transfers/ssh/ssh_test_utils.py
+++ b/tests/tests_transfers/ssh/ssh_test_utils.py
@@ -2,13 +2,13 @@ import builtins
 import copy
 import subprocess
 import sys
-from typing import Any
+from datashuttle.datashuttle_class import DataShuttle
 
 from datashuttle.utils import rclone, ssh, utils
 
 
 def setup_project_for_ssh(
-    project: Any,
+    project: DataShuttle,
 ) -> None:
     """
     Set up the project configs to use
@@ -69,7 +69,7 @@ def setup_ssh_connection(project, setup_ssh_key_pair=True):
     return verified
 
 
-def docker_is_running() -> bool:
+def docker_is_running()-> bool:
     if not is_docker_installed():
         return False
 
@@ -77,11 +77,11 @@ def docker_is_running() -> bool:
     return is_running
 
 
-def is_docker_installed() -> bool:
+def is_docker_installed()-> bool:
     return check_sys_command_returns_0("docker -v")
 
 
-def check_sys_command_returns_0(command: str) -> bool:
+def check_sys_command_returns_0(command: str)-> bool:
     return (
         subprocess.run(
             command,

--- a/tests/tests_transfers/ssh/ssh_test_utils.py
+++ b/tests/tests_transfers/ssh/ssh_test_utils.py
@@ -2,8 +2,8 @@ import builtins
 import copy
 import subprocess
 import sys
-from datashuttle.datashuttle_class import DataShuttle
 
+from datashuttle.datashuttle_class import DataShuttle
 from datashuttle.utils import rclone, ssh, utils
 
 
@@ -69,7 +69,7 @@ def setup_ssh_connection(project, setup_ssh_key_pair=True):
     return verified
 
 
-def docker_is_running()-> bool:
+def docker_is_running() -> bool:
     if not is_docker_installed():
         return False
 
@@ -77,11 +77,11 @@ def docker_is_running()-> bool:
     return is_running
 
 
-def is_docker_installed()-> bool:
+def is_docker_installed() -> bool:
     return check_sys_command_returns_0("docker -v")
 
 
-def check_sys_command_returns_0(command: str)-> bool:
+def check_sys_command_returns_0(command: str) -> bool:
     return (
         subprocess.run(
             command,

--- a/tests/tests_transfers/ssh/test_ssh_setup.py
+++ b/tests/tests_transfers/ssh/test_ssh_setup.py
@@ -1,13 +1,14 @@
 import builtins
 import copy
 import platform
-from typing import Iterator
-from datashuttle.datashuttle_class import DataShuttle
 from pathlib import Path
-from _pytest.fixtures import FixtureRequest
-from _pytest.capture import CaptureFixture
+from typing import Iterator
 
 import pytest
+from _pytest.capture import CaptureFixture
+from _pytest.fixtures import FixtureRequest
+
+from datashuttle.datashuttle_class import DataShuttle
 
 from ... import test_utils
 from . import ssh_test_utils
@@ -26,7 +27,9 @@ TEST_SSH: bool = ssh_test_utils.docker_is_running()
 )
 class TestSSH(BaseSSHTransfer):
     @pytest.fixture(scope="function")
-    def project(test: FixtureRequest, tmp_path: Path, setup_ssh_container_fixture: None)-> Iterator[DataShuttle]:
+    def project(
+        test: FixtureRequest, tmp_path: Path, setup_ssh_container_fixture: None
+    ) -> Iterator[DataShuttle]:
         """Set up a project with configs for SSH into
         the test Dockerfile image.
         """
@@ -50,7 +53,7 @@ class TestSSH(BaseSSHTransfer):
     @pytest.mark.parametrize("input_", ["n", "o", "@"])
     def test_verify_ssh_central_host_do_not_accept(
         self, capsys: CaptureFixture[str], project: DataShuttle, input_: str
-    )-> None:
+    ) -> None:
         """Test that host not accepted if input is not "y"."""
         orig_builtin = copy.deepcopy(builtins.input)
         builtins.input = lambda _: input_  # type: ignore
@@ -63,7 +66,9 @@ class TestSSH(BaseSSHTransfer):
 
         assert "Host not accepted. No connection made.\n" in captured.out
 
-    def test_verify_ssh_central_host_accept(self, capsys: CaptureFixture[str], project: DataShuttle) -> None:
+    def test_verify_ssh_central_host_accept(
+        self, capsys: CaptureFixture[str], project: DataShuttle
+    ) -> None:
         """User is asked to accept the server hostkey. Mock this here
         and check hostkey is successfully accepted and written to configs.
         """

--- a/tests/tests_transfers/ssh/test_ssh_setup.py
+++ b/tests/tests_transfers/ssh/test_ssh_setup.py
@@ -1,7 +1,11 @@
 import builtins
 import copy
 import platform
-from typing import Any, Iterator
+from typing import Iterator
+from datashuttle.datashuttle_class import DataShuttle
+from pathlib import Path
+from _pytest.fixtures import FixtureRequest
+from _pytest.capture import CaptureFixture
 
 import pytest
 
@@ -22,7 +26,7 @@ TEST_SSH: bool = ssh_test_utils.docker_is_running()
 )
 class TestSSH(BaseSSHTransfer):
     @pytest.fixture(scope="function")
-    def project(test, tmp_path, setup_ssh_container_fixture) -> Iterator[Any]:
+    def project(test: FixtureRequest, tmp_path: Path, setup_ssh_container_fixture: None)-> Iterator[DataShuttle]:
         """Set up a project with configs for SSH into
         the test Dockerfile image.
         """
@@ -45,8 +49,8 @@ class TestSSH(BaseSSHTransfer):
 
     @pytest.mark.parametrize("input_", ["n", "o", "@"])
     def test_verify_ssh_central_host_do_not_accept(
-        self, capsys, project, input_: str
-    ) -> None:
+        self, capsys: CaptureFixture[str], project: DataShuttle, input_: str
+    )-> None:
         """Test that host not accepted if input is not "y"."""
         orig_builtin = copy.deepcopy(builtins.input)
         builtins.input = lambda _: input_  # type: ignore
@@ -59,7 +63,7 @@ class TestSSH(BaseSSHTransfer):
 
         assert "Host not accepted. No connection made.\n" in captured.out
 
-    def test_verify_ssh_central_host_accept(self, capsys, project) -> None:
+    def test_verify_ssh_central_host_accept(self, capsys: CaptureFixture[str], project: DataShuttle) -> None:
         """User is asked to accept the server hostkey. Mock this here
         and check hostkey is successfully accepted and written to configs.
         """

--- a/tests/tests_transfers/ssh/test_ssh_setup.py
+++ b/tests/tests_transfers/ssh/test_ssh_setup.py
@@ -1,6 +1,7 @@
 import builtins
 import copy
 import platform
+from typing import Iterator,Any
 
 import pytest
 
@@ -8,7 +9,7 @@ from ... import test_utils
 from . import ssh_test_utils
 from .base_ssh import BaseSSHTransfer
 
-TEST_SSH = ssh_test_utils.docker_is_running()
+TEST_SSH: bool = ssh_test_utils.docker_is_running()
 
 
 @pytest.mark.skipif(
@@ -21,7 +22,7 @@ TEST_SSH = ssh_test_utils.docker_is_running()
 )
 class TestSSH(BaseSSHTransfer):
     @pytest.fixture(scope="function")
-    def project(test, tmp_path, setup_ssh_container_fixture):
+    def project(test, tmp_path, setup_ssh_container_fixture)-> Iterator[Any]:
         """Set up a project with configs for SSH into
         the test Dockerfile image.
         """
@@ -44,8 +45,8 @@ class TestSSH(BaseSSHTransfer):
 
     @pytest.mark.parametrize("input_", ["n", "o", "@"])
     def test_verify_ssh_central_host_do_not_accept(
-        self, capsys, project, input_
-    ):
+        self, capsys, project, input_: str
+    )-> None:
         """Test that host not accepted if input is not "y"."""
         orig_builtin = copy.deepcopy(builtins.input)
         builtins.input = lambda _: input_  # type: ignore
@@ -58,7 +59,7 @@ class TestSSH(BaseSSHTransfer):
 
         assert "Host not accepted. No connection made.\n" in captured.out
 
-    def test_verify_ssh_central_host_accept(self, capsys, project):
+    def test_verify_ssh_central_host_accept(self, capsys, project) -> None:
         """User is asked to accept the server hostkey. Mock this here
         and check hostkey is successfully accepted and written to configs.
         """

--- a/tests/tests_transfers/ssh/test_ssh_setup.py
+++ b/tests/tests_transfers/ssh/test_ssh_setup.py
@@ -1,7 +1,7 @@
 import builtins
 import copy
 import platform
-from typing import Iterator,Any
+from typing import Any, Iterator
 
 import pytest
 
@@ -22,7 +22,7 @@ TEST_SSH: bool = ssh_test_utils.docker_is_running()
 )
 class TestSSH(BaseSSHTransfer):
     @pytest.fixture(scope="function")
-    def project(test, tmp_path, setup_ssh_container_fixture)-> Iterator[Any]:
+    def project(test, tmp_path, setup_ssh_container_fixture) -> Iterator[Any]:
         """Set up a project with configs for SSH into
         the test Dockerfile image.
         """
@@ -46,7 +46,7 @@ class TestSSH(BaseSSHTransfer):
     @pytest.mark.parametrize("input_", ["n", "o", "@"])
     def test_verify_ssh_central_host_do_not_accept(
         self, capsys, project, input_: str
-    )-> None:
+    ) -> None:
         """Test that host not accepted if input is not "y"."""
         orig_builtin = copy.deepcopy(builtins.input)
         builtins.input = lambda _: input_  # type: ignore

--- a/tests/tests_transfers/ssh/test_ssh_suggest_next.py
+++ b/tests/tests_transfers/ssh/test_ssh_suggest_next.py
@@ -1,6 +1,6 @@
 import os
 import platform
-from typing import Iterator,Any
+from typing import Any, Iterator
 
 import pytest
 
@@ -28,7 +28,9 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     @pytest.fixture(
         scope="function",
     )
-    def ssh_setup(self, setup_project_paths, setup_ssh_container_fixture)-> Iterator[Any]:
+    def ssh_setup(
+        self, setup_project_paths, setup_ssh_container_fixture
+    ) -> Iterator[Any]:
         """
         Setup pathtable and project for SSH transfer tests.
         """
@@ -44,7 +46,7 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     async def test_ssh_suggest_next_sub_ses(
         self,
         ssh_setup,
-    )-> None:
+    ) -> None:
         """ """
         project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_suggest_next.py
+++ b/tests/tests_transfers/ssh/test_ssh_suggest_next.py
@@ -1,9 +1,10 @@
 import os
 import platform
-from typing import Iterator,Mapping
-from datashuttle.datashuttle_class import DataShuttle
+from typing import Iterator, Mapping
 
 import pytest
+
+from datashuttle.datashuttle_class import DataShuttle
 
 from ... import test_utils
 from ...tests_tui.tui_base import TuiBase
@@ -29,7 +30,11 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     @pytest.fixture(
         scope="function",
     )
-    def ssh_setup(self, setup_project_paths: Mapping[str,str], setup_ssh_container_fixture: None)-> Iterator[DataShuttle]:
+    def ssh_setup(
+        self,
+        setup_project_paths: Mapping[str, str],
+        setup_ssh_container_fixture: None,
+    ) -> Iterator[DataShuttle]:
         """
         Setup pathtable and project for SSH transfer tests.
         """
@@ -45,7 +50,7 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     async def test_ssh_suggest_next_sub_ses(
         self,
         ssh_setup: DataShuttle,
-    )-> None:
+    ) -> None:
         """ """
         project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_suggest_next.py
+++ b/tests/tests_transfers/ssh/test_ssh_suggest_next.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from typing import Iterator,Any
 
 import pytest
 
@@ -8,7 +9,7 @@ from ...tests_tui.tui_base import TuiBase
 from . import ssh_test_utils
 from .base_ssh import BaseSSHTransfer
 
-TEST_SSH = ssh_test_utils.docker_is_running()
+TEST_SSH: bool = ssh_test_utils.docker_is_running()
 
 
 @pytest.mark.skipif(
@@ -27,7 +28,7 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     @pytest.fixture(
         scope="function",
     )
-    def ssh_setup(self, setup_project_paths, setup_ssh_container_fixture):
+    def ssh_setup(self, setup_project_paths, setup_ssh_container_fixture)-> Iterator[Any]:
         """
         Setup pathtable and project for SSH transfer tests.
         """
@@ -43,7 +44,7 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     async def test_ssh_suggest_next_sub_ses(
         self,
         ssh_setup,
-    ):
+    )-> None:
         """ """
         project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_suggest_next.py
+++ b/tests/tests_transfers/ssh/test_ssh_suggest_next.py
@@ -1,6 +1,7 @@
 import os
 import platform
-from typing import Any, Iterator
+from typing import Iterator,Mapping
+from datashuttle.datashuttle_class import DataShuttle
 
 import pytest
 
@@ -28,9 +29,7 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     @pytest.fixture(
         scope="function",
     )
-    def ssh_setup(
-        self, setup_project_paths, setup_ssh_container_fixture
-    ) -> Iterator[Any]:
+    def ssh_setup(self, setup_project_paths: Mapping[str,str], setup_ssh_container_fixture: None)-> Iterator[DataShuttle]:
         """
         Setup pathtable and project for SSH transfer tests.
         """
@@ -45,8 +44,8 @@ class TestSSHDriveSuggestNext(BaseSSHTransfer, TuiBase):
     @pytest.mark.asyncio
     async def test_ssh_suggest_next_sub_ses(
         self,
-        ssh_setup,
-    ) -> None:
+        ssh_setup: DataShuttle,
+    )-> None:
         """ """
         project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_transfer.py
+++ b/tests/tests_transfers/ssh/test_ssh_transfer.py
@@ -1,12 +1,13 @@
 import fnmatch
 import platform
+from typing import Tuple,Any
 
 import pytest
 
 from . import ssh_test_utils
 from .base_ssh import BaseSSHTransfer
 
-TEST_SSH = ssh_test_utils.docker_is_running()
+TEST_SSH: bool = ssh_test_utils.docker_is_running()
 
 
 @pytest.mark.skipif(
@@ -21,7 +22,7 @@ class TestSSHTransfer(BaseSSHTransfer):
     @pytest.fixture(
         scope="class",
     )
-    def ssh_setup(self, pathtable_and_project, setup_ssh_container_fixture):
+    def ssh_setup(self, pathtable_and_project, setup_ssh_container_fixture)-> Tuple[Any, Any]:
         """
         After initial project setup (in `pathtable_and_project`)
         setup a container and the project's SSH connection to the container.
@@ -36,7 +37,7 @@ class TestSSHTransfer(BaseSSHTransfer):
 
         project.upload_rawdata()
 
-        return [pathtable, project]
+        return pathtable, project
 
     # -----------------------------------------------------------------
     # Test Setup SSH Connection
@@ -57,7 +58,7 @@ class TestSSHTransfer(BaseSSHTransfer):
         sub_names,
         ses_names,
         datatype,
-    ):
+    )-> None:
         """
         Test a subset of argument combinations while testing over SSH connection
         to a container. This is very slow, due to the rclone ssh transfer (which
@@ -81,7 +82,7 @@ class TestSSHTransfer(BaseSSHTransfer):
     # Therefore, test a few specific cases here by manually chopping down the pathtable based
     # on the sub / ses /datatype names to test the expected paths.
 
-    def test_ssh_wildcards_1(self, ssh_setup):
+    def test_ssh_wildcards_1(self, ssh_setup)-> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -105,7 +106,7 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_2(self, ssh_setup):
+    def test_ssh_wildcards_2(self, ssh_setup)-> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -127,7 +128,7 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_3(self, ssh_setup):
+    def test_ssh_wildcards_3(self, ssh_setup)-> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_transfer.py
+++ b/tests/tests_transfers/ssh/test_ssh_transfer.py
@@ -1,10 +1,11 @@
 import fnmatch
 import platform
-from typing import Tuple,List
-from datashuttle.datashuttle_class import DataShuttle
-import pandas as pd
+from typing import List, Tuple
 
+import pandas as pd
 import pytest
+
+from datashuttle.datashuttle_class import DataShuttle
 
 from . import ssh_test_utils
 from .base_ssh import BaseSSHTransfer
@@ -24,7 +25,11 @@ class TestSSHTransfer(BaseSSHTransfer):
     @pytest.fixture(
         scope="class",
     )
-    def ssh_setup(self, pathtable_and_project: Tuple[pd.DataFrame, DataShuttle], setup_ssh_container_fixture: None)-> Tuple[pd.DataFrame, DataShuttle]:
+    def ssh_setup(
+        self,
+        pathtable_and_project: Tuple[pd.DataFrame, DataShuttle],
+        setup_ssh_container_fixture: None,
+    ) -> Tuple[pd.DataFrame, DataShuttle]:
         """
         After initial project setup (in `pathtable_and_project`)
         setup a container and the project's SSH connection to the container.
@@ -60,7 +65,7 @@ class TestSSHTransfer(BaseSSHTransfer):
         sub_names: List[str],
         ses_names: List[str],
         datatype: List[str],
-    )-> None:
+    ) -> None:
         """
         Test a subset of argument combinations while testing over SSH connection
         to a container. This is very slow, due to the rclone ssh transfer (which
@@ -84,7 +89,9 @@ class TestSSHTransfer(BaseSSHTransfer):
     # Therefore, test a few specific cases here by manually chopping down the pathtable based
     # on the sub / ses /datatype names to test the expected paths.
 
-    def test_ssh_wildcards_1(self, ssh_setup: Tuple[pd.DataFrame, DataShuttle])-> None:
+    def test_ssh_wildcards_1(
+        self, ssh_setup: Tuple[pd.DataFrame, DataShuttle]
+    ) -> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -108,7 +115,9 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_2(self, ssh_setup: Tuple[pd.DataFrame, DataShuttle])-> None:
+    def test_ssh_wildcards_2(
+        self, ssh_setup: Tuple[pd.DataFrame, DataShuttle]
+    ) -> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -130,7 +139,9 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_3(self, ssh_setup: Tuple[pd.DataFrame, DataShuttle])-> None:
+    def test_ssh_wildcards_3(
+        self, ssh_setup: Tuple[pd.DataFrame, DataShuttle]
+    ) -> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_transfer.py
+++ b/tests/tests_transfers/ssh/test_ssh_transfer.py
@@ -1,6 +1,6 @@
 import fnmatch
 import platform
-from typing import Tuple,Any
+from typing import Any, Tuple
 
 import pytest
 
@@ -22,7 +22,9 @@ class TestSSHTransfer(BaseSSHTransfer):
     @pytest.fixture(
         scope="class",
     )
-    def ssh_setup(self, pathtable_and_project, setup_ssh_container_fixture)-> Tuple[Any, Any]:
+    def ssh_setup(
+        self, pathtable_and_project, setup_ssh_container_fixture
+    ) -> Tuple[Any, Any]:
         """
         After initial project setup (in `pathtable_and_project`)
         setup a container and the project's SSH connection to the container.
@@ -58,7 +60,7 @@ class TestSSHTransfer(BaseSSHTransfer):
         sub_names,
         ses_names,
         datatype,
-    )-> None:
+    ) -> None:
         """
         Test a subset of argument combinations while testing over SSH connection
         to a container. This is very slow, due to the rclone ssh transfer (which
@@ -82,7 +84,7 @@ class TestSSHTransfer(BaseSSHTransfer):
     # Therefore, test a few specific cases here by manually chopping down the pathtable based
     # on the sub / ses /datatype names to test the expected paths.
 
-    def test_ssh_wildcards_1(self, ssh_setup)-> None:
+    def test_ssh_wildcards_1(self, ssh_setup) -> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -106,7 +108,7 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_2(self, ssh_setup)-> None:
+    def test_ssh_wildcards_2(self, ssh_setup) -> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -128,7 +130,7 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_3(self, ssh_setup)-> None:
+    def test_ssh_wildcards_3(self, ssh_setup) -> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 

--- a/tests/tests_transfers/ssh/test_ssh_transfer.py
+++ b/tests/tests_transfers/ssh/test_ssh_transfer.py
@@ -1,6 +1,8 @@
 import fnmatch
 import platform
-from typing import Any, Tuple
+from typing import Tuple,List
+from datashuttle.datashuttle_class import DataShuttle
+import pandas as pd
 
 import pytest
 
@@ -22,9 +24,7 @@ class TestSSHTransfer(BaseSSHTransfer):
     @pytest.fixture(
         scope="class",
     )
-    def ssh_setup(
-        self, pathtable_and_project, setup_ssh_container_fixture
-    ) -> Tuple[Any, Any]:
+    def ssh_setup(self, pathtable_and_project: Tuple[pd.DataFrame, DataShuttle], setup_ssh_container_fixture: None)-> Tuple[pd.DataFrame, DataShuttle]:
         """
         After initial project setup (in `pathtable_and_project`)
         setup a container and the project's SSH connection to the container.
@@ -56,11 +56,11 @@ class TestSSHTransfer(BaseSSHTransfer):
     )
     def test_combinations_ssh_transfer(
         self,
-        ssh_setup,
-        sub_names,
-        ses_names,
-        datatype,
-    ) -> None:
+        ssh_setup: Tuple[pd.DataFrame, DataShuttle],
+        sub_names: List[str],
+        ses_names: List[str],
+        datatype: List[str],
+    )-> None:
         """
         Test a subset of argument combinations while testing over SSH connection
         to a container. This is very slow, due to the rclone ssh transfer (which
@@ -84,7 +84,7 @@ class TestSSHTransfer(BaseSSHTransfer):
     # Therefore, test a few specific cases here by manually chopping down the pathtable based
     # on the sub / ses /datatype names to test the expected paths.
 
-    def test_ssh_wildcards_1(self, ssh_setup) -> None:
+    def test_ssh_wildcards_1(self, ssh_setup: Tuple[pd.DataFrame, DataShuttle])-> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -108,7 +108,7 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_2(self, ssh_setup) -> None:
+    def test_ssh_wildcards_2(self, ssh_setup: Tuple[pd.DataFrame, DataShuttle])-> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 
@@ -130,7 +130,7 @@ class TestSSHTransfer(BaseSSHTransfer):
             project, sub_names, ses_names, datatype, expected_transferred_paths
         )
 
-    def test_ssh_wildcards_3(self, ssh_setup) -> None:
+    def test_ssh_wildcards_3(self, ssh_setup: Tuple[pd.DataFrame, DataShuttle])-> None:
         """Test a single custom transfer that combines different special keywords."""
         pathtable, project = ssh_setup
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Tests were previously excluded from mypy to avoid maintenance burden.
To evaluate feasibility and improve readability where helpful, this PR enables mypy checking for tests and adds an initial, minimal set of type hints. This helps surface real typing issues early and establishes patterns for future incremental improvements.

**What does this PR do?**
Enables mypy checking for test files.
Adds minimal, targeted type hints to selected SSH test files.

## References
Related issue: #532 – Extend type hints to tests

## How has this PR been tested?
Ran `pre-commit run mypy --all-files` locally

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
