### PR TITLE
docs: Add datashuttle demo GIF to Getting Started walkthrough

### DIFF
--- a/docs/source/pages/get_started/getting-started.md
+++ b/docs/source/pages/get_started/getting-started.md
@@ -26,6 +26,11 @@ a 'mock' experiment, standardised to the
    :class: only-light
    :width: 550px
 ```
+
+```{image} /_static/datashuttle-demo.gif
+:align: center
+:width: 700px
+```
 <br>
 
 We will upload data to a central data storage machine,


### PR DESCRIPTION
Added the datashuttle demo GIF to the Getting Started documentation.

Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/datashuttle/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**
- [x] Addition of a new feature

**Why is this PR needed?**
This PR addresses issue #576. The demo GIF provides a visual overview of datashuttle's key features and user interface, helping users understand how the tool works at a glance.

**What does this PR do?**
Adds the `datashuttle-demo.gif` file reference to the Getting Started walkthrough documentation. The GIF is displayed right after the file tree diagram to show users an animated demo of the datashuttle interface and workflow.

## References
Closes #576