### PR TITLE
Add waiting screen to validate and centralise CentralWaitingScreen

### DIFF
--- a/datashuttle/tui/css/tui_menu.tcss
+++ b/datashuttle/tui/css/tui_menu.tcss
@@ -554,7 +554,7 @@ ConfirmAndAwaitTransferPopup {
 
 /* Suggest next subject / session loading pop up --------------------------------------------------- */
 
-SearchingCentralForNextSubSesPopup {
+CentralWaitingScreen {
     align: center middle;
 }
 

--- a/datashuttle/tui/screens/modal_dialogs.py
+++ b/datashuttle/tui/screens/modal_dialogs.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from textual.worker import Worker
 
     from datashuttle.tui.app import TuiApp
-    from datashuttle.utils.custom_types import InterfaceOutput, Prefix
+    from datashuttle.utils.custom_types import InterfaceOutput
 
 import platform
 from pathlib import Path
@@ -238,24 +238,27 @@ class ConfirmAndAwaitTransferPopup(ModalScreen):
             self.app.show_modal_error_dialog(output)
 
 
-class SearchingCentralForNextSubSesPopup(ModalScreen):
-    """Show message and a loading indicator for suggesting the next subject or session.
+class CentralWaitingScreen(ModalScreen):
+    """Show a message and loading indicator while awaiting a slow central connection.
 
-    Used to await searching next sub/ses across including folders
-    present on the central machine. This search happens in a separate
-    thread to allow TUI to display the loading indicate without freezing.
-
-    Only displayed when the `include_central` flag is checked and the
-    connection method is "ssh".
+    Used when operations require network access (ssh, aws, gdrive), such as
+    suggesting the next sub/ses or validating the central project.
     """
 
-    def __init__(self, sub_or_ses: Prefix) -> None:
-        """Initialise SearchingCentralForNextSubSesPopup."""
+    def __init__(self, message: str) -> None:
+        """Initialise CentralWaitingScreen.
+
+        Parameters
+        ----------
+        message
+            Message to display while waiting.
+
+        """
         super().__init__()
-        self.message = f"Searching central for next {sub_or_ses}"
+        self.message = message
 
     def compose(self) -> ComposeResult:
-        """Add widgets to SearchingCentralForNextSubSesPopup."""
+        """Add widgets to CentralWaitingScreen."""
         yield Container(
             Label(self.message, id="searching_message_label"),
             LoadingIndicator(id="searching_animated_indicator"),

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -178,8 +178,14 @@ class ValidateContent(Container):
                 if include_central and self.interface.project.cfg[
                     "connection_method"
                 ] in ["aws", "gdrive", "ssh"]:
-                    self.validating_central_popup = modal_dialogs.CentralWaitingScreen("Validating central project...")
-                    self.parent_class.mainwindow.push_screen(self.validating_central_popup)
+                    self.validating_central_popup = (
+                        modal_dialogs.CentralWaitingScreen(
+                            "Validating central project..."
+                        )
+                    )
+                    self.parent_class.mainwindow.push_screen(
+                        self.validating_central_popup
+                    )
                     asyncio.create_task(
                         self.run_validate_and_dismiss_popup(
                             top_level_folder=top_level_folder,
@@ -248,7 +254,10 @@ class ValidateContent(Container):
             allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
         )
         await worker.wait()
-        if hasattr(self, "validating_central_popup") and self.validating_central_popup:
+        if (
+            hasattr(self, "validating_central_popup")
+            and self.validating_central_popup
+        ):
             self.validating_central_popup.dismiss()
             self.validating_central_popup = None
 

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -66,7 +66,9 @@ class ValidateContent(Container):
 
         self.parent_class = parent_class
         self.interface = interface
-        self.validating_central_popup = None
+        self.validating_central_popup: (
+            modal_dialogs.CentralWaitingScreen | None
+        ) = None
 
     def compose(self) -> ComposeResult:
         """Set up the widgets for the container."""
@@ -270,6 +272,7 @@ class ValidateContent(Container):
         allow_letters_in_sub_ses_values,
     ) -> None:
         """Run validation in a separate thread to avoid freezing the TUI."""
+        assert self.interface is not None
         success, output = self.interface.validate_project(
             top_level_folder=top_level_folder,
             include_central=include_central,

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import platform
 from typing import TYPE_CHECKING, Optional, Union, cast
 
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
 
 from pathlib import Path
 
+from textual import work
 from textual.containers import Container, Horizontal
 from textual.widgets import (
     Button,
@@ -64,6 +66,7 @@ class ValidateContent(Container):
 
         self.parent_class = parent_class
         self.interface = interface
+        self.validating_central_popup = None
 
     def compose(self) -> ComposeResult:
         """Set up the widgets for the container."""
@@ -172,21 +175,36 @@ class ValidateContent(Container):
                         "#validate_include_central_checkbox"
                     ).value
 
-                success, output = self.interface.validate_project(
-                    top_level_folder=top_level_folder,
-                    include_central=include_central,
-                    strict_mode=strict_mode,
-                    allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
-                )
-                if not success:
-                    self.parent_class.mainwindow.show_modal_error_dialog(
-                        cast("str", output)
+                if include_central and self.interface.project.cfg[
+                    "connection_method"
+                ] in ["aws", "gdrive", "ssh"]:
+                    self.validating_central_popup = modal_dialogs.CentralWaitingScreen("Validating central project...")
+                    self.parent_class.mainwindow.push_screen(self.validating_central_popup)
+                    asyncio.create_task(
+                        self.run_validate_and_dismiss_popup(
+                            top_level_folder=top_level_folder,
+                            include_central=include_central,
+                            strict_mode=strict_mode,
+                            allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
+                        ),
+                        name="validate_async_task",
                     )
                 else:
-                    self.write_results_to_richlog(output)
-                    self.query_one(
-                        "#validate_logs_label"
-                    ).value = f"Logs output to: {self.interface.project.get_logging_path()}"
+                    success, output = self.interface.validate_project(
+                        top_level_folder=top_level_folder,
+                        include_central=include_central,
+                        strict_mode=strict_mode,
+                        allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
+                    )
+                    if not success:
+                        self.parent_class.mainwindow.show_modal_error_dialog(
+                            cast("str", output)
+                        )
+                    else:
+                        self.write_results_to_richlog(output)
+                        self.query_one(
+                            "#validate_logs_label"
+                        ).value = f"Logs output to: {self.interface.project.get_logging_path()}"
             else:
                 path_ = self.query_one("#validate_path_input").value
 
@@ -214,6 +232,54 @@ class ValidateContent(Container):
         """Fill the Input with the path_ if it is not None."""
         if path_:
             self.query_one("#validate_path_input").value = path_.as_posix()
+
+    async def run_validate_and_dismiss_popup(
+        self,
+        top_level_folder,
+        include_central,
+        strict_mode,
+        allow_letters_in_sub_ses_values,
+    ) -> None:
+        """Run validation in a worker thread and dismiss the waiting popup when done."""
+        worker = self.validate_project_worker(
+            top_level_folder=top_level_folder,
+            include_central=include_central,
+            strict_mode=strict_mode,
+            allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
+        )
+        await worker.wait()
+        if hasattr(self, "validating_central_popup") and self.validating_central_popup:
+            self.validating_central_popup.dismiss()
+            self.validating_central_popup = None
+
+    @work(exclusive=True, thread=True)
+    def validate_project_worker(
+        self,
+        top_level_folder,
+        include_central,
+        strict_mode,
+        allow_letters_in_sub_ses_values,
+    ) -> None:
+        """Run validation in a separate thread to avoid freezing the TUI."""
+        success, output = self.interface.validate_project(
+            top_level_folder=top_level_folder,
+            include_central=include_central,
+            strict_mode=strict_mode,
+            allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
+        )
+        if not success:
+            self.app.call_from_thread(
+                self.parent_class.mainwindow.show_modal_error_dialog,
+                cast("str", output),
+            )
+        else:
+            self.app.call_from_thread(self.write_results_to_richlog, output)
+            self.app.call_from_thread(
+                setattr,
+                self.query_one("#validate_logs_label"),
+                "value",
+                f"Logs output to: {self.interface.project.get_logging_path()}",
+            )
 
     def write_results_to_richlog(self, results):
         """Display the validation results on the Rich Log widget."""

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
+    from textual.worker import Worker
 
     from datashuttle.tui.interface import Interface
     from datashuttle.tui.screens.project_manager import ProjectManagerScreen
@@ -188,7 +189,7 @@ class ValidateContent(Container):
                     self.parent_class.mainwindow.push_screen(
                         self.validating_central_popup
                     )
-                    asyncio.create_task(
+                    self._validate_task = asyncio.create_task(
                         self.run_validate_and_dismiss_popup(
                             top_level_folder=top_level_folder,
                             include_central=include_central,
@@ -270,7 +271,7 @@ class ValidateContent(Container):
         include_central,
         strict_mode,
         allow_letters_in_sub_ses_values,
-    ) -> None:
+    ) -> Worker[None]:
         """Run validation in a separate thread to avoid freezing the TUI."""
         assert self.interface is not None
         success, output = self.interface.validate_project(

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -287,12 +287,14 @@ class ValidateContent(Container):
             )
         else:
             self.app.call_from_thread(self.write_results_to_richlog, output)
-            self.app.call_from_thread(
-                setattr,
-                self.query_one("#validate_logs_label"),
-                "value",
-                f"Logs output to: {self.interface.project.get_logging_path()}",
-            )
+            self.app.call_from_thread(self._update_logs_label)
+
+    def _update_logs_label(self) -> None:
+        """Update the logs label with the current project logging path."""
+        assert self.interface is not None
+        self.query_one("#validate_logs_label").value = (
+            f"Logs output to: {self.interface.project.get_logging_path()}"
+        )
 
     def write_results_to_richlog(self, results):
         """Display the validation results on the Rich Log widget."""

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -292,7 +292,9 @@ class ValidateContent(Container):
     def _update_logs_label(self) -> None:
         """Update the logs label with the current project logging path."""
         assert self.interface is not None
-        self.query_one("#validate_logs_label").value = (
+        self.query_one(
+            "#validate_logs_label"
+        ).value = (
             f"Logs output to: {self.interface.project.get_logging_path()}"
         )
 

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import platform
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -156,7 +156,6 @@ class ValidateContent(Container):
             )
 
         elif event.button.id == "validate_validate_button":
-
             # Get settings from widgets
             select_value = self.query_one(
                 "#validate_top_level_folder_select"
@@ -173,7 +172,6 @@ class ValidateContent(Container):
             ).value
 
             if self.interface:
-
                 # If we are in a project, and it has a central storage we
                 # will connect and, if it's a slow connection, show a waiting screen
                 if self.interface.project.is_local_project():
@@ -186,7 +184,6 @@ class ValidateContent(Container):
                 if include_central and self.interface.project.cfg[
                     "connection_method"
                 ] in ["aws", "gdrive", "ssh"]:
-
                     self.validating_central_popup = (
                         modal_dialogs.CentralWaitingScreen(
                             "Validating central project..."

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import platform
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -192,14 +191,11 @@ class ValidateContent(Container):
                         self.validating_central_popup
                     )
 
-                asyncio.create_task(
-                    self.run_validate_and_dismiss_popup(
-                        top_level_folder=top_level_folder,
-                        include_central=include_central,
-                        strict_mode=strict_mode,
-                        allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
-                    ),
-                    name="validate_async_task",
+                self.run_validate_and_dismiss_popup(
+                    top_level_folder=top_level_folder,
+                    include_central=include_central,
+                    strict_mode=strict_mode,
+                    allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
                 )
             else:
                 path_ = self.query_one("#validate_path_input").value
@@ -229,6 +225,7 @@ class ValidateContent(Container):
         if path_:
             self.query_one("#validate_path_input").value = path_.as_posix()
 
+    @work(group="validate_async", exclusive=True)
     async def run_validate_and_dismiss_popup(
         self,
         top_level_folder,
@@ -236,7 +233,13 @@ class ValidateContent(Container):
         strict_mode,
         allow_letters_in_sub_ses_values,
     ) -> None:
-        """Run validation in a worker thread and dismiss the waiting popup when done."""
+        """Run validation in a worker thread and dismiss the waiting popup when done.
+
+        Decorated with ``@work`` so Textual owns the task lifecycle (no need to
+        hold an ``asyncio.Task`` reference to prevent premature GC), and so a
+        repeat button-press cancels the previous in-flight invocation via
+        ``exclusive=True``.
+        """
         worker = self.validate_project_worker(
             top_level_folder=top_level_folder,
             include_central=include_central,

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -156,7 +156,6 @@ class ValidateContent(Container):
             )
 
         elif event.button.id == "validate_validate_button":
-
             # Get settings from widgets
             select_value = self.query_one(
                 "#validate_top_level_folder_select"
@@ -173,7 +172,6 @@ class ValidateContent(Container):
             ).value
 
             if self.interface:
-
                 # If we are in a project, and it has a central storage we
                 # will connect and, if it's a slow connection, show a waiting screen
                 if self.interface.project.is_local_project():
@@ -186,7 +184,6 @@ class ValidateContent(Container):
                 if include_central and self.interface.project.cfg[
                     "connection_method"
                 ] in ["aws", "gdrive", "ssh"]:
-
                     self.validating_central_popup = (
                         modal_dialogs.CentralWaitingScreen(
                             "Validating central project..."

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -246,8 +246,7 @@ class ValidateContent(Container):
         )
         await worker.wait()
         if self.validating_central_popup:
-            self.validating_central_popup.dismiss()
-            self.validating_central_popup = None
+            self._hide_validating_central_popup()
 
     @work(exclusive=True, thread=True)
     def validate_project_worker(
@@ -268,6 +267,10 @@ class ValidateContent(Container):
         )
 
         if not success:
+            if self.validating_central_popup:
+                self.app.call_from_thread(
+                    self._hide_validating_central_popup,
+                )
             self.app.call_from_thread(
                 self.parent_class.mainwindow.show_modal_error_dialog,
                 output,
@@ -275,6 +278,10 @@ class ValidateContent(Container):
         else:
             self.app.call_from_thread(self.write_results_to_richlog, output)
             self.app.call_from_thread(self._update_logs_label)
+
+    def _hide_validating_central_popup(self):
+        self.validating_central_popup.dismiss()
+        self.validating_central_popup = None
 
     def _update_logs_label(self) -> None:
         """Update the logs label with the current project logging path."""

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -114,7 +114,6 @@ class ValidateContent(Container):
                 id="validate_arguments_horizontal",
             ),
             RichLog(highlight=True, markup=True, id="validate_richlog"),
-            Label("", id="validate_logs_label"),
             Button("Validate", id="validate_validate_button"),
         ]
 
@@ -277,20 +276,10 @@ class ValidateContent(Container):
             )
         else:
             self.app.call_from_thread(self.write_results_to_richlog, output)
-            self.app.call_from_thread(self._update_logs_label)
 
     def _hide_validating_central_popup(self):
         self.validating_central_popup.dismiss()
         self.validating_central_popup = None
-
-    def _update_logs_label(self) -> None:
-        """Update the logs label with the current project logging path."""
-        assert self.interface is not None
-        self.query_one(
-            "#validate_logs_label"
-        ).value = (
-            f"Logs output to: {self.interface.project.get_logging_path()}"
-        )
 
     def write_results_to_richlog(self, results):
         """Display the validation results on the Rich Log widget."""

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -156,6 +156,8 @@ class ValidateContent(Container):
             )
 
         elif event.button.id == "validate_validate_button":
+
+            # Get settings from widgets
             select_value = self.query_one(
                 "#validate_top_level_folder_select"
             ).value
@@ -171,6 +173,9 @@ class ValidateContent(Container):
             ).value
 
             if self.interface:
+
+                # If we are in a project, and it has a central storage we
+                # will connect and, if it's a slow connection, show a waiting screen
                 if self.interface.project.is_local_project():
                     include_central = False
                 else:
@@ -181,6 +186,7 @@ class ValidateContent(Container):
                 if include_central and self.interface.project.cfg[
                     "connection_method"
                 ] in ["aws", "gdrive", "ssh"]:
+
                     self.validating_central_popup = (
                         modal_dialogs.CentralWaitingScreen(
                             "Validating central project..."
@@ -189,31 +195,16 @@ class ValidateContent(Container):
                     self.parent_class.mainwindow.push_screen(
                         self.validating_central_popup
                     )
-                    self._validate_task = asyncio.create_task(
-                        self.run_validate_and_dismiss_popup(
-                            top_level_folder=top_level_folder,
-                            include_central=include_central,
-                            strict_mode=strict_mode,
-                            allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
-                        ),
-                        name="validate_async_task",
-                    )
-                else:
-                    success, output = self.interface.validate_project(
+
+                asyncio.create_task(
+                    self.run_validate_and_dismiss_popup(
                         top_level_folder=top_level_folder,
                         include_central=include_central,
                         strict_mode=strict_mode,
                         allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
-                    )
-                    if not success:
-                        self.parent_class.mainwindow.show_modal_error_dialog(
-                            cast("str", output)
-                        )
-                    else:
-                        self.write_results_to_richlog(output)
-                        self.query_one(
-                            "#validate_logs_label"
-                        ).value = f"Logs output to: {self.interface.project.get_logging_path()}"
+                    ),
+                    name="validate_async_task",
+                )
             else:
                 path_ = self.query_one("#validate_path_input").value
 
@@ -257,10 +248,7 @@ class ValidateContent(Container):
             allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
         )
         await worker.wait()
-        if (
-            hasattr(self, "validating_central_popup")
-            and self.validating_central_popup
-        ):
+        if self.validating_central_popup:
             self.validating_central_popup.dismiss()
             self.validating_central_popup = None
 
@@ -274,16 +262,18 @@ class ValidateContent(Container):
     ) -> Worker[None]:
         """Run validation in a separate thread to avoid freezing the TUI."""
         assert self.interface is not None
+
         success, output = self.interface.validate_project(
             top_level_folder=top_level_folder,
             include_central=include_central,
             strict_mode=strict_mode,
             allow_letters_in_sub_ses_values=allow_letters_in_sub_ses_values,
         )
+
         if not success:
             self.app.call_from_thread(
                 self.parent_class.mainwindow.show_modal_error_dialog,
-                cast("str", output),
+                output,
             )
         else:
             self.app.call_from_thread(self.write_results_to_richlog, output)

--- a/datashuttle/tui/shared/validate_content.py
+++ b/datashuttle/tui/shared/validate_content.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import platform
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -33,9 +33,7 @@ from datashuttle.tui.screens.datatypes import (
     CreateDatatypeCheckboxes,
     DisplayedDatatypesScreen,
 )
-from datashuttle.tui.screens.modal_dialogs import (
-    SearchingCentralForNextSubSesPopup,
-)
+from datashuttle.tui.screens import modal_dialogs
 from datashuttle.tui.tooltips import get_tooltip
 from datashuttle.tui.utils.tui_decorators import (
     ClickInfo,
@@ -65,7 +63,7 @@ class CreateFoldersTab(TreeAndInputTab):
         self.mainwindow = mainwindow
         self.interface = interface
         self.searching_central_popup_widget: (
-            SearchingCentralForNextSubSesPopup | None
+            modal_dialogs.CentralWaitingScreen | None
         ) = None
 
         self.click_info = ClickInfo()
@@ -342,7 +340,9 @@ class CreateFoldersTab(TreeAndInputTab):
             "connection_method"
         ] in ["aws", "gdrive", "ssh"]:
             self.searching_central_popup_widget = (
-                SearchingCentralForNextSubSesPopup(prefix)
+                modal_dialogs.CentralWaitingScreen(
+                    f"Searching central for next {prefix}"
+                )
             )
             self.mainwindow.push_screen(self.searching_central_popup_widget)
 

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -26,6 +26,7 @@ from datashuttle.tui.custom_widgets import (
     CustomDirectoryTree,
     TreeAndInputTab,
 )
+from datashuttle.tui.screens import modal_dialogs
 from datashuttle.tui.screens.create_folder_settings import (
     CreateFoldersSettingsScreen,
 )
@@ -33,7 +34,6 @@ from datashuttle.tui.screens.datatypes import (
     CreateDatatypeCheckboxes,
     DisplayedDatatypesScreen,
 )
-from datashuttle.tui.screens import modal_dialogs
 from datashuttle.tui.tooltips import get_tooltip
 from datashuttle.tui.utils.tui_decorators import (
     ClickInfo,

--- a/datashuttle/tui/tabs/create_folders.py
+++ b/datashuttle/tui/tabs/create_folders.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
@@ -316,7 +315,7 @@ class CreateFoldersTab(TreeAndInputTab):
         Shows a pop up screen in cases when searching for next sub/ses takes
         time such as searching central in SSH connection method.
 
-        Creates an asyncio task which handles the suggestion logic and
+        Spawns a Textual worker which handles the suggestion logic and
         dismissing the pop up.
 
         Parameters
@@ -346,13 +345,11 @@ class CreateFoldersTab(TreeAndInputTab):
             )
             self.mainwindow.push_screen(self.searching_central_popup_widget)
 
-        asyncio.create_task(
-            self.fill_suggestion_and_dismiss_popup(
-                prefix, input_id, include_central
-            ),
-            name=f"suggest_next_{prefix}_async_task",
+        self.fill_suggestion_and_dismiss_popup(
+            prefix, input_id, include_central
         )
 
+    @work(group="suggest_next_async", exclusive=True)
     async def fill_suggestion_and_dismiss_popup(
         self, prefix, input_id, include_central
     ) -> None:
@@ -363,6 +360,11 @@ class CreateFoldersTab(TreeAndInputTab):
 
         Else, if the worker successfully exits, this function handles dismissal
         of the popup.
+
+        Decorated with ``@work`` so Textual owns the task lifecycle (no need to
+        hold an ``asyncio.Task`` reference to prevent premature GC), and so a
+        repeat invocation cancels the previous in-flight one via
+        ``exclusive=True``.
 
         see `suggest_next_sub_ses()` for parameters.
         """

--- a/tests/tests_tui/test_tui_validate.py
+++ b/tests/tests_tui/test_tui_validate.py
@@ -54,6 +54,7 @@ class TestTuiValidate(TuiBase):
             await self.scroll_to_click_pause(
                 pilot, "#validate_validate_button"
             )
+            await pilot.pause(10)
 
             written_lines = [
                 ele.text
@@ -91,6 +92,7 @@ class TestTuiValidate(TuiBase):
             await self.scroll_to_click_pause(
                 pilot, "#validate_validate_button"
             )
+            await pilot.pause(10)
 
             args_, kwargs_ = spy_validate.call_args_list[0]
 
@@ -138,6 +140,7 @@ class TestTuiValidate(TuiBase):
             await self.scroll_to_click_pause(
                 pilot, "#validate_validate_button"
             )
+            await pilot.pause(10)
 
             args_, kwargs_ = spy_validate.call_args_list[1]
 
@@ -196,6 +199,7 @@ class TestTuiValidate(TuiBase):
             await self.scroll_to_click_pause(
                 pilot, "#validate_validate_button"
             )
+            await pilot.pause(10)
             warnings.filterwarnings("default")
 
             # Check args are passed through to function as expected


### PR DESCRIPTION
## Description

### What does this PR do?
- Adds a waiting screen when validating with `include_central=True` and the connection method is not `local_filesystem` (i.e. `ssh`, `aws`, `gdrive`), where the connection can be slow
- Centralises the waiting screen logic by replacing `SearchingCentralForNextSubSesPopup` and `ValidatingCentralPopup` with a single reusable `CentralWaitingScreen(message: str)` class

### Why is this PR needed?
Fixes #604

### What is the approach?
- `CentralWaitingScreen` takes a `message` string, displays a `Label` + `LoadingIndicator`, consistent with the pattern established in #484 and #479
- Validation runs in a `@work(exclusive=True, thread=True)` thread, UI updates use `call_from_thread`, matching the existing sub/ses suggestion pattern

### Is this a breaking change?
No

### How has this PR been tested?
All 65 TUI tests pass locally.

### Checklist
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The code has been formatted with pre-commit