### PR TITLE
Fix filelock logging tests.

### DIFF
--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -588,7 +588,7 @@ class TestLogging:
         errors = transfer_output["errors"]
         # in Linux, macOS backup files are sometimes written during logging,
         # we want to ignore these in case present.
-        if len(errors["file"]) > 1:
+        if len(errors["file_names"]) > 1:
             errors["file_names"] = [
                 filepath
                 for filepath in errors["file_names"]


### PR DESCRIPTION
This handles an additional case in which the filelock tests were failing (when only a single partial backup file). See #702 