### PR TITLE
Fix file lock logging tests.

### DIFF
--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -586,6 +586,13 @@ class TestLogging:
 
         # Check that errors and logs flag the transfer errors
         errors = transfer_output["errors"]
+        # in Linux, macOS backup files are written during logging ,we want to ignore these
+        errors["file_names"] = [
+            filepath
+            for filepath in errors["file_names"]
+            if "partial" not in filepath
+        ]
+
         assert errors["file_names"] == [relative_path.as_posix()]
         assert error_message in errors["messages"][0]
 


### PR DESCRIPTION
#623 added a test in which a file was locked before transfer, to check errors in transfer were propagated successfully to the user. On macOS/linux, the file was 'locked' by continuously writing to it. This test was leading to sporadic failure on linux/macOS because sometimes, a `.partial` file was created as the while was being written to. This PR ignores this file in the test.