### PR TITLE
remove duplicate fancylog dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "PyYAML",
     "requests",
     "rich",
-    "fancylog>=0.4.2",
     "simplejson",
     "pyperclip",
     "textual>=3.4.0,<8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,9 @@ dependencies = [
     "gitpython",
     "typeguard",
     "psutil",
-    # Skip the fancylog version which logs env packages
+    # Skip the fancylog versions which logs env packages
     # by default, which is slow due to subprocess calls.
-    "fancylog >= 0.7.0; python_version >= '3.11'",
-    "fancylog < 0.5.0; python_version < '3.11'",
+    "fancylog >=0.4.2,!=0.5.*,!=0.6.*"
 ]
 
 classifiers = [


### PR DESCRIPTION
the generic `fancylog>=0.4.2` on line 19 conflicts with the python-version-specific entries below it — this just removes the duplicate so the correct version-pinned ones are used.