### PR TITLE
Fix: Replace bare and broad exceptions with NeuroBlueprintError

### DIFF
--- a/datashuttle/utils/utils.py
+++ b/datashuttle/utils/utils.py
@@ -252,6 +252,11 @@ def get_values_from_bids_formatted_name(
 
         value = get_value_from_key_regexp(name, key)
 
+        if len(value) == 0:
+            raise NeuroBlueprintError(
+                f"No value is associated with the key {key} in {name}.",
+            )
+
         if len(value) > 1:
             raise NeuroBlueprintError(
                 f"There is more than one instance of {key} in {name}. "

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -627,7 +627,7 @@ def datetime_are_iso_format(
             format_to_check = utils.get_values_from_bids_formatted_name(
                 [name], key, return_as_int=False
             )[0]
-        except:
+        except NeuroBlueprintError:
             return []
 
         strfmt = formats[key]
@@ -1210,7 +1210,7 @@ def strip_uncheckable_names(
                 prefix,
                 return_as_int=return_as_int,  # type: ignore
             )[0]
-        except Exception:
+        except NeuroBlueprintError:
             continue
 
         if path_:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Bare `except:` blocks and overly broad `except Exception:` catches can intercept critical system-level exceptions like `KeyboardInterrupt` and `SystemExit`, as well as mask unexpected application bugs (like `AttributeError` or `IndexError`). This makes debugging extremely difficult and hides actual bugs.

**What does this PR do?**
- Replaces a bare `except:` block and an `except Exception:` block in [datashuttle/utils/validation.py](cci:7://file:///c:/Users/kunal/datashuttle/datashuttle/utils/validation.py:0:0-0:0) with `except NeuroBlueprintError:`.
- Adds an explicit check in [datashuttle/utils/utils.py](cci:7://file:///c:/Users/kunal/datashuttle/datashuttle/utils/utils.py:0:0-0:0) to raise a `NeuroBlueprintError` when regex parsing of a BIDS value comes up empty, instead of implicitly causing an `IndexError`. This allows the validation logic to safely and explicitly catch the expected error.

## References

N/A

## How has this PR been tested?

The test suite was run locally using `pytest`. The [test_validation_unit.py](cci:7://file:///c:/Users/kunal/datashuttle/tests/tests_unit/test_validation_unit.py:0:0-0:0) module passed successfully, confirming the previous behavior of the validation functions remains intact while safely catching the intended exceptions.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
