### PR TITLE
Handle textual v8, unpin textual in pyproject.toml

### DIFF
--- a/datashuttle/tui/shared/configs_content.py
+++ b/datashuttle/tui/shared/configs_content.py
@@ -744,7 +744,10 @@ class ConfigsContent(Container):
             if cfg_to_load["aws_region"] is None
             else cfg_to_load["aws_region"]
         )
-        select.value = value
+        if value is False:
+            select.clear()
+        else:
+            select.value = value
 
     def setup_widgets_to_display(
         self, connection_method: ConnectionMethods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
-    "textual>=3.4.0,<8",
+    "textual>=8.0.0",
     "show-in-file-manager",
     "gitpython",
     "typeguard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
-    "textual>=8.0.0",
+    "textual>=3.4.0,
     "show-in-file-manager",
     "gitpython",
     "typeguard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
-    "textual>=3.4.0,
+    "textual>=3.4.0",
     "show-in-file-manager",
     "gitpython",
     "typeguard",


### PR DESCRIPTION
Fixes https://github.com/neuroinformatics-unit/datashuttle/issues/688

Changes
Updated textual dependency in pyproject.toml from >=3.4.0,<8 to >=8.0.0, removing the temporary pin added in https://github.com/neuroinformatics-unit/datashuttle/pull/689
Fixed InvalidSelectValueError in configs_content.py by replacing select.value = False with select.clear(), which is the correct API in textual v8
Before
Selecting an existing project crashed with
`InvalidSelectValueError:

<img width="605" height="264" alt="Screenshot 2026-02-25 at 3 15 40 AM" src="https://github.com/user-attachments/assets/21f17b03-c694-4176-93a8-fc0fe66003ee" />

After
Existing projects load correctly with textual v8.
<img width="595" height="340" alt="Screenshot 2026-02-25 at 3 09 23 AM" src="https://github.com/user-attachments/assets/fa3841c9-4bdd-4f86-afa1-2b95d953f2ae" />
