### PR TITLE
Stop project being saved when rclone is not found on the system

### DIFF
--- a/datashuttle/datashuttle_class.py
+++ b/datashuttle/datashuttle_class.py
@@ -1219,6 +1219,11 @@ class DataShuttle:
             # For backward compatibility
             connection_method = "local_only"
 
+        if connection_method != "local_only":
+            # This will raise an error here, to ensure config
+            # is not saved at all if it cannot be set up
+            rclone.prompt_rclone_download_if_does_not_exist()
+
         if self._config_path.is_file():
             utils.log_and_raise_error(
                 "A config file already exists for this project. "


### PR DESCRIPTION
Currently, if `rclone` is not installed then the config set up throws an error, after the config is saved. This is annoying as if you then install rclone and try and remake the project, it throws an error saying that the project already exists. It may also exist in a strange state. This stops the project being set up if `rclone` cannot be found.