### PR TITLE
Fix logging tests

### DIFF
--- a/tests/tests_integration/test_logging.py
+++ b/tests/tests_integration/test_logging.py
@@ -23,12 +23,18 @@ TEST_PROJECT_NAME = test_utils.get_test_project_name()
 
 
 class TestLogging:
-    @pytest.fixture(scope="function")
+    @pytest.fixture(scope="function", autouse=True)
     def teardown_logger(self):
-        """Ensure the logger is deleted at the end of each test."""
-        yield
+        """Ensure the logger is deleted at the start and after the test."""
+        ds_logger.close_log_filehandler()
         if "datashuttle" in logging.root.manager.loggerDict:
-            logging.root.manager.loggerDict.pop("datashuttle")
+            logging.root.manager.loggerDict.pop("datashuttle", None)
+
+        yield
+
+        ds_logger.close_log_filehandler()
+        if "datashuttle" in logging.root.manager.loggerDict:
+            logging.root.manager.loggerDict.pop("datashuttle", None)
 
     # -------------------------------------------------------------------------
     # Basic Functionality Tests


### PR DESCRIPTION
Tests were [failing](https://github.com/neuroinformatics-unit/datashuttle/actions/runs/27517320756) due to an issue in in which the logger was expected to not have been set up yet, but was persisting, possibly having been set up in another test. This has never been an issue before so not exactly sure what's happening, maybe the order in which the tests are run has changed if pytest in a new version.

The solution is to tear down the logger before and after the offending test.