### PR TITLE
Fix duplicate fancylog dep, bare excepts, password cleanup

### DIFF
--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -168,6 +168,8 @@ class SetupSshScreen(ModalScreen):
             password
         )
 
+        self.query_one("#setup_ssh_password_input").value = ""
+
         if success:
             message = (
                 f"Connection set up successfully.\n"
@@ -220,7 +222,7 @@ class SetupSshScreen(ModalScreen):
         # may or may not be displayed.
         try:
             self.query_one("#setup_ssh_cancel_button").remove()
-        except BaseException:
+        except Exception:
             pass
 
         message = "Connection was set up successfully."

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -249,7 +249,7 @@ def save_hostkey_locally(key, central_host_id, hostkeys_path) -> None:
 
 
 def get_remote_server_key(central_host_id: str):
-    """Get the remove server host key for validation before connection.
+    """Get the remote server host key for validation before connection.
 
     Parameters
     ----------

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -627,7 +627,7 @@ def datetime_are_iso_format(
             format_to_check = utils.get_values_from_bids_formatted_name(
                 [name], key, return_as_int=False
             )[0]
-        except:
+        except Exception:
             return []
 
         strfmt = formats[key]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "PyYAML",
     "requests",
     "rich",
-    "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
     "textual>=3.4.0,<8",


### PR DESCRIPTION
went through the codebase and found a few things:

- fancylog>=0.4.2 on line 19 of pyproject.toml conflicts with the python-version-specific entries below — removed the duplicate (#710)
- bare `except:` in validation.py and `except BaseException` in setup_ssh.py — narrowed both to `except Exception`
- password stays in the TUI input widget after use — now cleared right after setup (#671)
- typo in ssh.py docstring: "remove" -> "remote"

I emailed hello@neuroinformatics.dev about GSoC 2026 (knqzx0@gmail.com)