### PR TITLE
Fix custom transfer widgets persisting

### DIFF
--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -282,12 +282,13 @@ class TransferTab(TreeAndInputTab):
                 "#transfer_toplevel_radiobutton"
             ).value
 
-        for widget in self.transfer_custom_widgets + self.refreshed_transfer_custom_widgets:
+        for widget in (
+            self.transfer_custom_widgets
+            + self.refreshed_transfer_custom_widgets
+        ):
             widget.display = self.query_one(
                 "#transfer_custom_radiobutton"
             ).value
-
-
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         """Update the transfer parameter widgets when the `transfer_radioset` are changed."""
@@ -331,7 +332,7 @@ class TransferTab(TreeAndInputTab):
                 self.refresh_after_datatype_changed,
             )
 
-    async def refresh_after_datatype_changed(self, ignore):
+    async def refresh_after_datatype_changed(self, ignore) -> None:
         """Refresh Checkboxes after the shown datatypes have changed.
 
         The widget must be completely removed and reinitialised.
@@ -348,13 +349,11 @@ class TransferTab(TreeAndInputTab):
 
         self.refreshed_transfer_custom_widgets = [
             self.create_datatype_checkboxes_widget(),
-            self.get_displayed_datatypes_button()
+            self.get_displayed_datatypes_button(),
         ]
 
         for widget in self.refreshed_transfer_custom_widgets:
             await container.mount(widget)
-       # await container.mount(self.create_datatype_checkboxes_widget())
-        #await container.mount(self.get_displayed_datatypes_button())
 
     def on_custom_directory_tree_directory_tree_special_key_press(
         self, event: CustomDirectoryTree.DirectoryTreeSpecialKeyPress

--- a/datashuttle/tui/tabs/transfer.py
+++ b/datashuttle/tui/tabs/transfer.py
@@ -142,6 +142,8 @@ class TransferTab(TreeAndInputTab):
             ),
             # These are almost identical to create tab
             Label("Datatype(s)", id="transfer_datatype_label"),
+        ]
+        self.refreshed_transfer_custom_widgets = [
             self.create_datatype_checkboxes_widget(),
             self.get_displayed_datatypes_button(),
         ]
@@ -161,6 +163,7 @@ class TransferTab(TreeAndInputTab):
             *self.transfer_all_widgets,
             *self.transfer_toplevel_widgets,
             *self.transfer_custom_widgets,
+            *self.refreshed_transfer_custom_widgets,
             id="transfer_params_container",
         )
         yield Horizontal(
@@ -279,10 +282,12 @@ class TransferTab(TreeAndInputTab):
                 "#transfer_toplevel_radiobutton"
             ).value
 
-        for widget in self.transfer_custom_widgets:
+        for widget in self.transfer_custom_widgets + self.refreshed_transfer_custom_widgets:
             widget.display = self.query_one(
                 "#transfer_custom_radiobutton"
             ).value
+
+
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         """Update the transfer parameter widgets when the `transfer_radioset` are changed."""
@@ -341,14 +346,15 @@ class TransferTab(TreeAndInputTab):
             "#transfer_tab_displayed_datatypes_button"
         ).remove()
 
-        (
-            Button(
-                "Displayed Datatypes",
-                id="transfer_tab_displayed_datatypes_button",
-            ),
-        )
-        await container.mount(self.create_datatype_checkboxes_widget())
-        await container.mount(self.get_displayed_datatypes_button())
+        self.refreshed_transfer_custom_widgets = [
+            self.create_datatype_checkboxes_widget(),
+            self.get_displayed_datatypes_button()
+        ]
+
+        for widget in self.refreshed_transfer_custom_widgets:
+            await container.mount(widget)
+       # await container.mount(self.create_datatype_checkboxes_widget())
+        #await container.mount(self.get_displayed_datatypes_button())
 
     def on_custom_directory_tree_directory_tree_special_key_press(
         self, event: CustomDirectoryTree.DirectoryTreeSpecialKeyPress

--- a/tests/tests_tui/test_tui_datatypes.py
+++ b/tests/tests_tui/test_tui_datatypes.py
@@ -213,3 +213,47 @@ class TestDatatypesTUI(TuiBase):
             assert kwargs["datatype"] == ["ecephys", "fusi"]
             assert kwargs["overwrite_existing_files"] == "never"
             assert kwargs["dry_run"] is False
+
+    @pytest.mark.asyncio
+    async def test_transfer_displayed_datatypes_widgets_hide_after_mode_switch(
+        self, setup_project_paths
+    ):
+        """Test that after editing the displayed datatypes in custom transfer, the
+        widgets are properly hidden. This test was added after a bug in which the
+        old, deleted widgets were still persistent on the other tabs.
+        """
+        tmp_config_path, tmp_path, project_name = setup_project_paths.values()
+
+        app = TuiApp()
+        async with app.run_test(size=self.tui_size()) as pilot:
+            await self.check_and_click_onto_existing_project(
+                pilot, project_name
+            )
+
+            await self.switch_tab(pilot, "transfer")
+            await self.scroll_to_click_pause(
+                pilot, "#transfer_custom_radiobutton"
+            )
+            await self.scroll_to_click_pause(
+                pilot,
+                "#transfer_tab_displayed_datatypes_button",
+            )
+            await self.scroll_to_click_pause(
+                pilot, "#displayed_datatypes_close_button"
+            )
+            await self.scroll_to_click_pause(
+                pilot, "#transfer_toplevel_radiobutton"
+            )
+
+            assert (
+                pilot.app.screen.query_one(
+                    "#transfer_custom_datatype_checkboxes"
+                ).display
+                is False
+            )
+            assert (
+                pilot.app.screen.query_one(
+                    "#transfer_tab_displayed_datatypes_button"
+                ).display
+                is False
+            )

--- a/tests/tests_tui/test_tui_datatypes.py
+++ b/tests/tests_tui/test_tui_datatypes.py
@@ -218,42 +218,96 @@ class TestDatatypesTUI(TuiBase):
     async def test_transfer_displayed_datatypes_widgets_hide_after_mode_switch(
         self, setup_project_paths
     ):
-        """Test that after editing the displayed datatypes in custom transfer, the
-        widgets are properly hidden. This test was added after a bug in which the
-        old, deleted widgets were still persistent on the other tabs.
+        """Check refreshed transfer widgets hide correctly and still drive transfer.
+
+        Covers the bug where the deleted custom widgets persisted after
+        switching transfer type, then verifies a newly displayed narrow
+        datatype can still be selected and transferred correctly.
         """
         tmp_config_path, tmp_path, project_name = setup_project_paths.values()
+        subs, sessions = test_utils.get_default_sub_sessions_to_test()
+        sub_to_transfer, ses_to_transfer = "sub-002", "ses-003"
+
+        refreshed_widgets = [
+            "#transfer_custom_datatype_checkboxes",
+            "#transfer_tab_displayed_datatypes_button",
+        ]
+
+        def assert_refreshed_widgets_display(pilot, expected):
+            for id in refreshed_widgets:
+                assert pilot.app.screen.query_one(id).display is expected
 
         app = TuiApp()
         async with app.run_test(size=self.tui_size()) as pilot:
             await self.check_and_click_onto_existing_project(
                 pilot, project_name
             )
-
             await self.switch_tab(pilot, "transfer")
             await self.scroll_to_click_pause(
                 pilot, "#transfer_custom_radiobutton"
             )
-            await self.scroll_to_click_pause(
-                pilot,
-                "#transfer_tab_displayed_datatypes_button",
+
+            # Set up a project containing only the (narrow) "conf" datatype.
+            project = pilot.app.screen.interface.project
+            folders_used = test_utils.get_all_broad_folders_used(value=False)
+            folders_used["conf"] = True
+
+            test_utils.make_and_check_local_project_folders(
+                project,
+                "rawdata",
+                subs,
+                sessions,
+                ["conf"],
+                datatypes_used=folders_used,
             )
-            await self.scroll_to_click_pause(
-                pilot, "#displayed_datatypes_close_button"
+            _, base_path_to_check = test_utils.handle_upload_or_download(
+                project, "upload", transfer_method=None
             )
+
+            # Display the narrow datatypes, refreshing the custom widgets.
+            await self.scroll_to_click_pause(
+                pilot, "#transfer_tab_displayed_datatypes_button"
+            )
+            pilot.app.screen.query_one(
+                "#displayed_datatypes_selection_list"
+            ).toggle_all()
+            await self.scroll_to_click_pause(
+                pilot, "#displayed_datatypes_save_button"
+            )
+
+            # The refreshed widgets must hide / show with the transfer mode.
             await self.scroll_to_click_pause(
                 pilot, "#transfer_toplevel_radiobutton"
             )
+            assert_refreshed_widgets_display(pilot, False)
+
+            await self.scroll_to_click_pause(
+                pilot, "#transfer_custom_radiobutton"
+            )
+            assert_refreshed_widgets_display(pilot, True)
+
+            # Select the newly displayed "conf" datatype and transfer.
+            await self.fill_input(
+                pilot, "#transfer_subject_input", sub_to_transfer
+            )
+            await self.fill_input(
+                pilot, "#transfer_session_input", ses_to_transfer
+            )
+            await self.change_checkbox(pilot, "#transfer_conf_checkbox")
 
             assert (
                 pilot.app.screen.query_one(
                     "#transfer_custom_datatype_checkboxes"
-                ).display
-                is False
+                ).datatype_config["conf"]["on"]
+                is True
             )
-            assert (
-                pilot.app.screen.query_one(
-                    "#transfer_tab_displayed_datatypes_button"
-                ).display
-                is False
+
+            await self.click_and_await_transfer(pilot)
+
+            test_utils.check_working_top_level_folder_only_exists(
+                "rawdata",
+                base_path_to_check / "rawdata",
+                [sub_to_transfer],
+                [ses_to_transfer],
+                folders_used,
             )

--- a/tests/tests_tui/test_tui_datatypes.py
+++ b/tests/tests_tui/test_tui_datatypes.py
@@ -224,7 +224,7 @@ class TestDatatypesTUI(TuiBase):
         switching transfer type, then verifies a newly displayed narrow
         datatype can still be selected and transferred correctly.
         """
-        tmp_config_path, tmp_path, project_name = setup_project_paths.values()
+        _, _, project_name = setup_project_paths.values()
         subs, sessions = test_utils.get_default_sub_sessions_to_test()
         sub_to_transfer, ses_to_transfer = "sub-002", "ses-003"
 


### PR DESCRIPTION
This PR fixes a bug in which the widgets for the cumstom transfer could persist after switching back to transfer entire project / top level folder, once the number of checkboxes had been customised. This is because fresh instances of the checkboxes are generated after customising them, but old versions of the widgets persisted in a list that was shown / hidden when the transfer type was changed.

This is fixed by separating these dynamic widgets into their own list which is properly updated. Tests are added.