### PR TITLE
clear password from TUI input after use

### DIFF
--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -168,6 +168,8 @@ class SetupSshScreen(ModalScreen):
             password
         )
 
+        self.query_one("#setup_ssh_password_input").value = ""
+
         if success:
             message = (
                 f"Connection set up successfully.\n"

--- a/datashuttle/tui/screens/setup_ssh.py
+++ b/datashuttle/tui/screens/setup_ssh.py
@@ -168,8 +168,6 @@ class SetupSshScreen(ModalScreen):
             password
         )
 
-        self.query_one("#setup_ssh_password_input").value = ""
-
         if success:
             message = (
                 f"Connection set up successfully.\n"
@@ -192,6 +190,7 @@ class SetupSshScreen(ModalScreen):
             )
             self.failed_password_attempts += 1
 
+        self.query_one("#setup_ssh_password_input").value = ""
         self.query_one("#messagebox_message_label").update(message)
 
     def try_setup_rclone_encryption(self):

--- a/datashuttle/utils/ssh.py
+++ b/datashuttle/utils/ssh.py
@@ -249,7 +249,7 @@ def save_hostkey_locally(key, central_host_id, hostkeys_path) -> None:
 
 
 def get_remote_server_key(central_host_id: str):
-    """Get the remove server host key for validation before connection.
+    """Get the remote server host key for validation before connection.
 
     Parameters
     ----------


### PR DESCRIPTION
the password was sticking around in the input widget after setup — now it gets cleared right after use. also fixed a small "remove" -> "remote" typo in ssh.py.