### PR TITLE
[joss] make links to source material explicitly links

### DIFF
--- a/joss-paper/paper.md
+++ b/joss-paper/paper.md
@@ -97,7 +97,7 @@ Currently, NeuroBlueprint is designed for experiments in which subjects go throu
 
 # Availability
 
-Datashuttle’s source code is available at https://github.com/neuroinformatics-unit/datashuttle and documentation published at https://datashuttle.neuroinformatics.dev.
+Datashuttle’s source code is available at <https://github.com/neuroinformatics-unit/datashuttle> and documentation published at <https://datashuttle.neuroinformatics.dev>.
 
 # Acknowledgements
 


### PR DESCRIPTION
Part of: https://github.com/openjournals/joss-reviews/issues/9642

It looks like PDF readers will autodetect these as links, but good to explicitly declare them as links for styling and also for the JATS generation