### PR TITLE
Fix search path `None` case.

### DIFF
--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -669,7 +669,7 @@ def search_local_filesystem(
 
 def search_central_via_connection(
     cfg: Configs,
-    search_path: Path,
+    search_path: Path | None,
     search_prefix: str,
     return_full_path: bool = False,
 ) -> tuple[List[Any], List[Any]]:
@@ -686,7 +686,7 @@ def search_central_via_connection(
         The path to search (relative to the local or remote drive). For example,
         for "local_filesystem" this is the path on the local machine. For any other
         connection to central, this is the path on the central storage that has been
-        connected to.
+        connected to. Can be `None` if Google Drive.
 
     search_prefix
         The search string e.g. "sub-*".
@@ -699,9 +699,11 @@ def search_central_via_connection(
         cfg["connection_method"]
     )
 
+    final_search_path = search_path.as_posix() if search_path else ""
+
     output = rclone.call_rclone_for_central_connection(
         cfg,
-        f'lsjson {rclone_config_name}:"{search_path.as_posix()}" {rclone.get_config_arg(cfg)}',
+        f'lsjson {rclone_config_name}:"{final_search_path}" {rclone.get_config_arg(cfg)}',
         pipe_std=True,
     )
 
@@ -710,7 +712,7 @@ def search_central_via_connection(
 
     if output.returncode != 0:
         utils.log_and_message(
-            f"Error searching files at {search_path.as_posix()}\n"
+            f"Error searching files at {final_search_path}\n"
             f"{output.stderr.decode('utf-8') if output.stderr else ''}"
         )
         return all_folder_names, all_filenames
@@ -725,7 +727,9 @@ def search_central_via_connection(
 
         is_dir = file_or_folder.get("IsDir", False)
 
-        to_append = search_path / name if return_full_path else name
+        to_append = (
+            search_path / name if (return_full_path and search_path) else name
+        )
 
         if is_dir:
             all_folder_names.append(to_append)

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -631,7 +631,7 @@ def search_for_folders(
 
 
 def search_local_filesystem(
-    search_path: Path, search_prefix: str, return_full_path: bool = False
+    search_path: Path | None, search_prefix: str, return_full_path: bool = False
 ) -> tuple[List[Any], List[Any]]:
     """Search local filesystem recursively.
 
@@ -644,7 +644,7 @@ def search_local_filesystem(
         The path to search (relative to the local or remote drive). For example,
         for "local_filesystem" this is the path on the local machine. For any other
         connection to central, this is the path on the central storage that has been
-        connected to.
+        connected to. Must not be ``None`` when searching the local filesystem.
 
     search_prefix
         The search string e.g. "sub-*".
@@ -653,6 +653,11 @@ def search_local_filesystem(
         If `True`, return the full filepath, otherwise return only the folder/file name.
 
     """
+    if search_path is None:
+        raise ValueError(
+            "search_path cannot be None when searching the local filesystem."
+        )
+
     all_folder_names = []
     all_filenames = []
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -690,7 +690,7 @@ def search_central_via_connection(
         The path to search (relative to the local or remote drive). For example,
         for "local_filesystem" this is the path on the local machine. For any other
         connection to central, this is the path on the central storage that has been
-        connected to. Can be `None` if Google Drive.
+        connected to. Can be `None` if connection method is `gdrive`.
 
     search_prefix
         The search string e.g. "sub-*".

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -718,8 +718,13 @@ def search_central_via_connection(
     all_filenames: list = []
 
     if output.returncode != 0:
+        display_search_path = (
+            f"{rclone_config_name}:<root>"
+            if search_path is None
+            else final_search_path
+        )
         utils.log_and_message(
-            f"Error searching files at {final_search_path}\n"
+            f"Error searching files at {display_search_path}\n"
             f"{output.stderr.decode('utf-8') if output.stderr else ''}"
         )
         return all_folder_names, all_filenames

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -631,7 +631,9 @@ def search_for_folders(
 
 
 def search_local_filesystem(
-    search_path: Path | None, search_prefix: str, return_full_path: bool = False
+    search_path: Path | None,
+    search_prefix: str,
+    return_full_path: bool = False,
 ) -> tuple[List[Any], List[Any]]:
     """Search local filesystem recursively.
 

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -728,7 +728,7 @@ def search_central_via_connection(
         is_dir = file_or_folder.get("IsDir", False)
 
         to_append = (
-            search_path / name if (return_full_path and search_path) else name
+            Path(final_search_path) / name if return_full_path else name
         )
 
         if is_dir:

--- a/datashuttle/utils/folders.py
+++ b/datashuttle/utils/folders.py
@@ -608,6 +608,8 @@ def search_for_folders(
         local_or_central == "local"
         or cfg["connection_method"] == "local_filesystem"
     ):
+        assert search_path is not None
+
         if not search_path.exists():
             if verbose:
                 utils.log_and_message(
@@ -631,7 +633,7 @@ def search_for_folders(
 
 
 def search_local_filesystem(
-    search_path: Path | None,
+    search_path: Path,
     search_prefix: str,
     return_full_path: bool = False,
 ) -> tuple[List[Any], List[Any]]:
@@ -646,7 +648,7 @@ def search_local_filesystem(
         The path to search (relative to the local or remote drive). For example,
         for "local_filesystem" this is the path on the local machine. For any other
         connection to central, this is the path on the central storage that has been
-        connected to. Must not be ``None`` when searching the local filesystem.
+        connected to.
 
     search_prefix
         The search string e.g. "sub-*".
@@ -655,11 +657,6 @@ def search_local_filesystem(
         If `True`, return the full filepath, otherwise return only the folder/file name.
 
     """
-    if search_path is None:
-        raise ValueError(
-            "search_path cannot be None when searching the local filesystem."
-        )
-
     all_folder_names = []
     all_filenames = []
 

--- a/tests/tests_integration/test_search_methods.py
+++ b/tests/tests_integration/test_search_methods.py
@@ -1,3 +1,5 @@
+import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -106,3 +108,69 @@ class TestSubSesSearches(BaseTest):
             assert central_method_files == local_method_files, (
                 f"Failed files, search_str: {search_str}, search_path: {search_path}"
             )
+
+    @pytest.mark.parametrize("return_full_path", [True, False])
+    def test_search_central_none_search_path(
+        self, project, monkeypatch, return_full_path
+    ):
+        """
+        Test `search_central_via_connection` when `search_path=None`.
+
+        When `search_path` is `None` (as is the case for Google Drive, where
+        `cfg["central_path"]` can be `None`), the function should search from
+        the root of the remote drive without error.
+
+        Verify that:
+        - the function handles ``search_path=None`` without raising
+        - when ``return_full_path=True``, returned items are :class:`~pathlib.Path`
+          objects relative to the remote root (e.g. ``Path("sub-001")``)
+        - when ``return_full_path=False``, returned items are plain strings
+        """
+        from datashuttle.utils import rclone
+
+        fake_entries = [
+            {"Name": "sub-001", "IsDir": True},
+            {"Name": "sub-002", "IsDir": True},
+            {"Name": "rawdata.md", "IsDir": False},
+        ]
+        fake_output = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(fake_entries).encode(),
+            stderr=b"",
+        )
+
+        captured_commands = []
+
+        def mock_call_rclone(cfg, command, pipe_std=False):
+            captured_commands.append(command)
+            return fake_output
+
+        monkeypatch.setattr(
+            rclone,
+            "call_rclone_for_central_connection",
+            mock_call_rclone,
+        )
+
+        folders, files = search_central_via_connection(
+            project.cfg,
+            None,
+            "*",
+            return_full_path=return_full_path,
+        )
+
+        assert len(folders) == 2
+        assert len(files) == 1
+
+        if return_full_path:
+            assert all(isinstance(f, Path) for f in folders)
+            assert all(isinstance(f, Path) for f in files)
+            assert sorted(folders) == [Path("sub-001"), Path("sub-002")]
+            assert files == [Path("rawdata.md")]
+        else:
+            assert all(isinstance(f, str) for f in folders)
+            assert all(isinstance(f, str) for f in files)
+            assert sorted(folders) == ["sub-001", "sub-002"]
+            assert files == ["rawdata.md"]
+
+        assert len(captured_commands) == 1, "Expected exactly one rclone call"


### PR DESCRIPTION
`central_path` can be `None` if `connection_method` is `gdrive`. This case was not handled by validation when `search_central` is `True`, leading to an error. The `None` case is explicitly handled here.