### PR TITLE
Add joss badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/neuroinformatics-unit/datashuttle/branch/main/graph/badge.svg?token=P8CCH3TI8K)](https://codecov.io/gh/neuroinformatics-unit/datashuttle)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://neuroinformatics.zulipchat.com/#narrow/channel/405999-DataShuttle)
+[![JOSS](https://joss.theoj.org/papers/10.21105/joss.09642/status.svg)](https://doi.org/10.21105/joss.09642)
 
 # **datashuttle**
 


### PR DESCRIPTION
closes #729 #725 by adding the JOSS doi badge. For some reason the zenodo DOI badge does not work, #724.