### PR TITLE
Fix check status error

### DIFF
--- a/datashuttle/tui/interface.py
+++ b/datashuttle/tui/interface.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 from datashuttle import DataShuttle
 from datashuttle.configs import load_configs
 from datashuttle.utils import aws, rclone, ssh, utils
+from datashuttle.utils.rclone import get_local_and_central_file_differences
 
 
 class Interface:
@@ -361,6 +362,20 @@ class Interface:
             )
 
             return True, None
+
+        except Exception as e:
+            return False, str(e)
+
+    def get_transfer_diffs(
+        self, top_level_folders_to_check: List[TopLevelFolder]
+    ) -> InterfaceOutput:
+        """Get a dict of differences between the local and central project."""
+        try:
+            transfer_diffs = get_local_and_central_file_differences(
+                self.get_configs(),
+                top_level_folders_to_check=top_level_folders_to_check,
+            )
+            return True, transfer_diffs
 
         except Exception as e:
             return False, str(e)

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -203,7 +203,8 @@ def run_function_that_requires_encrypted_rclone_config_access(
 
     if check_config_exists and not rclone_config_filepath.is_file():
         raise RuntimeError(
-            f"The way RClone configs are managed has changed since version v0.7.1\n"
+            f"The Rclone config file cannot be found. You may be seeing this as the way "
+            f"Rclone configs are managed was changed in v0.7.1\n"
             f"Please set up the {cfg['connection_method']} connection again."
         )
 


### PR DESCRIPTION
The call to `get_local_and_central_file_differences` for the TUI, which displays the transfer status of files (e.g. local-only, changed on local etc) was not wrapped in the `Interface` class. As such, when an error occured, it was not properly handled by the TUI. This is now fixed. 