### PR TITLE
Fix issue running transfers when Linux `bash` does not reside in `/bin/bash`

### DIFF
--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -128,28 +128,26 @@ def call_rclone_through_script_for_central_connection(
         # against the script path itself.
         run_command = ["bash", tmp_script_path]
 
-    try:
-        lambda_func = lambda: subprocess.run(
-            run_command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=False,
+    lambda_func = lambda: subprocess.run(
+        run_command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+    )
+
+    os.remove(tmp_script_path)
+
+    if rclone_encryption.connection_method_requires_encryption(
+        cfg["connection_method"]
+    ):
+        output = run_function_that_requires_encrypted_rclone_config_access(
+            cfg, lambda_func
         )
+    else:
+        output = lambda_func()
 
-        if rclone_encryption.connection_method_requires_encryption(
-            cfg["connection_method"]
-        ):
-            output = run_function_that_requires_encrypted_rclone_config_access(
-                cfg, lambda_func
-            )
-        else:
-            output = lambda_func()
-
-        if output.returncode != 0:
-            prompt_rclone_download_if_does_not_exist()
-
-    finally:
-        os.remove(tmp_script_path)
+    if output.returncode != 0:
+        prompt_rclone_download_if_does_not_exist()
 
     return output
 

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -27,7 +27,7 @@ import os
 import platform
 import shlex
 import subprocess
-from datetime import datetime
+import tempfile
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -112,45 +112,44 @@ def call_rclone_through_script_for_central_connection(
         suffix = ".sh"
         command = "#!/bin/bash\n" + command
 
-    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S%f")
-    tmp_script_path = (
-        cfg["local_path"] / ".datashuttle" / f"transfer_{timestamp}{suffix}"
-    )
-    tmp_script_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_script_path.write_text(command)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False
+    ) as tmp_script:
+        tmp_script.write(command)
+        tmp_script_path = tmp_script.name
 
-    # Run the script through the interpreter rather than executing the file
-    # directly. This avoids relying on the shebang interpreter being
-    # resolvable (e.g. `/bin/bash` may not exist at that path on some
-    # systems) and on the filesystem allowing exec, both of which can raise
-    # a misleading ENOENT on exec.
     if system == "Windows":
-        run_command = ["cmd", "/c", str(tmp_script_path)]
+        run_command = [tmp_script_path]
     else:
-        run_command = ["bash", str(tmp_script_path)]
+        # On non-Windows, run the script through bash rather than executing
+        # the file directly. This avoids relying on the shebang interpreter
+        # being resolvable (e.g. `/bin/bash` may not exist at that path on
+        # some HPC / container systems), which raises a misleading ENOENT
+        # against the script path itself.
+        run_command = ["bash", tmp_script_path]
 
-    # try:
-    lambda_func = lambda: subprocess.run(
-        run_command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        shell=False,
-    )
-
-    if rclone_encryption.connection_method_requires_encryption(
-        cfg["connection_method"]
-    ):
-        output = run_function_that_requires_encrypted_rclone_config_access(
-            cfg, lambda_func
+    try:
+        lambda_func = lambda: subprocess.run(
+            run_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
         )
-    else:
-        output = lambda_func()
 
-    if output.returncode != 0:
-        prompt_rclone_download_if_does_not_exist()
+        if rclone_encryption.connection_method_requires_encryption(
+            cfg["connection_method"]
+        ):
+            output = run_function_that_requires_encrypted_rclone_config_access(
+                cfg, lambda_func
+            )
+        else:
+            output = lambda_func()
 
-    # finally:
-    os.remove(tmp_script_path)
+        if output.returncode != 0:
+            prompt_rclone_download_if_does_not_exist()
+
+    finally:
+        os.remove(tmp_script_path)
 
     return output
 

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -27,7 +27,7 @@ import os
 import platform
 import shlex
 import subprocess
-import tempfile
+from datetime import datetime
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -112,11 +112,12 @@ def call_rclone_through_script_for_central_connection(
         suffix = ".sh"
         command = "#!/bin/bash\n" + command
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=suffix, delete=False
-    ) as tmp_script:
-        tmp_script.write(command)
-        tmp_script_path = tmp_script.name
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S%f")
+    tmp_script_path = (
+        cfg["local_path"] / ".datashuttle" / f"transfer_{timestamp}{suffix}"
+    )
+    tmp_script_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_script_path.write_text(command)
 
     try:
         if system != "Windows":

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -129,28 +129,28 @@ def call_rclone_through_script_for_central_connection(
     else:
         run_command = ["bash", str(tmp_script_path)]
 
-    try:
-        lambda_func = lambda: subprocess.run(
-            run_command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=False,
+    # try:
+    lambda_func = lambda: subprocess.run(
+        run_command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+    )
+
+    if rclone_encryption.connection_method_requires_encryption(
+        cfg["connection_method"]
+    ):
+        output = run_function_that_requires_encrypted_rclone_config_access(
+            cfg, lambda_func
         )
+    else:
+        output = lambda_func()
 
-        if rclone_encryption.connection_method_requires_encryption(
-            cfg["connection_method"]
-        ):
-            output = run_function_that_requires_encrypted_rclone_config_access(
-                cfg, lambda_func
-            )
-        else:
-            output = lambda_func()
+    if output.returncode != 0:
+        prompt_rclone_download_if_does_not_exist()
 
-        if output.returncode != 0:
-            prompt_rclone_download_if_does_not_exist()
-
-    finally:
-        os.remove(tmp_script_path)
+    # finally:
+    os.remove(tmp_script_path)
 
     return output
 

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -119,12 +119,19 @@ def call_rclone_through_script_for_central_connection(
     tmp_script_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_script_path.write_text(command)
 
-    try:
-        if system != "Windows":
-            os.chmod(tmp_script_path, 0o700)
+    # Run the script through the interpreter rather than executing the file
+    # directly. This avoids relying on the shebang interpreter being
+    # resolvable (e.g. `/bin/bash` may not exist at that path on some
+    # systems) and on the filesystem allowing exec, both of which can raise
+    # a misleading ENOENT on exec.
+    if system == "Windows":
+        run_command = ["cmd", "/c", str(tmp_script_path)]
+    else:
+        run_command = ["bash", str(tmp_script_path)]
 
+    try:
         lambda_func = lambda: subprocess.run(
-            [tmp_script_path],
+            run_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=False,

--- a/datashuttle/utils/rclone.py
+++ b/datashuttle/utils/rclone.py
@@ -135,8 +135,6 @@ def call_rclone_through_script_for_central_connection(
         shell=False,
     )
 
-    os.remove(tmp_script_path)
-
     if rclone_encryption.connection_method_requires_encryption(
         cfg["connection_method"]
     ):
@@ -148,6 +146,8 @@ def call_rclone_through_script_for_central_connection(
 
     if output.returncode != 0:
         prompt_rclone_download_if_does_not_exist()
+
+    os.remove(tmp_script_path)
 
     return output
 


### PR DESCRIPTION
As transfer calls to `rclone` can become very long, they are written to a script which is then executed a subprocess call, this is mostly for Windows (see #509 and [this comment](https://github.com/neuroinformatics-unit/datashuttle/pull/509#discussion_r2109890098)) but is also done for UNIX.

Previously, permissions were set on the `.sh` files and the file run directly wihh a subprocess call. Bash was run through the `#!/bin/bash` at the top of the script. However for some Linux distros e.g. NixOS bash is not at this location. This PR changes how this call works to instead directly call `bash` through the system call, which should auto-resolve the system `bash` wherever its located. `#!/bin/bash` at the top of the shell script is now non-functional but kept as it is a convention.

This PR thus:
- removes the `chmod` permission setting as it is now non-functional
- calls the script with `bash` directly
- no longer always deletes the script if the transfer errored out, as it makes debugging more difficult.


