### PR TITLE
replace bare except clauses with except Exception

### DIFF
--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -220,7 +220,7 @@ class SetupSshScreen(ModalScreen):
         # may or may not be displayed.
         try:
             self.query_one("#setup_ssh_cancel_button").remove()
-        except BaseException:
+        except Exception:
             pass
 
         message = "Connection was set up successfully."

--- a/datashuttle/utils/validation.py
+++ b/datashuttle/utils/validation.py
@@ -627,7 +627,7 @@ def datetime_are_iso_format(
             format_to_check = utils.get_values_from_bids_formatted_name(
                 [name], key, return_as_int=False
             )[0]
-        except:
+        except Exception:
             return []
 
         strfmt = formats[key]


### PR DESCRIPTION
narrowed down a bare `except:` in validation.py and an `except BaseException:` in setup_ssh.py to `except Exception` so they don't accidentally swallow things like KeyboardInterrupt.